### PR TITLE
Add Flash atention routine

### DIFF
--- a/bench/attention.bench.ts
+++ b/bench/attention.bench.ts
@@ -1,0 +1,137 @@
+import {
+  blockUntilReady,
+  defaultDevice,
+  init,
+  jit,
+  nn,
+  numpy as np,
+  random,
+} from "@jax-js/jax";
+import { afterAll, bench, suite } from "vitest";
+
+const devices = await init("webgpu");
+
+type AttentionOpts = { isCausal?: boolean };
+
+function attentionForwardNaive(
+  q: np.Array,
+  k: np.Array,
+  v: np.Array,
+  opts: AttentionOpts = {},
+): np.Array {
+  return nn.dotProductAttention(q, k, v, {
+    implementation: "naive",
+    isCausal: opts.isCausal,
+  });
+}
+
+function attentionForwardFlash(
+  q: np.Array,
+  k: np.Array,
+  v: np.Array,
+  opts: AttentionOpts = {},
+): np.Array {
+  return nn.dotProductAttention(q, k, v, {
+    implementation: "flash",
+    isCausal: opts.isCausal,
+  });
+}
+
+const attentionForwardNaiveJit = jit(function attentionForwardNaiveJit(
+  q: np.Array,
+  k: np.Array,
+  v: np.Array,
+): np.Array {
+  return attentionForwardNaive(q, k, v);
+});
+
+const attentionForwardNaiveCausalJit = jit(
+  function attentionForwardNaiveCausalJit(
+    q: np.Array,
+    k: np.Array,
+    v: np.Array,
+  ): np.Array {
+    return attentionForwardNaive(q, k, v, { isCausal: true });
+  },
+);
+
+afterAll(() => {
+  attentionForwardNaiveJit.dispose();
+  attentionForwardNaiveCausalJit.dispose();
+});
+
+const cases = [
+  { name: "B1 H16 S512 D64", batch: 1, heads: 16, seq: 512, dim: 64 },
+  { name: "B8 H16 S512 D64", batch: 8, heads: 16, seq: 512, dim: 64 },
+  { name: "B1 H16 S1024 D64", batch: 1, heads: 16, seq: 1024, dim: 64 },
+];
+const dtypes = [
+  { name: "fp32", dtype: np.float32 },
+  { name: "fp16", dtype: np.float16 },
+];
+const modes = [
+  { name: "dense", isCausal: false },
+  { name: "causal", isCausal: true },
+];
+
+for (const { name, batch, heads, seq, dim } of cases) {
+  for (const { name: dtypeName, dtype } of dtypes) {
+    for (const { name: modeName, isCausal } of modes) {
+      suite.skipIf(!devices.includes("webgpu"))(
+        `gpu attention forward ${name} ${dtypeName} ${modeName}`,
+        async () => {
+          defaultDevice("webgpu");
+
+          // jax.nn.dotProductAttention uses [B, sequence, heads, head_dim].
+          const shape = [batch, seq, heads, dim];
+          const q = random.uniform(random.key(3), shape).astype(dtype);
+          const k = random.uniform(random.key(4), shape).astype(dtype);
+          const v = random.uniform(random.key(5), shape).astype(dtype);
+          await blockUntilReady([q, k, v]);
+
+          const opts = { isCausal };
+          const jitFn = isCausal
+            ? attentionForwardNaiveCausalJit
+            : attentionForwardNaiveJit;
+
+          // Warm up kernels / JIT cache outside measured iterations.
+          let out = attentionForwardNaive(q.ref, k.ref, v.ref, opts);
+          await out.blockUntilReady();
+          out.dispose();
+
+          out = jitFn(q.ref, k.ref, v.ref);
+          await out.blockUntilReady();
+          out.dispose();
+
+          out = attentionForwardFlash(q.ref, k.ref, v.ref, opts);
+          await out.blockUntilReady();
+          out.dispose();
+
+          afterAll(() => {
+            q.dispose();
+            k.dispose();
+            v.dispose();
+          });
+
+          bench("naive eager", async () => {
+            const out = attentionForwardNaive(q.ref, k.ref, v.ref, opts);
+            await out.blockUntilReady();
+            out.dispose();
+          });
+
+          bench("naive jit", async () => {
+            const out = jitFn(q.ref, k.ref, v.ref);
+            await out.blockUntilReady();
+            out.dispose();
+          });
+
+          bench("flash", async () => {
+            const out = attentionForwardFlash(q.ref, k.ref, v.ref, opts);
+            await out.blockUntilReady();
+            out.dispose();
+          });
+        },
+      );
+    }
+  }
+}

--- a/src/backend/webgpu/routines.ts
+++ b/src/backend/webgpu/routines.ts
@@ -8,9 +8,14 @@ import {
   maxValueWgsl,
   ShaderInfo,
 } from "./codegen";
-import { DType, isFloatDtype } from "../../alu";
+import { byteWidth, DType, isFloatDtype } from "../../alu";
 import { UnsupportedRoutineError } from "../../backend";
-import { Routine, Routines, RoutineType } from "../../routine";
+import {
+  type FlashAttentionParams,
+  Routine,
+  Routines,
+  RoutineType,
+} from "../../routine";
 import { findPow2, prod } from "../../utils";
 
 type BitonicSortPass = {
@@ -588,6 +593,341 @@ fn main(
   ];
 }
 
