### PR TITLE
Fix i32.eqz and add arg* benchmarking (Previously: Add argreduce primitives with performance tests.)

### DIFF
--- a/bench/argreduce.bench.ts
+++ b/bench/argreduce.bench.ts
@@ -1,0 +1,49 @@
+import {
+  blockUntilReady,
+  defaultDevice,
+  init,
+  numpy as np,
+  random,
+} from "@jax-js/jax";
+import { afterAll, bench, suite } from "vitest";
+
+const devices = await init();
+
+// Benchmark argreduce operations on WebGPU
+suite.skipIf(!devices.includes("webgpu"))("gpu argreduce", async () => {
+  defaultDevice("webgpu");
+
+  // 1D array benchmarks
+  const arr10k = random.uniform(random.key(0), [10000]);
+  await blockUntilReady([arr10k]);
+  afterAll(() => arr10k.dispose());
+
+  bench("argmax 10k elements", async () => {
+    const result = np.argmax(arr10k.ref);
+    await result.blockUntilReady();
+    result.dispose();
+  });
+
+  bench("argmin 10k elements", async () => {
+    const result = np.argmin(arr10k.ref);
+    await result.blockUntilReady();
+    result.dispose();
+  });
+
+  // 2D array benchmarks (reduction along axis)
+  const arr2d = random.uniform(random.key(1), [100, 1000]);
+  await blockUntilReady([arr2d]);
+  afterAll(() => arr2d.dispose());
+
+  bench("argmax along axis (100x1000)", async () => {
+    const result = np.argmax(arr2d.ref, 1);
+    await result.blockUntilReady();
+    result.dispose();
+  });
+
+  bench("argmin along axis (100x1000)", async () => {
+    const result = np.argmin(arr2d.ref, 1);
+    await result.blockUntilReady();
+    result.dispose();
+  });
+});

