### PR TITLE
Fix `jax.lax.linalg.triangularSolve()` transpose behavior

### DIFF
--- a/src/library/lax-linalg.ts
+++ b/src/library/lax-linalg.ts
@@ -110,7 +110,10 @@ export function triangularSolve(
   } else {
     b = moveaxis(b, -2, -1);
   }
-  if (transposeA) a = moveaxis(a, -2, -1);
+  if (transposeA) {
+    a = moveaxis(a, -2, -1);
+    lower = !lower;
+  }
   let x = core.triangularSolve(a, b, { lower, unitDiagonal }) as Array;
   if (leftSide) x = moveaxis(x, -2, -1);
   return x;

--- a/src/library/numpy-linalg.ts
+++ b/src/library/numpy-linalg.ts
@@ -88,7 +88,11 @@ export function lstsq(a: ArrayLike, b: ArrayLike): Array {
     const aat = np.matmul(a, at.ref); // A @ A.T, shape (M, M)
     const l = cholesky(aat, { symmetrizeInput: false }); // L @ L.T = A @ A.T
     const lb = triangularSolve(l.ref, b, { leftSide: true, lower: true }); // L^-1 @ B
-    const llb = triangularSolve(l, lb, { leftSide: true, transposeA: true }); // (A @ A.T)^-1 @ B
+    const llb = triangularSolve(l, lb, {
+      leftSide: true,
+      lower: true,
+      transposeA: true,
+    }); // (A @ A.T)^-1 @ B
     return np.matmul(at, llb.ref); // A.T @ (A @ A.T)^-1 @ B
   } else {
     // Overdetermined system: (A.T @ A)^-1 @ A.T @ B
@@ -96,7 +100,11 @@ export function lstsq(a: ArrayLike, b: ArrayLike): Array {
     const l = cholesky(ata, { symmetrizeInput: false }); // L @ L.T = A.T @ A
     const atb = np.matmul(at, b); // A.T @ B
     const lb = triangularSolve(l.ref, atb, { leftSide: true, lower: true }); // L^-1 @ A.T @ B
-    const llb = triangularSolve(l, lb, { leftSide: true, transposeA: true }); // (A.T @ A)^-1 @ A.T @ B
+    const llb = triangularSolve(l, lb, {
+      leftSide: true,
+      lower: true,
+      transposeA: true,
+    }); // (A.T @ A)^-1 @ A.T @ B
     return llb;
   }
 }

--- a/test/lax-linalg.test.ts
+++ b/test/lax-linalg.test.ts
@@ -246,5 +246,34 @@ suite.each(devicesWithLinalg)("device:%s", (device) => {
       }
       expect(db).toBeAllclose(expected, { rtol: 1e-2, atol: 1e-3 });
     });
+
+    test("behavior with transposed A", () => {
+      // See: https://github.com/ekzhang/jax-js/issues/73
+      const L = np.array([
+        [1, 1000000],
+        [1, 1],
+      ]);
+      const b = np.array([[1], [1]]);
+      const x = lax.linalg.triangularSolve(L, b, {
+        leftSide: true,
+        lower: true,
+        transposeA: true,
+      });
+      expect(x).toBeAllclose([[0], [1]]);
+    });
+
+    test("right-hand side triangular solve", () => {
+      // Solve x @ U = b
+      const U = np.array([
+        [2, 1],
+        [0, 3],
+      ]);
+      const b = np.array([[4, 7]]);
+      const x = lax.linalg.triangularSolve(U, b, {
+        leftSide: false,
+        lower: false,
+      });
+      expect(x).toBeAllclose([[2, 5 / 3]]);
+    });
   });
 });


### PR DESCRIPTION
Triangular solve wasn't using the correct triangular half of the array when `transposeA` was passed, or when `leftSide` is false.

Fixes #73.