### PR TITLE
Implement numpy.linalg.vectorNorm

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -537,7 +537,7 @@ Cholesky but are missing other building blocks like:
 | `tensorinv`        | 🔴      |                                         |
 | `tensorsolve`      | 🔴      |                                         |
 | `trace`            | 🟢      |                                         |
-| `vector_norm`      | 🟠      |                                         |
+| `vector_norm`      | 🟢      |                                         |
 | `vecdot`           | 🟢      |                                         |
 
 ## [`jax.lax` module](https://docs.jax.dev/en/latest/jax.lax.html)

--- a/src/library/numpy-linalg.ts
+++ b/src/library/numpy-linalg.ts
@@ -232,3 +232,38 @@ export function solve(a: ArrayLike, b: ArrayLike): Array {
 export { tensordot } from "./numpy";
 export { trace } from "./numpy";
 export { vecdot } from "./numpy";
+
+/**
+ * Compute the vector norm of an array.
+ *
+ * @param x - Input array.
+ * @param opts.ord - Order of the norm (default 2). Supports `Infinity`, `-Infinity`, `0`, or any real number.
+ * @param opts.axis - Axis/axes to reduce over (default: all axes).
+ * @param opts.keepdims - Whether to keep reduced dimensions as size 1.
+ * @returns The norm of `x`, reduced over the given axes.
+ */
+export function vectorNorm(
+  x: ArrayLike,
+  {
+    ord = 2,
+    axis = null,
+    keepdims = false,
+  }: {
+    ord?: number;
+    axis?: number | number[] | null;
+    keepdims?: boolean;
+  } = {},
+): Array {
+  x = fudgeArray(x);
+  const ax = axis ?? null;
+
+  if (ord === Infinity) {
+    return np.max(np.abs(x), ax, { keepdims });
+  } else if (ord === -Infinity) {
+    return np.min(np.abs(x), ax, { keepdims });
+  } else if (ord === 0) {
+    return x.notEqual(0).astype(x.dtype).sum(ax, { keepdims });
+  } else {
+    return np.power(np.power(np.abs(x), ord).sum(ax, { keepdims }), 1 / ord);
+  }
+}

--- a/src/library/numpy-linalg.ts
+++ b/src/library/numpy-linalg.ts
@@ -237,9 +237,9 @@ export { vecdot } from "./numpy";
  * Compute the vector norm of an array.
  *
  * @param x - Input array.
- * @param opts.ord - Order of the norm (default 2). Supports `Infinity`, `-Infinity`, `0`, or any real number.
- * @param opts.axis - Axis/axes to reduce over (default: all axes).
- * @param opts.keepdims - Whether to keep reduced dimensions as size 1.
+ * @param ord - Order of the norm (default 2). Supports `Infinity`, `-Infinity`, `0`, or any real number.
+ * @param axis - Axis/axes to reduce over (default: all axes).
+ * @param keepdims - Whether to keep reduced dimensions as size 1.
  * @returns The norm of `x`, reduced over the given axes.
  */
 export function vectorNorm(

--- a/test/numpy-linalg.test.ts
+++ b/test/numpy-linalg.test.ts
@@ -301,4 +301,49 @@ suite.each(devicesWithLinalg)("device:%s", (device) => {
       expect(xPred).toBeAllclose(xTrue, { rtol: 1e-2, atol: 1e-4 });
     });
   });
+
+  suite("numpy.linalg.vectorNorm()", () => {
+    test("L2 norm (default)", () => {
+      const x = np.array([3.0, 4.0]);
+      expect(np.linalg.vectorNorm(x)).toBeAllclose(5.0);
+    });
+
+    test("L1 norm", () => {
+      const x = np.array([3.0, -4.0]);
+      expect(np.linalg.vectorNorm(x, { ord: 1 })).toBeAllclose(7.0);
+    });
+
+    test("Linf norm", () => {
+      const x = np.array([3.0, -4.0]);
+      expect(np.linalg.vectorNorm(x, { ord: Infinity })).toBeAllclose(4.0);
+    });
+
+    test("negative Inf norm", () => {
+      const x = np.array([3.0, -4.0]);
+      expect(np.linalg.vectorNorm(x, { ord: -Infinity })).toBeAllclose(3.0);
+    });
+
+    test("L0 norm (count nonzeros)", () => {
+      const x = np.array([0.0, 3.0, 0.0, -4.0, 5.0]);
+      expect(np.linalg.vectorNorm(x, { ord: 0 })).toBeAllclose(3.0);
+    });
+
+    test("axis argument", () => {
+      const x = np.array([
+        [3.0, 4.0],
+        [5.0, 12.0],
+      ]);
+      expect(np.linalg.vectorNorm(x, { axis: 1 })).toBeAllclose([5.0, 13.0]);
+    });
+
+    test("keepdims", () => {
+      const x = np.array([
+        [3.0, 4.0],
+        [5.0, 12.0],
+      ]);
+      const norms = np.linalg.vectorNorm(x, { axis: 1, keepdims: true });
+      expect(norms.shape).toEqual([2, 1]);
+      expect(norms).toBeAllclose([[5.0], [13.0]]);
+    });
+  });
 });


### PR DESCRIPTION
Add `numpy.linalg.vectorNorm(x, { ord, axis, keepdims })` supporting ord values 0, Infinity, -Infinity, and any real p. Also add 7 tests covering ord 0, 1, 2, Infinity, -Infinity, axis reduction, and keepdims.