--- a/src/backend/wasm/wasmblr.ts
+++ b/src/backend/wasm/wasmblr.ts
@@ -693,7 +693,7 @@ class I32 implements Type {
   shr_u = BINARY_OP("shr_u", 0x76, "i32", "i32", "i32");
   rotl = BINARY_OP("rotl", 0x77, "i32", "i32", "i32");
   rotr = BINARY_OP("rotr", 0x78, "i32", "i32", "i32");
-  eqz = BINARY_OP("eqz", 0x45, "i32", "i32", "i32");
+  eqz = UNARY_OP("eqz", 0x45, "i32", "i32");
   eq = BINARY_OP("eq", 0x46, "i32", "i32", "i32");
   ne = BINARY_OP("ne", 0x47, "i32", "i32", "i32");
   trunc_f32_s = UNARY_OP("trunc_f32_s", 0xa8, "f32", "i32");

--- a/test/argreduce.test.ts
+++ b/test/argreduce.test.ts
@@ -1,0 +1,71 @@
+import { defaultDevice, devices, init, numpy as np } from "@jax-js/jax";
+import { beforeEach, expect, suite, test } from "vitest";
+
+const devicesAvailable = await init();
+
+// Tests run on all available backends: CPU, WASM, and WebGPU
+suite.each(devices)("device:%s", (device) => {
+  const skipped = !devicesAvailable.includes(device);
+  beforeEach(({ skip }) => {
+    if (skipped) skip();
+    defaultDevice(device);
+  });
+
+  suite("argmax correctness", () => {
+    test("argmax returns first index on ties", () => {
+      const x = np.array([3, 5, 5, 2, 5, 1]);
+      const result = np.argmax(x);
+      expect(result.js()).toEqual(1); // First occurrence of maximum (5)
+    });
+
+    test("argmax works with negative values", () => {
+      const x = np.array([-10, -5, -20, -5, -15]);
+      const result = np.argmax(x);
+      expect(result.js()).toEqual(1); // First occurrence of maximum (-5)
+    });
+
+    test("argmax handles all equal values", () => {
+      const x = np.ones([5]);
+      const result = np.argmax(x);
+      expect(result.js()).toEqual(0); // Returns first index
+    });
+
+    test("argmax 2D various shapes", () => {
+      const x = np.array([
+        [1, 2, 3],
+        [6, 5, 4],
+        [7, 8, 9],
+      ]);
+
+      expect(np.argmax(x.ref).js()).toEqual(8); // Global argmax
+      expect(np.argmax(x.ref, 0).js()).toEqual([2, 2, 2]); // Column-wise
+      expect(np.argmax(x, 1).js()).toEqual([2, 0, 2]); // Row-wise
+    });
+  });
+
+  suite("argmin correctness", () => {
+    test("argmin returns first index on ties", () => {
+      const x = np.array([3, 1, 5, 1, 1, 2]);
+      const result = np.argmin(x);
+      expect(result.js()).toEqual(1); // First occurrence of minimum (1)
+    });
+
+    test("argmin handles all equal values", () => {
+      const x = np.ones([5]).mul(42);
+      const result = np.argmin(x);
+      expect(result.js()).toEqual(0); // Returns first index
+    });
+
+    test("argmin 2D various shapes", () => {
+      const x = np.array([
+        [9, 8, 7],
+        [4, 5, 6],
+        [3, 2, 1],
+      ]);
+
+      expect(np.argmin(x.ref).js()).toEqual(8); // Global argmin
+      expect(np.argmin(x.ref, 0).js()).toEqual([2, 2, 2]); // Column-wise
+      expect(np.argmin(x, 1).js()).toEqual([2, 0, 2]); // Row-wise
+    });
+  });
+});


### PR DESCRIPTION
# Notes

- Implement ArgMin/ArgMax reduction primitives for all backends (CPU, WASM, WebGPU).
- Fix WASM backend stack management for argreduce operations.
- Add comprehensive performance tests (test/argreduce.test.ts).
- Performance improvements: 2.5x faster overall, up to 6x on CPU backend (Only tested on M4 Pro for reference).
- All 33 tests pass across CPU, WASM, and WebGPU backends.
- We could probably be squeeze out a bit more performance with subgroups (requires some bigger changes).
- A lot of the added LOC come from the test file.

# Test Results

## PR Test Results

 RUN  v4.0.16 /Users/kylelukaszek/Projects/ts/jax-js

 ✓  chromium  test/argreduce.test.ts > device:cpu > jax.numpy.argmax() performance > efficiently finds argmax in large array 3ms
 ✓  chromium  test/argreduce.test.ts > device:cpu > jax.numpy.argmax() performance > efficiently finds argmax along axis 9ms
 ✓  chromium  test/argreduce.test.ts > device:cpu > jax.numpy.argmax() performance > argmax returns first index on ties 0ms
 ✓  chromium  test/argreduce.test.ts > device:cpu > jax.numpy.argmax() performance > argmax works with negative values 0ms
 ✓  chromium  test/argreduce.test.ts > device:cpu > jax.numpy.argmin() performance > efficiently finds argmin in large array 1ms
 ✓  chromium  test/argreduce.test.ts > device:cpu > jax.numpy.argmin() performance > efficiently finds argmin along axis 11ms
 ✓  chromium  test/argreduce.test.ts > device:cpu > jax.numpy.argmin() performance > argmin returns first index on ties 0ms
 ✓  chromium  test/argreduce.test.ts > device:cpu > argreduce correctness > argmax handles all equal values 0ms
 ✓  chromium  test/argreduce.test.ts > device:cpu > argreduce correctness > argmin handles all equal values 0ms
 ✓  chromium  test/argreduce.test.ts > device:cpu > argreduce correctness > argmax 2D various shapes 0ms
 ✓  chromium  test/argreduce.test.ts > device:cpu > argreduce correctness > argmin 2D various shapes 0ms
 ✓  chromium  test/argreduce.test.ts > device:wasm > jax.numpy.argmax() performance > efficiently finds argmax in large array 1ms
 ✓  chromium  test/argreduce.test.ts > device:wasm > jax.numpy.argmax() performance > efficiently finds argmax along axis 0ms
 ✓  chromium  test/argreduce.test.ts > device:wasm > jax.numpy.argmax() performance > argmax returns first index on ties 0ms
 ✓  chromium  test/argreduce.test.ts > device:wasm > jax.numpy.argmax() performance > argmax works with negative values 0ms
 ✓  chromium  test/argreduce.test.ts > device:wasm > jax.numpy.argmin() performance > efficiently finds argmin in large array 0ms
 ✓  chromium  test/argreduce.test.ts > device:wasm > jax.numpy.argmin() performance > efficiently finds argmin along axis 0ms
 ✓  chromium  test/argreduce.test.ts > device:wasm > jax.numpy.argmin() performance > argmin returns first index on ties 0ms
 ✓  chromium  test/argreduce.test.ts > device:wasm > argreduce correctness > argmax handles all equal values 0ms
 ✓  chromium  test/argreduce.test.ts > device:wasm > argreduce correctness > argmin handles all equal values 0ms
 ✓  chromium  test/argreduce.test.ts > device:wasm > argreduce correctness > argmax 2D various shapes 1ms
 ✓  chromium  test/argreduce.test.ts > device:wasm > argreduce correctness > argmin 2D various shapes 0ms
 ✓  chromium  test/argreduce.test.ts > device:webgpu > jax.numpy.argmax() performance > efficiently finds argmax in large array 24ms
 ✓  chromium  test/argreduce.test.ts > device:webgpu > jax.numpy.argmax() performance > efficiently finds argmax along axis 3ms
 ✓  chromium  test/argreduce.test.ts > device:webgpu > jax.numpy.argmax() performance > argmax returns first index on ties 2ms
 ✓  chromium  test/argreduce.test.ts > device:webgpu > jax.numpy.argmax() performance > argmax works with negative values 1ms
 ✓  chromium  test/argreduce.test.ts > device:webgpu > jax.numpy.argmin() performance > efficiently finds argmin in large array 2ms
 ✓  chromium  test/argreduce.test.ts > device:webgpu > jax.numpy.argmin() performance > efficiently finds argmin along axis 4ms
 ✓  chromium  test/argreduce.test.ts > device:webgpu > jax.numpy.argmin() performance > argmin returns first index on ties 1ms
 ✓  chromium  test/argreduce.test.ts > device:webgpu > argreduce correctness > argmax handles all equal values 1ms
 ✓  chromium  test/argreduce.test.ts > device:webgpu > argreduce correctness > argmin handles all equal values 2ms
 ✓  chromium  test/argreduce.test.ts > device:webgpu > argreduce correctness > argmax 2D various shapes 5ms
 ✓  chromium  test/argreduce.test.ts > device:webgpu > argreduce correctness > argmin 2D various shapes 6ms

 Test Files  1 passed (1)
      Tests  33 passed (33)
   Start at  02:04:38
   Duration  514ms (transform 0ms, setup 46ms, import 10ms, tests 82ms, environment 0ms)

## Upstream Test Results


 RUN  v4.0.16 /Users/kylelukaszek/Projects/ts/jax-js

 ✓  chromium  test/argreduce.test.ts > device:cpu > jax.numpy.argmax() performance > efficiently finds argmax in large array 11ms
 ✓  chromium  test/argreduce.test.ts > device:cpu > jax.numpy.argmax() performance > efficiently finds argmax along axis 52ms
 ✓  chromium  test/argreduce.test.ts > device:cpu > jax.numpy.argmax() performance > argmax returns first index on ties 1ms
 ✓  chromium  test/argreduce.test.ts > device:cpu > jax.numpy.argmax() performance > argmax works with negative values 1ms
 ✓  chromium  test/argreduce.test.ts > device:cpu > jax.numpy.argmin() performance > efficiently finds argmin in large array 6ms
 ✓  chromium  test/argreduce.test.ts > device:cpu > jax.numpy.argmin() performance > efficiently finds argmin along axis 54ms
 ✓  chromium  test/argreduce.test.ts > device:cpu > jax.numpy.argmin() performance > argmin returns first index on ties 1ms
 ✓  chromium  test/argreduce.test.ts > device:cpu > argreduce correctness > argmax handles all equal values 0ms
 ✓  chromium  test/argreduce.test.ts > device:cpu > argreduce correctness > argmin handles all equal values 1ms
 ✓  chromium  test/argreduce.test.ts > device:cpu > argreduce correctness > argmax 2D various shapes 2ms
 ✓  chromium  test/argreduce.test.ts > device:cpu > argreduce correctness > argmin 2D various shapes 2ms
 ✓  chromium  test/argreduce.test.ts > device:wasm > jax.numpy.argmax() performance > efficiently finds argmax in large array 2ms
 ✓  chromium  test/argreduce.test.ts > device:wasm > jax.numpy.argmax() performance > efficiently finds argmax along axis 2ms
 ✓  chromium  test/argreduce.test.ts > device:wasm > jax.numpy.argmax() performance > argmax returns first index on ties 1ms
 ✓  chromium  test/argreduce.test.ts > device:wasm > jax.numpy.argmax() performance > argmax works with negative values 1ms
 ✓  chromium  test/argreduce.test.ts > device:wasm > jax.numpy.argmin() performance > efficiently finds argmin in large array 1ms
 ✓  chromium  test/argreduce.test.ts > device:wasm > jax.numpy.argmin() performance > efficiently finds argmin along axis 1ms
 ✓  chromium  test/argreduce.test.ts > device:wasm > jax.numpy.argmin() performance > argmin returns first index on ties 0ms
 ✓  chromium  test/argreduce.test.ts > device:wasm > argreduce correctness > argmax handles all equal values 0ms
 ✓  chromium  test/argreduce.test.ts > device:wasm > argreduce correctness > argmin handles all equal values 1ms
 ✓  chromium  test/argreduce.test.ts > device:wasm > argreduce correctness > argmax 2D various shapes 2ms
 ✓  chromium  test/argreduce.test.ts > device:wasm > argreduce correctness > argmin 2D various shapes 1ms
 ✓  chromium  test/argreduce.test.ts > device:webgpu > jax.numpy.argmax() performance > efficiently finds argmax in large array 25ms
 ✓  chromium  test/argreduce.test.ts > device:webgpu > jax.numpy.argmax() performance > efficiently finds argmax along axis 3ms
 ✓  chromium  test/argreduce.test.ts > device:webgpu > jax.numpy.argmax() performance > argmax returns first index on ties 4ms
 ✓  chromium  test/argreduce.test.ts > device:webgpu > jax.numpy.argmax() performance > argmax works with negative values 2ms
 ✓  chromium  test/argreduce.test.ts > device:webgpu > jax.numpy.argmin() performance > efficiently finds argmin in large array 3ms
 ✓  chromium  test/argreduce.test.ts > device:webgpu > jax.numpy.argmin() performance > efficiently finds argmin along axis 5ms
 ✓  chromium  test/argreduce.test.ts > device:webgpu > jax.numpy.argmin() performance > argmin returns first index on ties 2ms
 ✓  chromium  test/argreduce.test.ts > device:webgpu > argreduce correctness > argmax handles all equal values 3ms
 ✓  chromium  test/argreduce.test.ts > device:webgpu > argreduce correctness > argmin handles all equal values 1ms
 ✓  chromium  test/argreduce.test.ts > device:webgpu > argreduce correctness > argmax 2D various shapes 10ms
 ✓  chromium  test/argreduce.test.ts > device:webgpu > argreduce correctness > argmin 2D various shapes 7ms

 Test Files  1 passed (1)
      Tests  33 passed (33)
   Start at  02:04:36
   Duration  653ms (transform 0ms, setup 53ms, import 9ms, tests 208ms, environment 0ms)

## PR Branch Final Vitest Results

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Failed Suites 1 ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯

 FAIL   chromium  packages/onnx/src/model.test.ts [ packages/onnx/src/model.test.ts ]
Error: Failed to import test file /Users/kylelukaszek/Projects/ts/jax-js/packages/onnx/src/model.test.ts
Caused by: TypeError: Failed to fetch dynamically imported module: http://localhost:63315/Users/kylelukaszek/Projects/ts/jax-js/packages/onnx/src/model.test.ts?import&browserv=1766821450951
⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯


 Test Files  1 failed | 30 passed (31)
      Tests  898 passed (898)
   Start at  02:44:09
   Duration  2.12s (transform 0ms, setup 2.15s, import 2.78s, tests 2.47s, environment 0ms)