### PR TITLE
Wasm execution on worker threads, in parallel

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,7 +311,9 @@ and determines how to execute compiled operations on them.
 There are currently 4 devices in jax-js:
 
 - `cpu`: Slow, interpreted JS, only meant for debugging.
-- `wasm`: [WebAssembly](https://webassembly.org/), currently single-threaded and blocking.
+- `wasm`: [WebAssembly](https://webassembly.org/), multi-threaded when
+  [`SharedArrayBuffer`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer)
+  is available.
 - `webgpu`: [WebGPU](https://developer.mozilla.org/en-US/docs/Web/API/WebGPU_API), available on
   [supported browsers](https://caniuse.com/webgpu) (Chrome, Firefox, Safari, iOS).
 - `webgl`: [WebGL2](https://developer.mozilla.org/en-US/docs/Web/API/WebGL2RenderingContext), via

--- a/src/backend/backend.test.ts
+++ b/src/backend/backend.test.ts
@@ -22,6 +22,17 @@ suite.each(devices)("device:%s", (device) => {
     if (skipped) skip();
   });
 
+  if (device === "wasm") {
+    // Make sure tests are configured so wasm runs with SharedArrayBuffer, we
+    // want to test the multithreaded backend.
+    test("SharedArrayBuffer is available", () => {
+      if (typeof window !== "undefined") {
+        expect(window.crossOriginIsolated).toBe(true);
+      }
+      expect(typeof SharedArrayBuffer).toBe("function");
+    });
+  }
+
   test("can run simple operations", async () => {
     const backend = getBackend(device);
 

--- a/src/backend/wasm.ts
+++ b/src/backend/wasm.ts
@@ -156,7 +156,7 @@ export class WasmBackend implements Backend {
       const ptrs = [...inputs, ...outputs].map(
         (slot) => this.#buffers.get(slot)!.ptr,
       );
-      func(...ptrs);
+      func(...ptrs, 0, exe.source.size);
     }
 
     if (tracing) {
@@ -204,14 +204,19 @@ function codegenWasm(kernel: Kernel): Uint8Array<ArrayBuffer> {
   if (distinctOps.has(AluOp.Threefry2x32))
     funcs.threefry2x32 = wasm_threefry2x32(cg);
 
-  const kernelFunc = cg.function(rep(kernel.nargs + 1, cg.i32), [], () => {
+  // Params: arg0, ..., argN-1, output, begin, end
+  const paramBegin = kernel.nargs + 1;
+  const paramEnd = kernel.nargs + 2;
+  const kernelFunc = cg.function(rep(kernel.nargs + 3, cg.i32), [], () => {
     const gidx = cg.local.declare(cg.i32);
+    cg.local.get(paramBegin);
+    cg.local.set(gidx);
     cg.loop(cg.void);
     {
-      // if (gidx >= size) break;
+      // if (gidx >= end) break;
       cg.block(cg.void);
       cg.local.get(gidx);
-      cg.i32.const(kernel.size);
+      cg.local.get(paramEnd);
       cg.i32.ge_u();
       cg.br_if(0);
 

--- a/src/backend/wasm.ts
+++ b/src/backend/wasm.ts
@@ -18,7 +18,14 @@ import {
 import { Routine, runCpuRoutine } from "../routine";
 import { emitTrace, isTracing, traceSourceInfo } from "../tracing";
 import { tuneNullopt } from "../tuner";
-import { DEBUG, FpHash, mapSetUnion, rep, runWithCache } from "../utils";
+import {
+  DEBUG,
+  FpHash,
+  mapSetUnion,
+  rep,
+  runWithCache,
+  runWithCacheAsync,
+} from "../utils";
 import { WasmAllocator } from "./wasm/allocator";
 import {
   wasm_asin,
@@ -31,6 +38,11 @@ import {
   wasm_sin,
   wasm_threefry2x32,
 } from "./wasm/builtins";
+import {
+  createWorkerPool,
+  hasSharedArrayBuffer,
+  WasmWorkerPool,
+} from "./wasm/parallel";
 import { CodeGenerator } from "./wasm/wasmblr";
 
 interface WasmBuffer {
@@ -41,6 +53,7 @@ interface WasmBuffer {
 
 interface WasmProgram {
   module: WebAssembly.Module;
+  parallel: boolean;
 }
 
 const moduleCache = new Map<string, WebAssembly.Module>();
@@ -54,12 +67,17 @@ export class WasmBackend implements Backend {
   #nextSlot: number;
   #allocator: WasmAllocator;
   #buffers: Map<Slot, WasmBuffer>;
+  #workerPool: WasmWorkerPool | null;
+  #pendingWork: Map<Slot, bigint> = new Map();
 
   constructor() {
-    this.#memory = new WebAssembly.Memory({ initial: 0 });
+    this.#memory = hasSharedArrayBuffer()
+      ? new WebAssembly.Memory({ initial: 0, maximum: 65536, shared: true })
+      : new WebAssembly.Memory({ initial: 0 });
     this.#allocator = new WasmAllocator(this.#memory);
     this.#nextSlot = 1;
     this.#buffers = new Map();
+    this.#workerPool = createWorkerPool(this.#memory);
   }
 
   malloc(size: number, initialData?: Uint8Array): Slot {
@@ -97,7 +115,9 @@ export class WasmBackend implements Backend {
     start?: number,
     count?: number,
   ): Promise<Uint8Array<ArrayBuffer>> {
-    return this.readSync(slot, start, count);
+    const epoch = this.#pendingWork.get(slot);
+    if (epoch) await this.#workerPool!.waitForEpoch(epoch);
+    return this.#readData(slot, start, count);
   }
 
   readSync(
@@ -105,23 +125,52 @@ export class WasmBackend implements Backend {
     start?: number,
     count?: number,
   ): Uint8Array<ArrayBuffer> {
+    const epoch = this.#pendingWork.get(slot);
+    if (epoch && this.#workerPool!.epoch < epoch)
+      throw new Error("cannot read synchronously from a slot with async work");
+    return this.#readData(slot, start, count);
+  }
+
+  #readData(
+    slot: Slot,
+    start?: number,
+    count?: number,
+  ): Uint8Array<ArrayBuffer> {
     const buffer = this.#getBuffer(slot);
     if (start === undefined) start = 0;
     if (count === undefined) count = buffer.byteLength - start;
-    return buffer.slice(start, start + count);
+    if (buffer.buffer instanceof SharedArrayBuffer) {
+      // For SharedArrayBuffer, we need to copy the data to ArrayBuffer.
+      return new Uint8Array(buffer.slice(start, start + count));
+    } else {
+      return buffer.slice(start, start + count);
+    }
   }
 
   async prepareKernel(kernel: Kernel): Promise<Executable<WasmProgram>> {
-    return this.prepareKernelSync(kernel);
+    const kernelHash = FpHash.hash(kernel);
+    const module = await runWithCacheAsync(
+      moduleCache,
+      kernelHash.toString(),
+      () => WebAssembly.compile(codegenWasm(kernel)),
+    );
+    return new Executable(kernel, {
+      module,
+      parallel: this.#workerPool !== null,
+    });
   }
 
   prepareKernelSync(kernel: Kernel): Executable<WasmProgram> {
     const kernelHash = FpHash.hash(kernel);
-    const module = runWithCache(moduleCache, kernelHash.toString(), () => {
-      const bytes = codegenWasm(kernel);
-      return new WebAssembly.Module(bytes);
+    const module = runWithCache(
+      moduleCache,
+      kernelHash.toString(),
+      () => new WebAssembly.Module(codegenWasm(kernel)),
+    );
+    return new Executable(kernel, {
+      module,
+      parallel: false,
     });
-    return new Executable(kernel, { module });
   }
 
   async prepareRoutine(routine: Routine): Promise<Executable<WasmProgram>> {
@@ -131,7 +180,7 @@ export class WasmBackend implements Backend {
   prepareRoutineSync(routine: Routine): Executable<WasmProgram> {
     // Currently, Wasm routines fall back to the CPU reference implementation
     // implementation. We may optimize this in the future.
-    return new Executable(routine, undefined as any);
+    return new Executable(routine, { module: undefined!, parallel: false });
   }
 
   dispatch(
@@ -149,14 +198,33 @@ export class WasmBackend implements Backend {
         outputs.map((slot) => this.#getBuffer(slot)),
       );
     } else {
-      const instance = new WebAssembly.Instance(exe.data.module, {
-        env: { memory: this.#memory },
-      });
-      const func = instance.exports.kernel as (...args: number[]) => void;
       const ptrs = [...inputs, ...outputs].map(
         (slot) => this.#buffers.get(slot)!.ptr,
       );
-      func(...ptrs, 0, exe.source.size);
+      if (exe.data.parallel && this.#workerPool) {
+        const epoch = this.#workerPool.dispatch(
+          exe.data.module,
+          ptrs,
+          exe.source.size,
+        );
+        for (const slot of outputs) this.#pendingWork.set(slot, epoch);
+      } else {
+        if (
+          inputs.some((slot) => {
+            const epoch = this.#pendingWork.get(slot);
+            return epoch && this.#workerPool!.epoch < epoch;
+          })
+        ) {
+          throw new Error(
+            "cannot dispatch synchronously with pending async work",
+          );
+        }
+        const instance = new WebAssembly.Instance(exe.data.module, {
+          env: { memory: this.#memory },
+        });
+        const func = instance.exports.kernel as (...args: number[]) => void;
+        func(...ptrs, 0, exe.source.size);
+      }
     }
 
     if (tracing) {
@@ -182,6 +250,9 @@ function codegenWasm(kernel: Kernel): Uint8Array<ArrayBuffer> {
 
   const cg = new CodeGenerator();
   cg.memory.import("env", "memory");
+  if (hasSharedArrayBuffer()) {
+    cg.memory.pages(0, 65536).shared(true);
+  }
 
   const distinctOps = mapSetUnion(
     tune.exp.distinctOps(),

--- a/src/backend/wasm/parallel.ts
+++ b/src/backend/wasm/parallel.ts
@@ -1,15 +1,177 @@
-/**
- * Check if SharedArrayBuffer is supported, and if so, use it for parallel
- * async execution in worker threads when available.
- *
- * This requires `window.crossOriginIsolated` to be true, which is only the case
- * if the page is served with headers:
- *
- * ```text
- * Cross-Origin-Opener-Policy: same-origin
- * Cross-Origin-Embedder-Policy: require-corp
- * ```
- */
+// Parallel execution support for the WASM backend using Web Workers.
+//
+// This requires `crossOriginIsolated` to be true, which is only the case if
+// the page is served with headers:
+//
+// ```text
+// Cross-Origin-Opener-Policy: same-origin
+// Cross-Origin-Embedder-Policy: require-corp
+// ```
+
+/** Check if SharedArrayBuffer is available. */
 export function hasSharedArrayBuffer(): boolean {
   return typeof SharedArrayBuffer !== "undefined";
+}
+
+const MIN_ELEMS_PER_THREAD = 256;
+
+const WORKER_SOURCE = `
+let memory = null;
+let cachedModule = null;
+let cachedFunc = null;
+
+self.onmessage = (e) => {
+  const msg = e.data;
+  if (msg.type === "init") {
+    memory = msg.memory;
+    postMessage({ type: "ready" });
+    return;
+  }
+  try {
+    const { module, ptrs, begin, end } = msg;
+    if (module !== cachedModule) {
+      cachedModule = module;
+      const instance = new WebAssembly.Instance(module, { env: { memory } });
+      cachedFunc = instance.exports.kernel;
+    }
+    cachedFunc(...ptrs, begin, end);
+    postMessage({ type: "done", ok: true });
+  } catch (err) {
+    postMessage({ type: "done", ok: false, error: String(err) });
+  }
+};
+`;
+
+/** Pool of Web Workers for parallel WASM kernel dispatch. */
+export class WasmWorkerPool {
+  #memory: WebAssembly.Memory;
+  #numWorkers: number;
+  #workers: Worker[] = [];
+  #ready: Promise<void> = Promise.resolve();
+  /** Serializes dispatches so concurrent read() calls don't clobber onmessage. */
+  #queue: Promise<void> = Promise.resolve();
+  #epoch: bigint = 0n;
+  #epochEnd: bigint = 0n;
+  #hooks: Map<bigint, (() => void)[]> = new Map();
+
+  constructor(memory: WebAssembly.Memory, numWorkers: number) {
+    if (numWorkers <= 0) {
+      throw new Error("numWorkers must be positive");
+    }
+    this.#memory = memory;
+    this.#numWorkers = numWorkers;
+  }
+
+  get epoch(): bigint {
+    return this.#epoch;
+  }
+
+  waitForEpoch(target: bigint): Promise<void> {
+    if (target <= this.#epoch) return Promise.resolve();
+    return new Promise((resolve) => {
+      if (target <= this.#epoch) return resolve();
+      const hooks = this.#hooks.get(target);
+      if (hooks) hooks.push(resolve);
+      else this.#hooks.set(target, [resolve]);
+    });
+  }
+
+  #ensureInit() {
+    if (this.#workers.length > 0) return;
+    // Called lazily to avoid creating workers if not used.
+    const blob = new Blob([WORKER_SOURCE], { type: "application/javascript" });
+    const url = URL.createObjectURL(blob);
+    this.#workers = [];
+    const readyPromises: Promise<void>[] = [];
+    for (let i = 0; i < this.#numWorkers; i++) {
+      const worker = new Worker(url);
+      this.#workers.push(worker);
+      readyPromises.push(
+        new Promise<void>((resolve, reject) => {
+          worker.onmessage = () => resolve();
+          worker.onerror = (e) =>
+            reject(new Error(e.message || "Worker failed to load"));
+        }),
+      );
+      worker.postMessage({ type: "init", memory: this.#memory });
+    }
+    this.#ready = Promise.all(readyPromises).then(() => {
+      URL.revokeObjectURL(url);
+    });
+    this.#queue = this.#ready;
+  }
+
+  /**
+   * Dispatch a kernel across multiple workers.
+   *
+   * Returns an epoch that can be used to wait for the ongoing work to complete,
+   * which is guaranteed to be monotonically increasing.
+   */
+  dispatch(module: WebAssembly.Module, ptrs: number[], size: number): bigint {
+    this.#ensureInit();
+    this.#epochEnd++;
+    const result = this.#queue.then(() =>
+      this.#dispatchNow(module, ptrs, size),
+    );
+    this.#queue = result
+      .then(
+        () => {},
+        () => {}, // Swallow errors to avoid blocking the queue.
+      )
+      .then(() => {
+        this.#epoch++;
+        const hooks = this.#hooks.get(this.#epoch);
+        if (hooks) {
+          for (const hook of hooks) hook();
+          this.#hooks.delete(this.#epoch);
+        }
+      });
+    return this.#epochEnd;
+  }
+
+  async #dispatchNow(
+    module: WebAssembly.Module,
+    ptrs: number[],
+    size: number,
+  ): Promise<void> {
+    if (size === 0) return;
+    const n = Math.min(
+      this.#workers.length,
+      Math.ceil(size / MIN_ELEMS_PER_THREAD),
+    );
+    const chunkSize = Math.ceil(size / n);
+    const promises: Promise<void>[] = [];
+    for (let i = 0; i < n; i++) {
+      const begin = i * chunkSize;
+      const end = Math.min(begin + chunkSize, size);
+      if (begin >= size) break;
+      const worker = this.#workers[i];
+      promises.push(
+        new Promise<void>((resolve, reject) => {
+          worker.onmessage = (e) => {
+            if (e.data.ok) resolve();
+            else reject(new Error(`Worker error: ${e.data.error}`));
+          };
+          worker.postMessage({ module, ptrs, begin, end });
+        }),
+      );
+    }
+    await Promise.all(promises);
+  }
+}
+
+/** Try to create a worker pool. Returns null if workers are unavailable. */
+export function createWorkerPool(
+  memory: WebAssembly.Memory,
+): WasmWorkerPool | null {
+  if (!hasSharedArrayBuffer()) return null;
+  try {
+    const numWorkers = Math.max(
+      1,
+      (typeof navigator !== "undefined" && navigator.hardwareConcurrency) || 4,
+    );
+    return new WasmWorkerPool(memory, numWorkers);
+  } catch {
+    return null;
+  }
 }

--- a/src/backend/wasm/parallel.ts
+++ b/src/backend/wasm/parallel.ts
@@ -1,0 +1,15 @@
+/**
+ * Check if SharedArrayBuffer is supported, and if so, use it for parallel
+ * async execution in worker threads when available.
+ *
+ * This requires `window.crossOriginIsolated` to be true, which is only the case
+ * if the page is served with headers:
+ *
+ * ```text
+ * Cross-Origin-Opener-Policy: same-origin
+ * Cross-Origin-Embedder-Policy: require-corp
+ * ```
+ */
+export function hasSharedArrayBuffer(): boolean {
+  return typeof SharedArrayBuffer !== "undefined";
+}

--- a/src/backend/wasm/parallel.ts
+++ b/src/backend/wasm/parallel.ts
@@ -10,7 +10,10 @@
 
 /** Check if SharedArrayBuffer is available. */
 export function hasSharedArrayBuffer(): boolean {
-  return typeof SharedArrayBuffer !== "undefined";
+  // Node.js has SharedArrayBuffer but not Worker, so check both.
+  return (
+    typeof SharedArrayBuffer !== "undefined" && typeof Worker !== "undefined"
+  );
 }
 
 const MIN_ELEMS_PER_THREAD = 256;
@@ -84,7 +87,7 @@ export class WasmWorkerPool {
     this.#workers = [];
     const readyPromises: Promise<void>[] = [];
     for (let i = 0; i < this.#numWorkers; i++) {
-      const worker = new Worker(url);
+      const worker = new Worker(url, { type: "module" });
       this.#workers.push(worker);
       readyPromises.push(
         new Promise<void>((resolve, reject) => {

--- a/src/backend/wasm/wasmblr.ts
+++ b/src/backend/wasm/wasmblr.ts
@@ -410,7 +410,7 @@ export class CodeGenerator {
         concat(importSectionBytes, encodeString(this.memory.aString));
         concat(importSectionBytes, encodeString(this.memory.bString));
         importSectionBytes.push(0x02); // memory flag
-        if (this.memory.min && this.memory.max) {
+        if (this.memory.max) {
           if (this.memory.isShared) {
             importSectionBytes.push(0x03);
           } else {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -438,3 +438,19 @@ export function runWithCache<V>(
     return value;
   }
 }
+
+/** Async version of `runWithCache`. */
+export async function runWithCacheAsync<V>(
+  cache: Map<string, V>,
+  key: unknown,
+  thunk: () => Promise<V>,
+): Promise<V> {
+  const keyStr = JSON.stringify(key);
+  if (cache.has(keyStr)) {
+    return cache.get(keyStr)!;
+  } else {
+    const value = await thunk();
+    cache.set(keyStr, value);
+    return value;
+  }
+}

--- a/test/platform-test/deno.test.ts
+++ b/test/platform-test/deno.test.ts
@@ -12,6 +12,12 @@ import { beforeEach, expect, suite, test } from "vitest";
 const denoDevices: Device[] = ["cpu", "wasm", "webgpu"];
 const devicesAvailable = await init(...denoDevices);
 
+test("SharedArrayBuffer is available", () => {
+  expect(typeof SharedArrayBuffer).toBe("function");
+  const mem = new WebAssembly.Memory({ initial: 1, maximum: 1, shared: true });
+  expect(mem.buffer instanceof SharedArrayBuffer).toBe(true);
+});
+
 suite.each(denoDevices)("device:%s", (device) => {
   const skipped = !devicesAvailable.includes(device);
   beforeEach(({ skip }) => {

--- a/test/platform-test/node.test.ts
+++ b/test/platform-test/node.test.ts
@@ -6,6 +6,12 @@ import { beforeEach, expect, suite, test } from "vitest";
 const nodeDevices: Device[] = ["cpu", "wasm"];
 const devicesAvailable = await init(...nodeDevices);
 
+test("SharedArrayBuffer is available", () => {
+  expect(typeof SharedArrayBuffer).toBe("function");
+  const mem = new WebAssembly.Memory({ initial: 1, maximum: 1, shared: true });
+  expect(mem.buffer instanceof SharedArrayBuffer).toBe(true);
+});
+
 suite.each(nodeDevices)("device:%s", (device) => {
   const skipped = !devicesAvailable.includes(device);
   beforeEach(({ skip }) => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,12 @@ export default defineConfig({
       using: false, // Needed to lower 'using' statements in tests.
     },
   },
+  server: {
+    headers: {
+      "Cross-Origin-Opener-Policy": "same-origin",
+      "Cross-Origin-Embedder-Policy": "require-corp",
+    },
+  },
   test: {
     browser: {
       enabled: true,

--- a/website/src/lib/homepage/MatmulPerfDemo.svelte
+++ b/website/src/lib/homepage/MatmulPerfDemo.svelte
@@ -13,7 +13,7 @@
     live: boolean;
   }
 
-  // Fall back to these if
+  // Fall back to these if demo can't run.
   const ericLaptopResults: PerfResults = {
     flops: {
       Wasm: 8.85,

--- a/website/src/lib/homepage/MatmulPerfDemo.svelte
+++ b/website/src/lib/homepage/MatmulPerfDemo.svelte
@@ -16,7 +16,7 @@
   // Fall back to these if
   const ericLaptopResults: PerfResults = {
     flops: {
-      Wasm: 2.72,
+      Wasm: 8.85,
       WebGPU: 2071,
       "WebGPU-fp16": 3343,
     },
@@ -117,7 +117,7 @@
 
     return {
       flops: {
-        Wasm: await benchFlops(128, "wasm", "float32"),
+        Wasm: await benchFlops(256, "wasm", "float32"),
         WebGPU: await benchFlops(gpuDim, "webgpu", "float32"),
         "WebGPU-fp16": hasF16
           ? await benchFlops(gpuDim, "webgpu", "float16")


### PR DESCRIPTION
First step toward getting the WebAssembly backend to be fast & performant. After this, need to implement SIMD and also improve codegen + m/n unrolling (see https://jott.live/markdown/mm_wasm).

This is already something like 6x faster than before