+function flashAttentionUniform(
+  B: number,
+  L: number,
+  N: number,
+  S: number,
+  numSeqTiles: number,
+  scale: number,
+): Uint8Array<ArrayBuffer> {
+  const buf = new ArrayBuffer(24);
+  const view = new DataView(buf);
+  view.setUint32(0, B, true);
+  view.setUint32(4, L, true);
+  view.setUint32(8, N, true);
+  view.setUint32(12, S, true);
+  view.setUint32(16, numSeqTiles, true);
+  view.setFloat32(20, scale, true);
+  return new Uint8Array(buf);
+}
+
+function broadcastIndexWgsl(
+  shape: number[],
+  targetShape: number[],
+  targetNames: string[],
+): string {
+  if (shape.length > targetShape.length) {
+    throw new Error(
+      `Cannot broadcast shape ${shape} to ${targetShape}: too many dimensions`,
+    );
+  }
+  const offset = targetShape.length - shape.length;
+  const terms: string[] = [];
+  for (let i = 0; i < shape.length; i++) {
+    const dim = shape[i];
+    const targetDim = targetShape[offset + i];
+    if (dim === 1) continue;
+    if (dim !== targetDim) {
+      throw new Error(`Cannot broadcast shape ${shape} to ${targetShape}`);
+    }
+    const stride = prod(shape.slice(i + 1));
+    const name = targetNames[offset + i];
+    terms.push(stride === 1 ? name : `${name} * ${stride}u`);
+  }
+  return terms.length === 0 ? "0u" : terms.join(" + ");
+}
+
+function createFlashAttention(
+  device: GPUDevice,
+  type: RoutineType,
+  { scale, isCausal, localWindowSize, hasMask }: FlashAttentionParams,
+): ShaderInfo[] {
+  const dtype = type.inputDtypes[0];
+  const ty = dtypeToWgsl(dtype, true);
+  const biasTy = dtypeToWgsl(type.inputDtypes[3], true);
+  const maskTy = dtypeToWgsl(type.inputDtypes[4], true);
+  const [B, L, N, H] = type.inputShapes[0];
+  const S = type.inputShapes[1][1];
+  const K = type.inputShapes[1][2];
+  const G = N / K;
+  if (H % 4 !== 0) {
+    throw new Error(
+      `flash_attention: head dimension ${H} must be divisible by 4`,
+    );
+  }
+
+  const vecFactor = 4;
+  const headVec = H / vecFactor;
+  const workgroupSize = findPow2(128, device.limits.maxComputeWorkgroupSizeX);
+  const numSeqTiles = Math.ceil(L / workgroupSize);
+  const maxKStep = 32;
+  const biasIndex = broadcastIndexWgsl(
+    type.inputShapes[3],
+    [B, N, L, S],
+    ["batch_idx", "head_idx", "q_idx_global", "k_idx_global"],
+  );
+  const maskIndex = broadcastIndexWgsl(
+    type.inputShapes[4],
+    [B, N, L, S],
+    ["batch_idx", "head_idx", "q_idx_global", "k_idx_global"],
+  );
+  const validKConditions = ["k_idx_global < uniforms.S"];
+  if (isCausal) validKConditions.push("k_idx_global <= q_idx_global");
+  if (localWindowSize !== null) {
+    const [before, after] = localWindowSize;
+    if (
+      before < 0 ||
+      after < 0 ||
+      !Number.isInteger(before) ||
+      !Number.isInteger(after)
+    ) {
+      throw new Error(
+        `flash_attention: localWindowSize values must be non-negative integers, got ${localWindowSize}`,
+      );
+    }
+    if (before < L) {
+      validKConditions.push(`k_idx_global + ${before}u >= q_idx_global`);
+    }
+    if (after < S) {
+      validKConditions.push(`k_idx_global <= q_idx_global + ${after}u`);
+    }
+  }
+  const validK = validKConditions.join(" && ");
+  const loadMask = hasMask ? `return mask[${maskIndex}] != 0;` : "return true;";
+  const applyMask = hasMask
+    ? "if (valid_score) {\n        valid_score = load_mask(batch_idx, head_idx, q_idx_global, k_idx_global);\n      }"
+    : "";
+  const kRangeInit: string[] = [];
+  if (localWindowSize !== null) {
+    const [before, after] = localWindowSize;
+    if (before < L) {
+      kRangeInit.push(
+        `k_start_first = max(q_tile_start, ${before}u) - ${before}u;`,
+      );
+    }
+    if (after < S) {
+      kRangeInit.push(`k_end = min(k_end, q_tile_end + ${after}u);`);
+    }
+  }
+  if (isCausal) {
+    kRangeInit.push("k_end = min(k_end, q_tile_end);");
+  }
+
+  const storageBytes = 2 * maxKStep * headVec * vecFactor * byteWidth(dtype);
+  if (storageBytes > device.limits.maxComputeWorkgroupStorageSize) {
+    throw new Error(
+      `flash_attention: head dimension ${H} exceeds WebGPU workgroup storage limit`,
+    );
+  }
+
+  const needsF16 =
+    dtype === DType.Float16 || type.inputDtypes[3] === DType.Float16;
+  const code = `
+${needsF16 ? "enable f16;" : ""}
+${headerWgsl}
+
+const min_value = -3.4028234663852886e+38f;
+
+struct Uniforms {
+  B: u32,
+  L: u32,
+  N: u32,
+  S: u32,
+  num_seq_tiles: u32,
+  scale: f32,
+}
+
+@group(0) @binding(0) var<storage, read> query: array<${ty}>;
+@group(0) @binding(1) var<storage, read> key: array<${ty}>;
+@group(0) @binding(2) var<storage, read> value: array<${ty}>;
+@group(0) @binding(3) var<storage, read> bias: array<${biasTy}>;
+@group(0) @binding(4) var<storage, read> mask: array<${maskTy}>;
+@group(0) @binding(5) var<storage, read_write> output: array<${ty}>;
+
+@group(1) @binding(0) var<uniform> uniforms: Uniforms;
+
+var<workgroup> k_tile: array<vec4<${ty}>, ${maxKStep * headVec}>;
+var<workgroup> v_tile: array<vec4<${ty}>, ${maxKStep * headVec}>;
+
+fn load_bias(
+  batch_idx: u32,
+  head_idx: u32,
+  q_idx_global: u32,
+  k_idx_global: u32,
+) -> f32 {
+  return f32(bias[${biasIndex}]);
+}
+
+fn load_mask(
+  batch_idx: u32,
+  head_idx: u32,
+  q_idx_global: u32,
+  k_idx_global: u32,
+) -> bool {
+  ${loadMask}
+}
+
+@compute @workgroup_size(${workgroupSize})
+fn main(
+  @builtin(workgroup_id) wg_id: vec3<u32>,
+  @builtin(local_invocation_id) local_id: vec3<u32>,
+) {
+  let workgroup_idx = wg_id.x + wg_id.y * ${gridOffsetY}u;
+  let batch_head_idx = workgroup_idx / uniforms.num_seq_tiles;
+  let head_idx = batch_head_idx % uniforms.N;
+  let kv_head_idx = head_idx / ${G}u;
+  let batch_idx = batch_head_idx / uniforms.N;
+  if (batch_idx >= uniforms.B) {
+    return;
+  }
+
+  let local_idx = local_id.x;
+  let q_tile_start = (workgroup_idx % uniforms.num_seq_tiles) * ${workgroupSize}u;
+  let q_tile_end = min(q_tile_start + ${workgroupSize}u, uniforms.L);
+  let q_idx_global = q_tile_start + local_idx;
+  let valid_q = q_idx_global < uniforms.L;
+
+  var k_start_first = 0u;
+  var k_end = uniforms.S;
+  ${kRangeInit.join("\n  ")}
+
+  var q_tile: array<vec4<f32>, ${headVec}>;
+  var o_tile: array<vec4<f32>, ${headVec}>;
+  var qk_scores: array<f32, ${maxKStep}>;
+  var qk_valid: array<bool, ${maxKStep}>;
+  for (var i = 0u; i < ${headVec}u; i++) {
+    q_tile[i] = vec4<f32>(0.0);
+    o_tile[i] = vec4<f32>(0.0);
+  }
+
+  if (valid_q) {
+    let q_offset = ((batch_idx * uniforms.L + q_idx_global) * uniforms.N + head_idx) * ${H}u;
+    for (var i = 0u; i < ${headVec}u; i++) {
+      let offset = q_offset + i * 4u;
+      q_tile[i] = vec4<f32>(
+        f32(query[offset]),
+        f32(query[offset + 1u]),
+        f32(query[offset + 2u]),
+        f32(query[offset + 3u])
+      ) * uniforms.scale;
+    }
+  }
+
+  var previous_max = min_value;
+  var previous_denom = 0.0;
+
+  for (var k_start = k_start_first; k_start < k_end; k_start += ${maxKStep}u) {
+    workgroupBarrier();
+    for (var idx = local_idx; idx < ${maxKStep * headVec}u; idx += ${workgroupSize}u) {
+      let k_slot = idx / ${headVec}u;
+      let vec_idx = idx % ${headVec}u;
+      let k_idx_global = k_start + k_slot;
+      var k_val = vec4<${ty}>(${ty}(0));
+      var v_val = vec4<${ty}>(${ty}(0));
+      if (k_idx_global < k_end) {
+        let offset = ((batch_idx * uniforms.S + k_idx_global) * ${K}u + kv_head_idx) * ${H}u + vec_idx * 4u;
+        k_val = vec4<${ty}>(
+          key[offset],
+          key[offset + 1u],
+          key[offset + 2u],
+          key[offset + 3u]
+        );
+        v_val = vec4<${ty}>(
+          value[offset],
+          value[offset + 1u],
+          value[offset + 2u],
+          value[offset + 3u]
+        );
+      }
+      k_tile[idx] = k_val;
+      v_tile[idx] = v_val;
+    }
+    workgroupBarrier();
+
+    for (var k = 0u; k < ${maxKStep}u; k++) {
+      let k_idx_global = k_start + k;
+      var score = min_value;
+      var valid_score = valid_q && ${validK};
+      ${applyMask}
+      if (valid_score) {
+        var dot_val = 0.0;
+        for (var i = 0u; i < ${headVec}u; i++) {
+          dot_val += dot(q_tile[i], vec4<f32>(k_tile[k * ${headVec}u + i]));
+        }
+        score = dot_val + load_bias(batch_idx, head_idx, q_idx_global, k_idx_global);
+      }
+      qk_scores[k] = score;
+      qk_valid[k] = valid_score;
+    }
+
+    var local_max = min_value;
+    for (var k = 0u; k < ${maxKStep}u; k++) {
+      if (qk_valid[k]) {
+        local_max = max(local_max, qk_scores[k]);
+      }
+    }
+    let new_max = max(previous_max, local_max);
+
+    var sum = 0.0;
+    for (var k = 0u; k < ${maxKStep}u; k++) {
+      var exp_val = 0.0;
+      if (qk_valid[k]) {
+        exp_val = exp(qk_scores[k] - new_max);
+      }
+      qk_scores[k] = exp_val;
+      sum += exp_val;
+    }
+
+    let dleft = previous_denom * exp(previous_max - new_max);
+    var denom = dleft + sum;
+    denom = select(denom, 0.0000001, denom == 0.0);
+    let o_ratio = dleft / denom;
+    for (var k = 0u; k < ${maxKStep}u; k++) {
+      qk_scores[k] = qk_scores[k] / denom;
+    }
+    previous_max = new_max;
+    previous_denom = denom;
+
+    for (var i = 0u; i < ${headVec}u; i++) {
+      var acc = vec4<f32>(0.0);
+      for (var k = 0u; k < ${maxKStep}u; k++) {
+        acc += vec4<f32>(v_tile[k * ${headVec}u + i]) * qk_scores[k];
+      }
+      o_tile[i] = o_tile[i] * o_ratio + acc;
+    }
+  }
+
+  if (valid_q) {
+    let out_offset = ((batch_idx * uniforms.L + q_idx_global) * uniforms.N + head_idx) * ${H}u;
+    for (var i = 0u; i < ${headVec}u; i++) {
+      let offset = out_offset + i * 4u;
+      output[offset] = ${ty}(o_tile[i].x);
+      output[offset + 1u] = ${ty}(o_tile[i].y);
+      output[offset + 2u] = ${ty}(o_tile[i].z);
+      output[offset + 3u] = ${ty}(o_tile[i].w);
+    }
+  }
+}
+`.trim();
+
+  const grid = calculateGrid(B * N * numSeqTiles);
+  return [
+    {
+      code,
+      numInputs: 5,
+      numOutputs: 1,
+      hasUniform: true,
+      passes: [
+        {
+          grid,
+          uniform: flashAttentionUniform(B, L, N, S, numSeqTiles, scale),
+        },
+      ],
+    },
+  ];
+}
+
 export function createRoutineShader(
   device: GPUDevice,
   routine: Routine,
@@ -603,6 +943,8 @@ export function createRoutineShader(
       return createCholesky(device, routine.type);
     case Routines.LU:
       return createLU(device, routine.type);
+    case Routines.FlashAttention:
+      return createFlashAttention(device, routine.type, routine.params);
     default:
       throw new UnsupportedRoutineError(routine.name, "webgpu");
   }

--- a/src/frontend/array.ts
+++ b/src/frontend/array.ts
@@ -1141,6 +1141,7 @@ export class Array extends Tracer {
       [Primitive.TriangularSolve]: Array.#routine(Primitive.TriangularSolve),
       [Primitive.Cholesky]: Array.#routine(Primitive.Cholesky),
       [Primitive.LU]: Array.#routine(Primitive.LU),
+      [Primitive.FlashAttention]: Array.#routine(Primitive.FlashAttention),
       [Primitive.Jit](args, { jaxpr }) {
         if (jaxpr.inBinders.length !== args.length) {
           throw new Error(

--- a/src/frontend/core.ts
+++ b/src/frontend/core.ts
@@ -1,7 +1,7 @@
 /** @file Core library internals and interpreter stack, based on Autodidax. */
 
 import { AluGroup, AluOp, DType, isFloatDtype, promoteTypes } from "../alu";
-import { Routines } from "../routine";
+import { type FlashAttentionParams, Routines } from "../routine";
 import { type Pair } from "../shape";
 import {
   JsTreeDef,
@@ -93,6 +93,7 @@ export enum Primitive {
   TriangularSolve = "triangular_solve", // A is upper triangular, A @ X.T = B.T
   Cholesky = "cholesky", // A is positive-definite, A = L @ L^T
   LU = "lu", // LU decomposition with partial pivoting
+  FlashAttention = "flash_attention", // forward scaled dot-product attention
 
   // JIT compilation
   Jit = "jit",
@@ -123,6 +124,7 @@ interface PrimitiveParamsImpl extends Record<Primitive, Record<string, any>> {
   [Primitive.Shrink]: { slice: Pair[] };
   [Primitive.Pad]: { width: Pair[] };
   [Primitive.TriangularSolve]: { unitDiagonal: boolean };
+  [Primitive.FlashAttention]: FlashAttentionParams;
   [Primitive.Jit]: { name: string; jaxpr: Jaxpr; numConsts: number };
 }
 
@@ -147,6 +149,7 @@ export const routinePrimitives = new Map([
   [Primitive.TriangularSolve, Routines.TriangularSolve],
   [Primitive.Cholesky, Routines.Cholesky],
   [Primitive.LU, Routines.LU],
+  [Primitive.FlashAttention, Routines.FlashAttention],
 ]);
 
 export function add(x: TracerValue, y: TracerValue) {
@@ -540,6 +543,21 @@ export function sort(x: TracerValue) {
   const nd = ndim(x);
   if (nd === 0) throw new Error("sort: requires at least 1D input");
   return bind1(Primitive.Sort, [x]);
+}
+
+export function flashAttention(
+  query: TracerValue,
+  key: TracerValue,
+  value: TracerValue,
+  bias: TracerValue,
+  mask: TracerValue,
+  params: FlashAttentionParams,
+) {
+  return bind1(
+    Primitive.FlashAttention,
+    [query, key, value, bias, mask],
+    params,
+  );
 }
 
 export function argsort(x: TracerValue) {

--- a/src/frontend/jaxpr.ts
+++ b/src/frontend/jaxpr.ts
@@ -1012,6 +1012,60 @@ export const abstractEvalRules: { [P in Primitive]: AbstractEvalRule<P> } = {
       new ShapedArray([...batch, m], DType.Int32, false),
     ];
   },
+  [Primitive.FlashAttention]([query, key, value, bias, mask]) {
+    if (query.ndim !== 4 || key.ndim !== 4 || value.ndim !== 4) {
+      throw new TypeError(
+        `flash_attention: expected rank-4 Q/K/V inputs, got ${query}, ${key}, ${value}`,
+      );
+    }
+    if (!isFloatDtype(query.dtype) || query.dtype !== key.dtype) {
+      throw new TypeError(
+        `flash_attention: query/key must have matching floating dtype, got ${query.dtype} and ${key.dtype}`,
+      );
+    }
+    if (value.dtype !== query.dtype) {
+      throw new TypeError(
+        `flash_attention: value dtype must match query dtype, got ${value.dtype} and ${query.dtype}`,
+      );
+    }
+    if (!isFloatDtype(bias.dtype)) {
+      throw new TypeError(
+        `flash_attention: bias must have floating dtype, got ${bias.dtype}`,
+      );
+    }
+    if (mask.dtype !== DType.Bool) {
+      throw new TypeError(
+        `flash_attention: mask must have boolean dtype, got ${mask.dtype}`,
+      );
+    }
+    const [B, L, N, H] = query.shape;
+    const [Bk, S, K, Hk] = key.shape;
+    if (
+      !deepEqual(value.shape, key.shape) ||
+      B !== Bk ||
+      H !== Hk ||
+      N < K ||
+      N % K !== 0
+    ) {
+      throw new TypeError(
+        `flash_attention: shape mismatch Q=${query}, K=${key}, V=${value}`,
+      );
+    }
+    const targetShape = [B, N, L, S];
+    const biasShape = generalBroadcast(bias.shape, targetShape);
+    if (!deepEqual(biasShape, targetShape)) {
+      throw new TypeError(
+        `flash_attention: bias shape ${bias.shape} is not broadcastable to [${B}, ${N}, ${L}, ${S}]`,
+      );
+    }
+    const maskShape = generalBroadcast(mask.shape, targetShape);
+    if (!deepEqual(maskShape, targetShape)) {
+      throw new TypeError(
+        `flash_attention: mask shape ${mask.shape} is not broadcastable to [${B}, ${N}, ${L}, ${S}]`,
+      );
+    }
+    return [new ShapedArray([B, L, N, H], query.dtype, false)];
+  },
   [Primitive.Jit](args, { jaxpr }) {
     const { inTypes, outTypes } = typecheckJaxpr(jaxpr);
     if (args.length !== inTypes.length) {

--- a/src/frontend/jit.ts
+++ b/src/frontend/jit.ts
@@ -778,6 +778,7 @@ const jitRules: { [P in Primitive]: JitRule<P> } = {
   [Primitive.TriangularSolve]: routineNoJit(),
   [Primitive.Cholesky]: routineNoJit(),
   [Primitive.LU]: routineNoJit(),
+  [Primitive.FlashAttention]: routineNoJit(),
   [Primitive.Jit]() {
     throw new Error(
       "internal: Jit should have been flattened before JIT compilation",

--- a/src/frontend/jvp.ts
+++ b/src/frontend/jvp.ts
@@ -157,6 +157,68 @@ function batchMatmulT(a: Tracer, b: Tracer): Tracer {
 function mT(a: Tracer): Tracer {
   return moveaxis(a, -2, -1);
 }
+
+function repeatAttentionHeads(x: Tracer, nHeads: number): Tracer {
+  const [B, S, K, H] = x.shape;
+  if (K === nHeads) return x;
+  const groups = nHeads / K;
+  return broadcast(x, [B, S, K, groups, H], [3]).reshape([B, S, nHeads, H]);
+}
+
+/** Compute attention logits: query/key [B, L/S, N/K, H] -> [B, N, L, S]. */
+function attentionScores(query: Tracer, key: Tracer, scale: number): Tracer {
+  const [B, L, N, H] = query.shape;
+  const S = key.shape[1];
+  const q = moveaxis(query, 1, 2).reshape([B, N, L, 1, H]);
+  const k = moveaxis(repeatAttentionHeads(key, N), 1, 2).reshape([
+    B,
+    N,
+    1,
+    S,
+    H,
+  ]);
+  return dot(q, k).mul(scale);
+}
+
+/** Apply attention probabilities [B, N, L, S] to values [B, S, K, H]. */
+function attentionApply(probs: Tracer, value: Tracer): Tracer {
+  const [B, N, L, S] = probs.shape;
+  const H = value.shape[3];
+  const v = moveaxis(repeatAttentionHeads(value, N), 1, 2).reshape([
+    B,
+    N,
+    1,
+    S,
+    H,
+  ]);
+  const out = probs.reshape([B, N, L, S, 1]).mul(v).sum(3);
+  return moveaxis(out, 1, 2);
+}
+
+function attentionCausalMask(L: number, S: number): Tracer {
+  const q = arange(L).reshape([1, 1, L, 1]);
+  const k = arange(S).reshape([1, 1, 1, S]);
+  return less(k, q.add(1));
+}
+
+function attentionLocalMask(
+  L: number,
+  S: number,
+  [before, after]: Pair,
+): Tracer {
+  const q = arange(L).reshape([1, 1, L, 1]);
+  const k = arange(S).reshape([1, 1, 1, S]);
+  return less(k, q.add(after + 1)).mul(less(q, k.add(before + 1)));
+}
+
+function softmaxLast(x: Tracer): Tracer {
+  const xMax = reduce(x.ref, AluOp.Max, -1, { keepdims: true });
+  const unnormalized = exp(x.sub(xMax));
+  return unnormalized.ref.div(
+    reduce(unnormalized, AluOp.Add, -1, { keepdims: true }),
+  );
+}
+
 function sliceAxis(a: Tracer, axis: number, p: Pair): Tracer {
   const slices = Array(a.shape.length).fill([]);
   slices[checkAxis(axis, a.ndim)] = p;
@@ -393,6 +455,44 @@ const jvpRules: { [P in Primitive]: JvpRule<P> } = {
       [luMatrix, pivots, permutation],
       [lDot.add(uDot), zerosLike(pivots.ref), zerosLike(permutation.ref)],
     ];
+  },
+  [Primitive.FlashAttention](
+    [q, k, v, bias, mask],
+    [dq, dk, dv, db, dmask],
+    { scale, isCausal, localWindowSize, hasMask },
+  ) {
+    dmask.dispose();
+    const primal = bind1(
+      Primitive.FlashAttention,
+      [q.ref, k.ref, v.ref, bias.ref, mask.ref],
+      { scale, isCausal, localWindowSize, hasMask },
+    );
+    let scores = attentionScores(q.ref, k.ref, scale).add(bias);
+    let ds = attentionScores(dq, k, scale)
+      .add(attentionScores(q, dk, scale))
+      .add(db);
+    if (hasMask) {
+      scores = where(mask.ref, scores, -Infinity);
+      ds = where(mask, ds, 0);
+    }
+    if (isCausal || localWindowSize !== null) {
+      let mask = isCausal
+        ? attentionCausalMask(q.shape[1], k.shape[1])
+        : attentionLocalMask(q.shape[1], k.shape[1], localWindowSize!);
+      if (isCausal && localWindowSize !== null) {
+        mask = mask.mul(
+          attentionLocalMask(q.shape[1], k.shape[1], localWindowSize),
+        );
+      }
+      scores = where(mask.ref, scores, -Infinity);
+      ds = where(mask, ds, 0);
+    }
+    const probs = softmaxLast(scores);
+    const dprobs = probs.ref.mul(
+      ds.ref.sub(probs.ref.mul(ds).sum(-1, { keepdims: true })),
+    );
+    const tangent = attentionApply(dprobs, v).add(attentionApply(probs, dv));
+    return [[primal], [tangent]];
   },
   [Primitive.Jit](primals, tangents, { name, jaxpr }) {
     const newJaxpr = jvpJaxpr(jaxpr);

--- a/src/library/nn.ts
+++ b/src/library/nn.ts
@@ -19,11 +19,11 @@ import {
   negative,
   onesLike,
   reciprocal,
+  repeat,
   sqrt,
   square,
   squeeze,
   tanh,
-  tile,
   where,
   zerosLike,
 } from "./numpy";
@@ -31,6 +31,7 @@ import { eye, fudgeArray, tri } from "../frontend/array";
 import {
   type Axis,
   erfc,
+  flashAttention,
   type ReduceOpts,
   shrink,
   stopGradient,
@@ -415,6 +416,28 @@ export function oneHot(x: Array, numClasses: number): Array {
   return eye(numClasses, undefined, { device: x.device }).slice(x);
 }
 
+function normalizeLocalWindowSize(
+  localWindowSize: number | [number, number] | undefined,
+): Pair | null {
+  if (localWindowSize === undefined) return null;
+  const [before, after] =
+    typeof localWindowSize === "number"
+      ? [localWindowSize, localWindowSize]
+      : localWindowSize;
+  if (
+    before < 0 ||
+    after < 0 ||
+    !Number.isInteger(before) ||
+    !Number.isInteger(after)
+  ) {
+    throw new Error(
+      `dotProductAttention: localWindowSize values must be non-negative, ` +
+        `got ${localWindowSize}`,
+    );
+  }
+  return [before, after];
+}
+
 /**
  * Scaled dot product attention (SDPA).
  *
@@ -452,6 +475,9 @@ export function oneHot(x: Array, numClasses: number): Array {
  *   values; shape `(B,)`. Taken from the beginning of the tensor.
  * @param opts.localWindowSize - If specified, applies a local attention window
  *   of the given size. Can be a single number or a tuple `[left, right]`.
+ * @param opts.implementation - Selects the implementation. Use `"naive"` for
+ *   the composable matmul/softmax path, or `"flash"` for the streaming
+ *   attention routine. If omitted, currently defaults to `"naive"`.
  *
  * @returns The result of the attention operation; shape is the same as query
  *   `[B, L, N, H]`, or `[L, N, H]` if `B` is omitted.
@@ -468,6 +494,7 @@ export function dotProductAttention(
     querySeqLengths?: ArrayLike;
     keyValueSeqLengths?: ArrayLike;
     localWindowSize?: number | [number, number];
+    implementation?: "flash" | "naive" | null;
   } = {},
 ): Array {
   query = fudgeArray(query);
@@ -512,10 +539,43 @@ export function dotProductAttention(
         `divisible by number of key/value heads K=${K} for GQA`,
     );
   const G = N / K; // number of query groups
-  key = tile(key, [1, 1, G, 1]);
-  value = tile(value, [1, 1, G, 1]);
 
   const scale = opts.scale ?? 1 / Math.sqrt(H);
+  const localWindowSize = normalizeLocalWindowSize(opts.localWindowSize);
+  const implementation = opts.implementation ?? "naive";
+  if (implementation === "flash") {
+    if (
+      opts.querySeqLengths !== undefined ||
+      opts.keyValueSeqLengths !== undefined
+    ) {
+      throw new Error(
+        `dotProductAttention: implementation="flash" does not yet support ` +
+          `sequence lengths`,
+      );
+    }
+    const out = flashAttention(
+      query,
+      key,
+      value,
+      opts.bias ?? 0,
+      opts.mask ?? true,
+      {
+        scale,
+        isCausal: opts.isCausal ?? false,
+        localWindowSize,
+        hasMask: opts.mask !== undefined,
+      },
+    ) as Array;
+    return isRank3 ? out.reshape([L, N, H]) : out;
+  } else if (implementation !== "naive") {
+    throw new Error(
+      `dotProductAttention: unknown implementation ${implementation}`,
+    );
+  }
+
+  key = repeat(key, G, 2);
+  value = repeat(value, G, 2);
+
   let scores = einsum("BLNH,BSNH->BNLS", query, key).mul(scale);
   if (opts.bias !== undefined) {
     scores = scores.add(opts.bias);
@@ -529,22 +589,8 @@ export function dotProductAttention(
     const causalMask = tri(L, S, 0, { dtype: DType.Bool });
     scores = where(causalMask, scores, -Infinity);
   }
-  if (opts.localWindowSize !== undefined) {
-    const [before, after] =
-      typeof opts.localWindowSize === "number"
-        ? [opts.localWindowSize, opts.localWindowSize]
-        : opts.localWindowSize;
-    if (
-      before < 0 ||
-      after < 0 ||
-      !Number.isInteger(before) ||
-      !Number.isInteger(after)
-    ) {
-      throw new Error(
-        `dotProductAttention: localWindowSize values must be non-negative, ` +
-          `got ${opts.localWindowSize}`,
-      );
-    }
+  if (localWindowSize !== null) {
+    const [before, after] = localWindowSize;
     const localMask = tri(L, S, after, { dtype: DType.Bool }).mul(
       tri(L, S, -before - 1, { dtype: DType.Bool }).notEqual(true),
     );

--- a/src/routine.ts
+++ b/src/routine.ts
@@ -1,6 +1,7 @@
 // Custom lowering for advanced operations that don't fit into AluExp.
 
 import { DataArray, DType, dtypedArray } from "./alu";
+import type { Pair } from "./shape";
 
 /**
  * Advanced operations that don't fit into the `AluExp` compiler representation.
@@ -74,6 +75,16 @@ export enum Routines {
    *   such that `P = eye(M).slice(Permutation)` -> `P @ A = L @ U`.
    */
   LU = "LU",
+
+  /**
+   * Forward scaled dot-product attention.
+   *
+   * Inputs are `query: [B, L, N, H]`, `key: [B, S, K, H]`,
+   * `value: [B, S, K, H]`, `bias` broadcastable to `[B, N, L, S]`,
+   * and boolean `mask` broadcastable to `[B, N, L, S]` where true means attend.
+   * Supports GQA/MQA when N is divisible by K. The output is `[B, L, N, H]`.
+   */
+  FlashAttention = "FlashAttention",
 }
 
 export interface RoutineType {
@@ -81,6 +92,18 @@ export interface RoutineType {
   inputDtypes: DType[];
   outputShapes: number[][];
   outputDtypes: DType[];
+}
+
+/** Parameters for the FlashAttention primitive/routine. */
+export interface FlashAttentionParams {
+  /** Scaling factor applied to QK logits, usually `1 / sqrt(headDim)`. */
+  scale: number;
+  /** If true, only attends to keys with index <= query index. */
+  isCausal: boolean;
+  /** Optional local attention window `[before, after]`, or null for dense attention. */
+  localWindowSize: Pair | null;
+  /** Whether to apply the mask input. If false, the mask input is ignored. */
+  hasMask: boolean;
 }
 
 // Reference implementation of each routine in CPU is below.
@@ -109,6 +132,8 @@ export function runCpuRoutine(
       return runCholesky(type, inputAr, outputAr);
     case Routines.LU:
       return runLU(type, inputAr, outputAr);
+    case Routines.FlashAttention:
+      throw new Error("flash_attention routine is only supported on WebGPU");
     default:
       name satisfies never; // Exhaustiveness check
   }

--- a/test/nn.test.ts
+++ b/test/nn.test.ts
@@ -397,6 +397,83 @@ suite.each(devices)("device:%s", (device) => {
       expect(out.shape).toEqual([1, 2, 2, 2]);
     });
 
+    if (device === "webgpu") {
+      test("flash attention matches naive attention with bias", () => {
+        const query = np.array([[[[1, 0, 0, 0]], [[0, 1, 0, 0]]]]);
+        const key = np.array([
+          [[[1, 0, 0, 0]], [[0, 1, 0, 0]], [[1, 1, 0, 0]]],
+        ]);
+        const value = np.array([
+          [[[1, 2, 3, 4]], [[5, 6, 7, 8]], [[9, 10, 11, 12]]],
+        ]);
+        const bias = np.array([
+          [
+            [
+              [0, -1, 0.5],
+              [0.25, 0, -0.5],
+            ],
+          ],
+        ]);
+
+        const naive = nn.dotProductAttention(query.ref, key.ref, value.ref, {
+          bias: bias.ref,
+          implementation: "naive",
+        });
+        const flash = nn.dotProductAttention(query, key, value, {
+          bias,
+          implementation: "flash",
+        });
+        expect(flash).toBeAllclose(naive, { atol: 1e-4 });
+      });
+
+      test("flash attention matches naive attention with mask", () => {
+        const query = np.array([
+          [[[1, 0, 0, 0]], [[0, 1, 0, 0]], [[1, 1, 0, 0]]],
+        ]);
+        const key = np.array([
+          [[[1, 0, 0, 0]], [[0, 1, 0, 0]], [[1, 1, 0, 0]]],
+        ]);
+        const value = np.array([
+          [[[1, 2, 3, 4]], [[5, 6, 7, 8]], [[9, 10, 11, 12]]],
+        ]);
+        const mask = np.array([
+          [true, false, true],
+          [false, true, false],
+          [true, true, false],
+        ]);
+
+        const naive = nn.dotProductAttention(query.ref, key.ref, value.ref, {
+          mask: mask.ref,
+          implementation: "naive",
+        });
+        const flash = nn.dotProductAttention(query, key, value, {
+          mask,
+          implementation: "flash",
+        });
+        expect(flash).toBeAllclose(naive, { atol: 1e-4 });
+      });
+
+      test("flash attention matches naive attention with local window", () => {
+        const query = np.arange(32).astype(np.float32).reshape([1, 4, 2, 4]);
+        const key = np.arange(16).astype(np.float32).reshape([1, 4, 1, 4]);
+        const value = np
+          .arange(16)
+          .astype(np.float32)
+          .reshape([1, 4, 1, 4])
+          .add(1);
+
+        const naive = nn.dotProductAttention(query.ref, key.ref, value.ref, {
+          localWindowSize: [1, 1],
+          implementation: "naive",
+        });
+        const flash = nn.dotProductAttention(query, key, value, {
+          localWindowSize: [1, 1],
+          implementation: "flash",
+        });
+        expect(flash).toBeAllclose(naive, { atol: 1e-4 });
+      });
+    }
+
     test("grouped-query attention (GQA)", () => {
       // Q: B=1, L=2, N=4 (query heads), H=2
       // K/V: B=1, S=2, K=2 (key/value heads), H=2
@@ -408,6 +485,75 @@ suite.each(devices)("device:%s", (device) => {
       const out = nn.dotProductAttention(query, key, value);
       expect(out.shape).toEqual([1, 2, 4, 2]);
     });
+
+    if (device === "webgpu") {
+      test("flash attention matches naive attention with GQA and causal mask", () => {
+        const query = np.array([
+          [
+            [
+              [1, 0, 0, 0],
+              [0, 1, 0, 0],
+              [1, 1, 0, 0],
+              [0.5, 0.5, 0, 0],
+            ],
+            [
+              [0, 1, 0, 0],
+              [1, 0, 0, 0],
+              [0.5, 0.25, 0, 0],
+              [0.25, 0.5, 0, 0],
+            ],
+            [
+              [1, 1, 0, 0],
+              [0.5, 0.5, 0, 0],
+              [1, 0.5, 0, 0],
+              [0.5, 1, 0, 0],
+            ],
+          ],
+        ]);
+        const key = np.array([
+          [
+            [
+              [1, 0, 0, 0],
+              [0, 1, 0, 0],
+            ],
+            [
+              [0, 1, 0, 0],
+              [1, 0, 0, 0],
+            ],
+            [
+              [1, 1, 0, 0],
+              [0.5, 0.5, 0, 0],
+            ],
+          ],
+        ]);
+        const value = np.array([
+          [
+            [
+              [1, 2, 3, 4],
+              [5, 6, 7, 8],
+            ],
+            [
+              [9, 10, 11, 12],
+              [13, 14, 15, 16],
+            ],
+            [
+              [17, 18, 19, 20],
+              [21, 22, 23, 24],
+            ],
+          ],
+        ]);
+
+        const naive = nn.dotProductAttention(query.ref, key.ref, value.ref, {
+          isCausal: true,
+          implementation: "naive",
+        });
+        const flash = nn.dotProductAttention(query, key, value, {
+          isCausal: true,
+          implementation: "flash",
+        });
+        expect(flash).toBeAllclose(naive, { atol: 1e-4 });
+      });
+    }
 
     test("multi-query attention (MQA)", () => {
       // Q: B=1, L=2, N=4 (query heads), H=2

--- a/website/src/routes/tts/pocket-tts.ts
+++ b/website/src/routes/tts/pocket-tts.ts
@@ -254,6 +254,7 @@ export function runMimiStreamingMultiheadAttention(
     x = nn.dotProductAttention(q, k.ref, v.ref, {
       isCausal: true,
       localWindowSize: context ? [context - 1, 0] : undefined,
+      implementation: "flash",
     });
     kvCache = { key: k, value: v };
   } else {
@@ -282,7 +283,10 @@ export function runMimiStreamingMultiheadAttention(
     const mask = context
       ? maskDelta.ref.lessEqual(0).mul(maskDelta.greater(-context))
       : maskDelta.lessEqual(0);
-    x = nn.dotProductAttention(q, kvCache.key.ref, kvCache.value.ref, { mask });
+    x = nn.dotProductAttention(q, kvCache.key.ref, kvCache.value.ref, {
+      mask,
+      implementation: "flash",
+    });
   }
   x = x.reshape([T, embedDim]);
   x = runLinear(outProj, x);


### PR DESCRIPTION
```
pnpm test bench bench/attention.bench.ts
```

This is not actually much faster than the jit version of standard attention yet, surprisingly. It's better for causal attention though due to blockwise sparsity.

Meh, I probably won't merge for now until we find an example of a workload where this helps.