### PR TITLE
Add timer to REPL

### DIFF
--- a/website/src/lib/repl/EmbeddedRepl.svelte
+++ b/website/src/lib/repl/EmbeddedRepl.svelte
@@ -33,13 +33,10 @@
   let device = $state<Device>("webgpu");
 
   let expanded = $state(false);
-  let runDurationMs = $state<number | null>(null);
+  let runDurationMs = $derived(runner.runDurationMs);
 
   async function handleRun() {
-    const startMs = performance.now();
-    runDurationMs = null;
     await runner.runProgram(editor.getText(), device);
-    runDurationMs = performance.now() - startMs;
   }
 </script>
 

--- a/website/src/lib/repl/runner.svelte.ts
+++ b/website/src/lib/repl/runner.svelte.ts
@@ -24,6 +24,7 @@ export class ReplRunner {
   running = $state(false);
   finished = $state(false);
   consoleLines: ConsoleLine[] = $state([]);
+  runDurationMs = $state<number | null>(null);
   consoleTimers = new Map<string, number>();
   mockConsole: Console;
 
@@ -48,16 +49,17 @@ export class ReplRunner {
     if (this.running) return;
     this.running = true;
     this.finished = false;
-    const startTime = Date.now();
+    this.runDurationMs = null;
+    const startTime = performance.now();
     try {
       await _runProgram(source, device, this);
     } finally {
-      const endTime = Date.now();
-      if (endTime - startTime < 100) {
+      const endTime = performance.now();
+      const duration = endTime - startTime;
+      this.runDurationMs = duration;
+      if (duration < 100) {
         // Take at least 100ms, otherwise it's unclear it actually ran.
-        await new Promise((resolve) =>
-          setTimeout(resolve, 100 - (endTime - startTime)),
-        );
+        await new Promise((resolve) => setTimeout(resolve, 100 - duration));
       }
       this.running = false;
       this.finished = true;

--- a/website/src/routes/repl/+page.svelte
+++ b/website/src/routes/repl/+page.svelte
@@ -71,7 +71,7 @@
 
   let consoleLines = $derived(replRunner.consoleLines);
   let mockConsole = replRunner.mockConsole;
-  let runDurationMs = $state<number | null>(null);
+  let runDurationMs = $derived(replRunner.runDurationMs);
 
   afterNavigate(({ type }) => {
     if (type === "enter") return; // Already handled on load
@@ -126,10 +126,7 @@
   }
 
   async function handleRun() {
-    const startMs = performance.now();
-    runDurationMs = null;
     await replRunner.runProgram(replEditor.getText(), device);
-    runDurationMs = performance.now() - startMs;
   }
 </script>
 


### PR DESCRIPTION
I added a very simple timer to the REPL that tracks execution with `performance.now()`
I think adding the timer helps quickly demonstrate the difference between the runs, between WebGPU / WASM but especially the CPU.
<img width="511" height="297" alt="image" src="https://github.com/user-attachments/assets/a3129db8-d34c-4ec7-83d4-22ad15b19eaa" />
Also, I wanted to learn some Svelte! 🙂 
