### PR TITLE
Cholesky and TriangularSolve on WebGPU

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -508,7 +508,7 @@ Cholesky but are missing other building blocks like:
 
 | API                | Support | Notes                                   |
 | ------------------ | ------- | --------------------------------------- |
-| `cholesky`         | 🟡      | Not yet on WebGPU                       |
+| `cholesky`         | 🟢      |                                         |
 | `cond`             | 🔴      |                                         |
 | `cross`            | 🟠      |                                         |
 | `det`              | 🔴      |                                         |

--- a/src/frontend/core.ts
+++ b/src/frontend/core.ts
@@ -464,6 +464,13 @@ export function triangularSolve(
   }: { lower?: boolean; unitDiagonal?: boolean } = {},
 ) {
   // Solve a triangular linear system `A @ X.T = B.T`, transposed for speed.
+  const as = getShape(a);
+  const bs = getShape(b);
+  if (as.length < 2 || bs.length < 2)
+    throw new Error(`triangular_solve: must be >=2D, got a=${as}, b=${bs}`);
+  const n = as[as.length - 2];
+  if (n !== as[as.length - 1] || n !== bs[bs.length - 1])
+    throw new Error(`triangular_solve: incompatible shapes a=${as}, b=${bs}`);
   if (lower) {
     // Convert lower-triangular solve into upper-triangular solve by
     // flipping the matrices.
@@ -476,6 +483,9 @@ export function triangularSolve(
 }
 
 export function cholesky(x: TracerValue) {
+  const aval = ShapedArray.fromAval(getAval(x));
+  if (aval.ndim < 2 || aval.shape[aval.ndim - 1] !== aval.shape[aval.ndim - 2])
+    throw new Error(`cholesky: expected batch of square matrices, got ${aval}`);
   return bind1(Primitive.Cholesky, [x]);
 }
 

--- a/test/lax-linalg.test.ts
+++ b/test/lax-linalg.test.ts
@@ -10,8 +10,9 @@ import {
 import { beforeEach, expect, suite, test } from "vitest";
 
 const devicesAvailable = await init();
+const devicesWithLinalg: Device[] = ["cpu", "wasm", "webgpu"];
 
-suite.each(["cpu", "wasm"] as Device[])("device:%s", (device) => {
+suite.each(devicesWithLinalg)("device:%s", (device) => {
   const skipped = !devicesAvailable.includes(device);
   beforeEach(({ skip }) => {
     if (skipped) skip();
@@ -80,7 +81,7 @@ suite.each(["cpu", "wasm"] as Device[])("device:%s", (device) => {
       const eps = 1e-4;
       const L2 = lax.linalg.cholesky(x.add(dx.mul(eps)));
       const dL_fd = L2.sub(L).div(eps);
-      expect(dL).toBeAllclose(dL_fd, { rtol: 1e-2, atol: 1e-3 });
+      expect(dL).toBeAllclose(dL_fd, { rtol: 1e-2, atol: 2e-3 });
     });
 
     test("works with grad", () => {

--- a/test/numpy-linalg.test.ts
+++ b/test/numpy-linalg.test.ts
@@ -9,8 +9,9 @@ import {
 import { beforeEach, expect, suite, test } from "vitest";
 
 const devicesAvailable = await init();
+const devicesWithLinalg: Device[] = ["cpu", "wasm", "webgpu"];
 
-suite.each(["cpu", "wasm"] as Device[])("device:%s", (device) => {
+suite.each(devicesWithLinalg)("device:%s", (device) => {
   const skipped = !devicesAvailable.includes(device);
   beforeEach(({ skip }) => {
     if (skipped) skip();


### PR DESCRIPTION
This adds support for Cholesky and TriangularSolve routines via WebGPU shaders. Actually not too hard to parallelize across multiple threads in workgroup.

I didn't put O(n) sized things in shared memory, instead opting for `storageBarrier()` since it's easier. WebGPU has a limit of 16KB-32KB shared memory which can only fit n=4096 or n=8192 for float32, ehh let's just keep stuff in GMEM.

https://web3dsurvey.com/webgpu/limits/maxComputeWorkgroupStorageSize