### PR TITLE
Make DETR ResNet-50 3x faster

### DIFF
--- a/src/tuner.ts
+++ b/src/tuner.ts
@@ -253,7 +253,7 @@ export function tuneWebgpu(kernel: Kernel): TuneResult {
     const choices: number[][] = [];
     const composedSts = sts.map((st) => st.compose(dim.st));
     for (let axis = 0; axis < dim.groups; axis++) {
-      for (const amount of [3, 4]) {
+      for (const amount of [3, 4, 5]) {
         // Axis is not upcasted, divisible, and has a buffer with stride 0 on
         // that axis (mem coalescing) while not already a stride-0 upcast.
         if (


### PR DESCRIPTION
I think after this change, it's about the same runtime as onnxruntime-web. Basically if you look at the kernels, you see a bunch of stuff à la `[625, 256] x [256, 2048]` matmuls that are only half-unrolled like the following:

```wgsl
fn nan() -> f32 { let bits = 0xffffffffu; return bitcast<f32>(bits); }
fn inf() -> f32 { let bits = 0x7f800000u; return bitcast<f32>(bits); }

@group(0) @binding(0) var<storage, read> in0 : array<f32>;
@group(0) @binding(1) var<storage, read> in1 : array<f32>;
@group(0) @binding(2) var<storage, read_write> result : array<f32>;

@compute @workgroup_size(256)
fn main(@builtin(global_invocation_id) id : vec3<u32>) {
  if (id.x >= 320000) { return; }
  let gidx: i32 = i32(id.x);
  _ = &in0; _ = &in1;
  var acc0: f32 = f32(0);
  var acc1: f32 = f32(0);
  var acc2: f32 = f32(0);
  var acc3: f32 = f32(0);
  for (var ridx: i32 = 0; ridx < 64; ridx++) {
    let alu0: i32 = ((gidx / 512) * 256) + (ridx * 4);
    let alu1: f32 = in0[alu0];
    let alu2: i32 = (((gidx / 8) % 64) * 32) + (((gidx % 8) * 4) + (ridx * 8192));
    let alu3: f32 = in0[alu0 + 1];
    let alu4: f32 = in0[alu0 + 2];
    let alu5: f32 = in0[alu0 + 3];
    acc0 += alu1 * in1[alu2] + alu3 * in1[alu2 + 2048] + alu4 * in1[alu2 + 4096] + alu5 * in1[alu2 + 6144];
    acc1 += alu1 * in1[alu2 + 1] + alu3 * in1[alu2 + 2049] + alu4 * in1[alu2 + 4097] + alu5 * in1[alu2 + 6145];
    acc2 += alu1 * in1[alu2 + 2] + alu3 * in1[alu2 + 2050] + alu4 * in1[alu2 + 4098] + alu5 * in1[alu2 + 6146];
    acc3 += alu1 * in1[alu2 + 3] + alu3 * in1[alu2 + 2051] + alu4 * in1[alu2 + 4099] + alu5 * in1[alu2 + 6147];
  }
  let alu6: i32 = ((gidx / 512) * 2048) + ((((gidx / 8) % 64) * 32) + ((gidx % 8) * 4));
  result[alu6] = acc0;
  result[alu6 + 1] = acc1;
  result[alu6 + 2] = acc2;
  result[alu6 + 3] = acc3;
}
```

This is 0.65 GFLOPs but takes ~6 ms on my laptop which is only 100 GFLOPs, about 15-30% of what I would expect for this size matmul. The problem is that the 625=5^4 axis isn't evenly divisible by any of the unroll sizes in the kernel tuner heuristic.

Just adding an unroll-by-5 option fixes this.

Separately going to make a change with some WebGPU timestamp profiling machinery that helped me figure this out.