### PR TITLE
feat(numpy): add sinc function

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -410,7 +410,7 @@ Most operations behave the same way as they do in JAX.
 | `sign`                | 🟢      |                                         |
 | `signbit`             | 🔴      |                                         |
 | `sin`                 | 🟢      |                                         |
-| `sinc`                | 🟠      |                                         |
+| `sinc`                | 🟡      | JVP not supported at x=0                |
 | `sinh`                | 🟢      |                                         |
 | `size`                | 🟢      |                                         |
 | `sort`                | 🟢      | sorting                                 |

--- a/src/library/numpy.ts
+++ b/src/library/numpy.ts
@@ -1300,6 +1300,25 @@ export function tan(x: ArrayLike): Array {
   return sin(x.ref).div(cos(x));
 }
 
+/**
+ * @function
+ * Return the normalized sinc function.
+ *
+ * The sinc function is defined as `sin(πx) / (πx)` for `x != 0`, and `1` for `x = 0`.
+ * This is the normalized sinc function commonly used in signal processing.
+ *
+ * **Note:** JVP is not supported at x=0 due to discontinuous derivative. This
+ * requires a custom JVP rule to handle properly (see JAX implementation).
+ *
+ * @param x - Input array.
+ * @returns Array with sinc(x) values.
+ */
+export const sinc = jit(function sinc(x: Array): Array {
+  const pix = x.ref.mul(Math.PI);
+  // sinc(0) = 1, otherwise sin(πx) / (πx)
+  return where(equal(x, 0), 1, sin(pix.ref).div(pix));
+});
+
 /** Element-wise inverse cosine function (inverse of cos). */
 export function acos(x: ArrayLike): Array {
   return subtract(pi / 2, asin(x));

--- a/test/numpy.test.ts
+++ b/test/numpy.test.ts
@@ -1444,6 +1444,38 @@ suite.each(devices)("device:%s", (device) => {
     });
   });
 
+  suite("jax.numpy.sinc()", () => {
+    test("sinc(0) = 1", () => {
+      expect(np.sinc(0).js()).toBeCloseTo(1, 5);
+    });
+
+    test("sinc at integer values is 0", () => {
+      // sinc(n) = sin(πn) / (πn) = 0 for non-zero integers
+      const x = np.array([1, 2, 3, -1, -2, -3]);
+      const result: number[] = np.sinc(x).js();
+      for (const val of result) {
+        expect(val).toBeCloseTo(0, 5);
+      }
+    });
+
+    test("sinc at 0.5", () => {
+      // sinc(0.5) = sin(π/2) / (π/2) = 1 / (π/2) = 2/π
+      expect(np.sinc(0.5).js()).toBeCloseTo(2 / Math.PI, 5);
+    });
+
+    test("sinc is symmetric", () => {
+      const x = np.array([0.1, 0.5, 1.5, 2.5]);
+      const negX = np.array([-0.1, -0.5, -1.5, -2.5]);
+      expect(np.sinc(x).js()).toBeAllclose(np.sinc(negX).js());
+    });
+
+    test("sinc on array", () => {
+      const x = np.array([0, 0.5, 1]);
+      const expected = [1, 2 / Math.PI, 0];
+      expect(np.sinc(x).js()).toBeAllclose(expected);
+    });
+  });
+
   suite("jax.numpy.atan()", () => {
     test("arctan values", () => {
       const vals = [-1000, -100, -10, -1, 0, 1, 10, 100, 1000, Infinity];


### PR DESCRIPTION
## Summary

- Adds the `sinc` function to `jax.numpy`, implementing the normalized sinc function commonly used in signal processing
- `sinc(x) = sin(πx) / (πx)` for `x != 0`, and `sinc(0) = 1`
- Updates FEATURES.md to mark `sinc` as implemented

## Test coverage

- `sinc(0) = 1`
- `sinc` at integer values is 0
- `sinc(0.5) = 2/π`
- `sinc` is symmetric
- `sinc` on array inputs