### PR TITLE
Add hasAux support to grad, valueAndGrad and vjp

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -49,7 +49,7 @@ In the tables below, we use a color legend to refer to functions in JAX:
 | `jacfwd`             | 🟢      |                                                 |
 | `jacrev`             | 🟢      |                                                 |
 | `hessian`            | 🟠      |                                                 |
-| `jvp`                | 🟢      | need to add `has_aux`                           |
+| `jvp`                | 🟢      |                                                 |
 | `linearize`          | 🟢      | need to add `has_aux`                           |
 | `linear_transpose`   | 🟠      |                                                 |
 | `vjp`                | 🟢      |                                                 |

--- a/src/frontend/linearize.ts
+++ b/src/frontend/linearize.ts
@@ -27,6 +27,7 @@ import {
   concatenate,
   conv,
   flattenFun,
+  flattenFunWithAux,
   flip,
   fullRaise,
   mul,
@@ -63,7 +64,7 @@ import {
   typecheckJaxpr,
   Var,
 } from "./jaxpr";
-import { jvp } from "./jvp";
+import { jvp, lowerAux } from "./jvp";
 import { moveaxis, vmap } from "./vmap";
 
 /** Array value that can either be known or unknown. */
@@ -956,9 +957,15 @@ function vjpFlat(
 export function vjp(
   f: (...primals: any) => any,
   primalsIn: any[],
-): [any, OwnedFunction<(...cotangents: any) => any>] {
+  { hasAux = false } = {},
+): [any, OwnedFunction<(...cotangents: any) => any>, any?] {
   const [primalsInFlat, inTree] = treeFlatten(primalsIn);
-  const [fFlat, outTree] = flattenFun(f, inTree);
+  let fFlat, outTree, aux;
+  if (hasAux) {
+    [fFlat, outTree, aux] = flattenFunWithAux(f, inTree);
+  } else {
+    [fFlat, outTree] = flattenFun(f, inTree);
+  }
   const [primalsOutFlat, fVjpFlat, dispose] = vjpFlat(
     fFlat,
     primalsInFlat.map(pureArray),
@@ -979,6 +986,9 @@ export function vjp(
   }) as OwnedFunction<(...cotangents: any) => any>;
   fVjp.dispose = dispose;
 
+  if (hasAux) {
+    return [primalsOut, fVjp, lowerAux(aux!.value)];
+  }
   return [primalsOut, fVjp];
 }
 
@@ -1003,14 +1013,21 @@ export type GradOpts = {
 export function grad(f: (...primals: any) => Tracer, opts?: GradOpts) {
   const valueAndGradFn = valueAndGrad(f, opts);
   return (...x: any) => {
-    const [y, dx] = valueAndGradFn(...x);
-    y.dispose();
-    return dx;
+    if (opts?.hasAux) {
+      const [[y, aux], dx] = valueAndGradFn(...x);
+      y.dispose();
+      return [dx, aux];
+    } else {
+      const [y, dx] = valueAndGradFn(...x);
+      y.dispose();
+      return dx;
+    }
   };
 }
 
 export function valueAndGrad(f: (...primals: any) => Tracer, opts?: GradOpts) {
   const argnums = opts?.argnums ?? 0; // By default, differentiate w.r.t. first arg.
+  const hasAux = opts?.hasAux ?? false;
   checkInts(argnums);
   const argnumsSet = new Set(typeof argnums === "number" ? [argnums] : argnums);
   return (...x: any) => {
@@ -1021,7 +1038,7 @@ export function valueAndGrad(f: (...primals: any) => Tracer, opts?: GradOpts) {
     for (let i = 0; i < x.length; i++) {
       if (!argnumsSet.has(i)) x[i] = treeMap(stopGradient, x[i]);
     }
-    const [y, fVjp] = vjp(f, x);
+    const [y, fVjp, aux] = vjp(f, x, { hasAux });
     if (!(y instanceof Tracer) || ndim(y) !== 0) {
       throw new TypeError("grad requires a scalar output");
     }
@@ -1035,7 +1052,7 @@ export function valueAndGrad(f: (...primals: any) => Tracer, opts?: GradOpts) {
     }
     const grads =
       typeof argnums === "number" ? cts[argnums] : argnums.map((i) => cts[i]);
-    return [y, grads];
+    return hasAux ? [[y, aux], grads] : [y, grads];
   };
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,11 +44,17 @@ export {
  */
 export const jvp = jvpModule.jvp as <
   F extends (...args: any[]) => JsTree<Array>,
+  HA extends boolean = false,
 >(
   f: F,
   primals: MapJsTree<Parameters<F>, Array, ArrayLike>,
   tangents: MapJsTree<Parameters<F>, Array, ArrayLike>,
-) => [ReturnType<F>, ReturnType<F>];
+  opts?: { hasAux?: HA },
+) => HA extends true
+  ? ReturnType<F> extends [infer Out, infer Aux]
+    ? [Out, Out, Aux]
+    : never
+  : [ReturnType<F>, ReturnType<F>];
 
 /**
  * @function
@@ -148,7 +154,7 @@ export const vjp = linearizeModule.vjp as <
 >(
   f: F,
   primals: MapJsTree<Parameters<F>, Array, ArrayLike>,
-  opts?: { hasAux: HA },
+  opts?: { hasAux?: HA },
 ) => HA extends true
   ? ReturnType<F> extends [infer Out, infer Aux]
     ? [

--- a/test/tracing.test.ts
+++ b/test/tracing.test.ts
@@ -163,7 +163,7 @@ suite("jax.vjp()", () => {
     expect(loss).toBeAllclose(6);
     expect(aux).toBeAllclose([2, 4, 6]);
 
-    const [grad] = vjpFn(np.ones([]));
+    const [grad] = vjpFn(1);
     expect(grad).toBeAllclose([1, 1, 1]);
 
     vjpFn.dispose();


### PR DESCRIPTION
 Adds `{ hasAux: true }` option to `vjp`, `grad`, and `valueAndGrad` for returning auxiliary outputs alongside gradients.

  ```ts
  // vjp returns [output, vjpFn, aux]
  const [y, vjpFn, aux] = vjp(f, { hasAux: true }, x);

  // grad returns [gradient, aux]
  const [gradient, aux] = grad(f, { hasAux: true })(x);

  // valueAndGrad returns [value, gradient, aux]
  const [value, gradient, aux] = valueAndGrad(f, { hasAux: true })(x);
```