### PR TITLE
webgpu: lift uniforms for nullary kernels

### DIFF
--- a/src/backend/webgpu.ts
+++ b/src/backend/webgpu.ts
@@ -1,32 +1,17 @@
-import { AluExp, AluGroup, AluOp, DType, isFloatDtype, Kernel } from "../alu";
-import {
-  Backend,
-  Device,
-  Executable,
-  Slot,
-  SlotError,
-  UnsupportedOpError,
-} from "../backend";
+import { AluExp, AluOp, DType, Kernel } from "../alu";
+import { Backend, Device, Executable, Slot, SlotError } from "../backend";
 import { Routine } from "../routine";
 import { tuneWebgpu } from "../tuner";
-import {
-  DEBUG,
-  findPow2,
-  FpHash,
-  mapSetUnion,
-  prod,
-  range,
-  strip1,
-} from "../utils";
-import { erfSrc, threefrySrc } from "./webgpu/builtins";
+import { DEBUG, findPow2, FpHash, prod, range, strip1 } from "../utils";
 import {
   calculateGrid,
   constToWgsl,
   dtypeToWgsl,
-  headerWgsl,
-  maxValueWgsl,
   ShaderInfo,
+  WgslBuilder,
+  WgslExpCodegen,
 } from "./webgpu/codegen";
+import { nullaryKernelSource } from "./webgpu/nullaryKernel";
 import { SyncReader } from "./webgpu/reader";
 import { createRoutineShader } from "./webgpu/routines";
 import { maybeAcquireTracingSlot, recordTrace } from "./webgpu/tracing";
@@ -276,6 +261,9 @@ export class WebGPUBackend implements Backend {
  * and y axes, to run the kernel.
  */
 function pipelineSource(device: GPUDevice, kernel: Kernel): ShaderInfo {
+  const nullaryKernel = nullaryKernelSource(device, kernel);
+  if (nullaryKernel) return nullaryKernel;
+
   const tune = tuneWebgpu(kernel);
   if (DEBUG >= 3) {
     console.info(`kernel.exp: ${kernel.exp}\ntune.exp: ${tune.exp}`);
@@ -284,46 +272,8 @@ function pipelineSource(device: GPUDevice, kernel: Kernel): ShaderInfo {
   const { nargs, reduction: re } = kernel;
   const args = Array.from({ length: nargs }, (_, i) => `in${i}`);
 
-  // binding(0..n-1): input buffers
-  // binding(n): output buffer
-
-  const shader: string[] = []; // line-separated
-  let indent = "";
-  const pushIndent = Symbol("pushIndent");
-  const popIndent = Symbol("popIndent");
-  const emit = (...lines: (string | symbol)[]) => {
-    for (const line of lines) {
-      if (line === pushIndent) indent += "  ";
-      else if (line === popIndent) indent = indent.slice(0, -2);
-      else shader.push(line ? indent + (line as string) : line);
-    }
-  };
-
-  if (
-    tune.exp.some((exp) => exp.dtype === DType.Float16) ||
-    tune.epilogue?.some((exp) => exp.dtype === DType.Float16)
-  ) {
-    if (!device.features.has("shader-f16"))
-      throw new Error("WebGPU device does not support shader-f16 feature");
-    emit("enable f16;");
-  }
-
-  emit(headerWgsl);
-
-  // Global functions at the start of the shader.
-  const distinctOps = mapSetUnion(
-    tune.exp.distinctOps(),
-    tune.epilogue?.distinctOps(),
-  );
-  if (distinctOps.has(AluOp.Threefry2x32)) {
-    emit(threefrySrc);
-  }
-  if (distinctOps.has(AluOp.Erf) || distinctOps.has(AluOp.Erfc)) {
-    emit(erfSrc);
-  }
-
-  // End global function definitions.
-  emit("");
+  const wb = new WgslBuilder();
+  wb.emitPreamble(device, [tune.exp, tune.epilogue]);
 
   const usedArgs: (DType | null)[] = Array.from({ length: nargs }, () => null);
   tune.exp.fold((exp) => {
@@ -333,16 +283,18 @@ function pipelineSource(device: GPUDevice, kernel: Kernel): ShaderInfo {
     if (exp.op === AluOp.GlobalIndex) usedArgs[exp.arg[0]] = exp.dtype;
   });
 
+  // binding(0..n-1): input buffers
+  // binding(n): output buffer
   for (let i = 0; i < nargs; i++) {
     // If not used, just assume float32, all that matters is size / alignment.
     const ty = dtypeToWgsl(usedArgs[i] ?? DType.Float32, true);
-    emit(
+    wb.emit(
       `@group(0) @binding(${i}) var<storage, read> ${args[i]} : array<${ty}>;`,
     );
   }
 
   const resultTy = dtypeToWgsl(kernel.dtype, true);
-  emit(
+  wb.emit(
     `@group(0) @binding(${nargs}) var<storage, read_write> result : array<${resultTy}>;`,
   );
 
@@ -353,185 +305,33 @@ function pipelineSource(device: GPUDevice, kernel: Kernel): ShaderInfo {
   const gridSize = Math.ceil(tune.threadCount / workgroupSize);
   const [gridX, gridY] = calculateGrid(gridSize);
 
-  emit(
+  wb.emit(
     "",
     `@compute @workgroup_size(${workgroupSize})`,
     "fn main(@builtin(global_invocation_id) id : vec3<u32>) {",
-    pushIndent,
+    wb.pushIndent,
   );
   if (gridY === 1) {
-    emit(
+    wb.emit(
       `if (id.x >= ${tune.threadCount}) { return; }`,
       "let gidx: i32 = i32(id.x);",
     );
   } else {
     const sizeX = gridX * workgroupSize;
-    emit(
+    wb.emit(
       `if (${sizeX} * id.y + id.x >= ${tune.threadCount}) { return; }`,
       `let gidx: i32 = i32(${sizeX} * id.y + id.x);`,
     );
   }
 
-  // Generate code for each AluExp operation.
-  // Some expressions may be used twice, so we keep track of them.
-  let gensymCount = 0;
-  const gensym = () => `alu${gensymCount++}`;
-  const isGensym = (text: string) => text.match(/^alu[0-9]+$/);
+  wb.emitPhonyAssignments(args);
 
-  // Insert phony assignments, in case some inputs are not in use.
-  // https://github.com/gpuweb/gpuweb/discussions/4582#discussioncomment-9146686
-  if (args.length > 0) {
-    emit(args.map((arg) => `_ = &${arg};`).join(" "));
-  }
-
-  const references = new Map<AluExp, number>();
-  const seen = new Set<AluExp>();
-  const countReferences = (exp: AluExp) => {
-    references.set(exp, (references.get(exp) ?? 0) + 1);
-    if (!seen.has(exp)) {
-      seen.add(exp);
-      for (const src of exp.src) countReferences(src);
-    }
-  };
-
-  const expContext = new Map<AluExp, string>();
-  const gen = (exp: AluExp): string => {
-    if (expContext.has(exp)) return expContext.get(exp)!;
-    const { op, src, dtype, arg } = exp;
-
-    // Some of these cases early `return` to force-inline them.
-    let source = "";
-    if (AluGroup.Binary.has(op) || AluGroup.Compare.has(op)) {
-      const a = gen(src[0]);
-      const b = gen(src[1]);
-      if (op === AluOp.Add) {
-        if (dtype === DType.Bool) source = `(${a} || ${b})`;
-        else source = `(${a} + ${b})`;
-      } else if (op === AluOp.Sub) source = `(${a} - ${b})`;
-      else if (op === AluOp.Mul) {
-        if (dtype === DType.Bool) source = `(${a} && ${b})`;
-        else source = `(${a} * ${b})`;
-      } else if (op === AluOp.Idiv)
-        source = isFloatDtype(dtype) ? `trunc(${a} / ${b})` : `(${a} / ${b})`;
-      else if (op === AluOp.Mod) source = `(${a} % ${b})`;
-      else if (op === AluOp.Min) {
-        if (dtype === DType.Bool) source = `(${a} && ${b})`;
-        else source = `min(${strip1(a)}, ${strip1(b)})`;
-      } else if (op === AluOp.Max) {
-        if (dtype === DType.Bool) source = `(${a} || ${b})`;
-        else source = `max(${strip1(a)}, ${strip1(b)})`;
-      } else if (op === AluOp.BitCombine) {
-        if (arg === "and") source = `(${a} & ${b})`;
-        else if (arg === "or") source = `(${a} | ${b})`;
-        else source = dtype === DType.Bool ? `(${a} != ${b})` : `(${a} ^ ${b})`;
-      } else if (op === AluOp.BitShift) {
-        if (arg === "shl") source = `(${a} << ${b})`;
-        else source = `(${a} >> ${b})`;
-      } else if (op === AluOp.Cmplt) source = `(${a} < ${b})`;
-      else if (op === AluOp.Cmpne) {
-        // Edge case: WebGPU doesn't handle NaN correctly, it's unspecified.
-        // This is a reliable way I found to detect NaNs, since the spec says
-        // for `max()`: if one operand is a NaN, the other is returned.
-        if (isFloatDtype(src[0].dtype)) {
-          const x = isGensym(a) ? a : gensym();
-          if (x !== a) emit(`let ${x} = ${a};`);
-          source = `(${x} != ${b} || min(${x}, ${dtypeToWgsl(src[0].dtype)}(inf())) != ${x})`;
-        } else {
-          source = `(${a} != ${b})`;
-        }
-      }
-    } else if (AluGroup.Unary.has(op)) {
-      if (op === AluOp.Reciprocal && src[0].op === AluOp.Sqrt) {
-        // Special case: 1/sqrt(x) is optimized as rsqrt(x)
-        const a = gen(src[0].src[0]);
-        source = `inverseSqrt(${a})`;
-      } else {
-        const a = gen(src[0]);
-        if (op === AluOp.Sin) source = `sin(${strip1(a)})`;
-        else if (op === AluOp.Cos) source = `cos(${strip1(a)})`;
-        else if (op === AluOp.Asin) source = `asin(${strip1(a)})`;
-        else if (op === AluOp.Atan) source = `atan(${strip1(a)})`;
-        else if (op === AluOp.Exp) source = `exp(${strip1(a)})`;
-        else if (op === AluOp.Log) source = `log(${strip1(a)})`;
-        else if (op === AluOp.Erf || op === AluOp.Erfc) {
-          const funcName = op === AluOp.Erf ? "erf" : "erfc";
-          if (dtype !== DType.Float32) {
-            // Always compute special functions in f32 for precision.
-            source = `${dtypeToWgsl(dtype)}(${funcName}(f32(${strip1(a)})))`;
-          } else {
-            source = `${funcName}(${strip1(a)})`;
-          }
-        } else if (op === AluOp.Sqrt) source = `sqrt(${strip1(a)})`;
-        else if (op === AluOp.Reciprocal) source = `(1.0 / ${a})`;
-        else if (op === AluOp.Floor) source = `floor(${strip1(a)})`;
-        else if (op === AluOp.Ceil) source = `ceil(${strip1(a)})`;
-        else if (op === AluOp.Cast) {
-          const srcTy = dtypeToWgsl(src[0].dtype);
-          const dstTy = dtypeToWgsl(dtype);
-          if (
-            isFloatDtype(src[0].dtype) &&
-            !(isFloatDtype(dtype) || dtype === DType.Bool)
-          ) {
-            // Edge case: Float->Int conversion with saturating upper bound.
-            //
-            // Because of the [WGSL spec](https://www.w3.org/TR/WGSL/#floating-point-conversion),
-            // we need to work around strange type conversion behaviors for correctness when
-            // converting large floats to integers. Hopefully the compiler understands.
-            //
-            // - 1e20f converted to u32 is the largest float value representable in u32, 4294967040u
-            //   Note this is smaller than the maximum u32 value 4294967295u
-            // - 1e20f converted to i32 is the maximum i32 value, 2147483520i
-            //   Note this is smaller than the maximum i32 value 2147483647i
-            const maxVal = maxValueWgsl(dtype);
-            const x = isGensym(a) ? a : gensym();
-            if (x !== a) emit(`let ${x}: ${srcTy} = ${strip1(a)};`);
-            source = `select(${dstTy}(${x}), ${maxVal}, ${x} >= ${srcTy}(${maxVal}))`;
-          } else {
-            source = `${dstTy}(${strip1(a)})`;
-          }
-        } else if (op === AluOp.Bitcast)
-          source = `bitcast<${dtypeToWgsl(dtype)}>(${strip1(a)})`;
-      }
-    } else if (op === AluOp.Where) {
-      // select(f, t, cond) -> cond ? t : f
-      source = `select(${strip1(gen(src[2]))}, ${strip1(gen(src[1]))}, ${strip1(gen(src[0]))})`;
-    } else if (op === AluOp.Threefry2x32) {
-      const x = gensym(); // temporary to hold the `vec2<u32>(x0, x1)`
-      const [k0, k1, c0, c1] = src.map((x) => strip1(gen(x)));
-      emit(`let ${x} = threefry2x32(vec2(${k0}, ${k1}), vec2(${c0}, ${c1}));`);
-      if (arg === "xor") source = `(${x}.x ^ ${x}.y)`;
-      else if (arg === 0) source = `${x}.x`;
-      else if (arg === 1) source = `${x}.y`;
-      else throw new UnsupportedOpError(op, dtype, "webgpu", arg);
-    } else if (op === AluOp.Const) {
-      return constToWgsl(dtype, arg);
-    } else if (op === AluOp.Special) {
-      return arg[0] as string;
-    } else if (op === AluOp.Variable) {
-      return arg as string;
-    } else if (op === AluOp.GlobalIndex) {
-      source = `${args[arg[0]]}[${strip1(gen(src[0]))}]`;
-      if (dtype === DType.Bool) source = `(${source} != 0)`; // bool is represented as i32
-    }
-
-    if (!source) throw new UnsupportedOpError(op, dtype, "webgpu", arg);
-    const typeName = dtypeToWgsl(dtype);
-    if ((references.get(exp) ?? 0) > 1) {
-      const name = gensym();
-      expContext.set(exp, name);
-      emit(`let ${name}: ${typeName} = ${strip1(source)};`);
-      return name;
-    } else {
-      expContext.set(exp, source);
-      return source;
-    }
-  };
-
+  const gen = new WgslExpCodegen(wb, args);
   if (!re) {
-    countReferences(tune.exp);
-    let rhs = strip1(gen(tune.exp));
+    gen.countReferences(tune.exp);
+    let rhs = strip1(gen.run(tune.exp));
     if (resultTy !== dtypeToWgsl(tune.exp.dtype)) rhs = `${resultTy}(${rhs})`;
-    emit(`result[gidx] = ${rhs};`);
+    wb.emit(`result[gidx] = ${rhs};`);
   } else {
     if ((tune.size.groups ?? 1) > 1) {
       throw new Error("WebGPU backend does not support group optimization yet");
@@ -541,14 +341,14 @@ function pipelineSource(device: GPUDevice, kernel: Kernel): ShaderInfo {
 
     const acc = [...Array(upcast)].map((_, i) => `acc${i}`);
     for (let i = 0; i < upcast; i++) {
-      emit(
+      wb.emit(
         `var ${acc[i]}: ${dtypeToWgsl(re.dtype)} = ${constToWgsl(re.dtype, re.identity)};`,
       ); // Initialize accumulators.
     }
 
-    emit(
+    wb.emit(
       `for (var ridx: i32 = 0; ridx < ${tune.size.reduce}; ridx++) {`,
-      pushIndent,
+      wb.pushIndent,
     );
 
     // Now generate (shared) expressions for each accumulator and unroll value.
@@ -562,12 +362,12 @@ function pipelineSource(device: GPUDevice, kernel: Kernel): ShaderInfo {
           unroll: AluExp.i32(un),
         });
         exps[up].push(exp.simplify(cache));
-        countReferences(exps[up][un]);
+        gen.countReferences(exps[up][un]);
       }
     }
 
     // After references are counted, we can generate the code.
-    const items = exps.map((ar) => ar.map(gen).map(strip1));
+    const items = exps.map((ar) => ar.map((x) => gen.run(x)).map(strip1));
     for (let i = 0; i < upcast; i++) {
       let rhs = items[i][0];
       for (let j = 1; j < unroll; j++) {
@@ -587,31 +387,31 @@ function pipelineSource(device: GPUDevice, kernel: Kernel): ShaderInfo {
               : `max(${rhs}, ${items[i][j]})`;
         } else throw new Error(`Unsupported reduction op: ${re.op}`);
       }
-      if (re.op === AluOp.Add) emit(`${acc[i]} += ${rhs};`);
-      else if (re.op === AluOp.Mul) emit(`${acc[i]} *= ${rhs};`);
+      if (re.op === AluOp.Add) wb.emit(`${acc[i]} += ${rhs};`);
+      else if (re.op === AluOp.Mul) wb.emit(`${acc[i]} *= ${rhs};`);
       else if (re.op === AluOp.Min) {
         // For booleans, min is AND; for numerics, use min()
-        if (re.dtype === DType.Bool) emit(`${acc[i]} = ${acc[i]} && ${rhs};`);
-        else emit(`${acc[i]} = min(${acc[i]}, ${rhs});`);
+        if (re.dtype === DType.Bool)
+          wb.emit(`${acc[i]} = ${acc[i]} && ${rhs};`);
+        else wb.emit(`${acc[i]} = min(${acc[i]}, ${rhs});`);
       } else if (re.op === AluOp.Max) {
         // For booleans, max is OR; for numerics, use max()
-        if (re.dtype === DType.Bool) emit(`${acc[i]} = ${acc[i]} || ${rhs};`);
-        else emit(`${acc[i]} = max(${acc[i]}, ${rhs});`);
+        if (re.dtype === DType.Bool)
+          wb.emit(`${acc[i]} = ${acc[i]} || ${rhs};`);
+        else wb.emit(`${acc[i]} = max(${acc[i]}, ${rhs});`);
       } else throw new Error(`Unsupported reduction op: ${re.op}`);
     }
-    emit(popIndent, "}");
+    wb.emit(wb.popIndent, "}");
 
     // Exited the reduction loop scope. Erase any local variables.
-    expContext.clear();
-    references.clear();
-    seen.clear();
+    gen.reset();
 
     const outputIdxExps: AluExp[] = [];
     const fusionExps: AluExp[] = [];
     for (let i = 0; i < upcast; i++) {
       const exp = tune.outputIdxExp.substitute({ upcast: AluExp.i32(i) });
       outputIdxExps.push(exp.simplify(cache));
-      countReferences(outputIdxExps[i]);
+      gen.countReferences(outputIdxExps[i]);
       fusionExps.push(
         tune
           .epilogue!.substitute({
@@ -620,20 +420,20 @@ function pipelineSource(device: GPUDevice, kernel: Kernel): ShaderInfo {
           })
           .simplify(cache),
       );
-      countReferences(fusionExps[i]);
+      gen.countReferences(fusionExps[i]);
     }
     for (let i = 0; i < upcast; i++) {
-      const index = strip1(gen(outputIdxExps[i]));
-      let rhs = strip1(gen(fusionExps[i]));
+      const index = strip1(gen.run(outputIdxExps[i]));
+      let rhs = strip1(gen.run(fusionExps[i]));
       if (resultTy !== dtypeToWgsl(fusionExps[i].dtype))
         rhs = `${resultTy}(${rhs})`;
-      emit(`result[${index}] = ${rhs};`);
+      wb.emit(`result[${index}] = ${rhs};`);
     }
   }
 
-  emit(popIndent, "}");
+  wb.emit(wb.popIndent, "}");
   return {
-    code: shader.join("\n"),
+    code: wb.toString(),
     numInputs: nargs,
     numOutputs: 1,
     hasUniform: false,

--- a/src/backend/webgpu/codegen.ts
+++ b/src/backend/webgpu/codegen.ts
@@ -1,6 +1,9 @@
 // Shared codegen helpers for generating WGSL.
 
-import { DType } from "../../alu";
+import { erfSrc, threefrySrc } from "./builtins";
+import { AluExp, AluGroup, AluOp, DType, isFloatDtype } from "../../alu";
+import { UnsupportedOpError } from "../../backend";
+import { mapSetUnion, strip1 } from "../../utils";
 
 export interface ShaderInfo {
   code: string; // WGSL shader source code.
@@ -17,6 +20,61 @@ export const headerWgsl = String.raw`
 fn nan() -> f32 { let bits = 0xffffffffu; return bitcast<f32>(bits); }
 fn inf() -> f32 { let bits = 0x7f800000u; return bitcast<f32>(bits); }
 `.trim();
+
+/** Builder class for simple program generation with WGSL. */
+export class WgslBuilder {
+  readonly pushIndent = Symbol("pushIndent");
+  readonly popIndent = Symbol("popIndent");
+  readonly lines: string[] = [];
+  #indent = "";
+
+  emit(...lines: (string | symbol)[]): void {
+    for (const line of lines) {
+      if (line === this.pushIndent) this.#indent += "  ";
+      else if (line === this.popIndent)
+        this.#indent = this.#indent.slice(0, -2);
+      else this.lines.push(line ? this.#indent + (line as string) : "");
+    }
+  }
+
+  emitPreamble(device: GPUDevice, exps: (AluExp | null | undefined)[]): void {
+    let hasFloat16 = false;
+    let distinctOps = new Map<AluOp, Set<DType>>();
+    for (const exp of exps) {
+      if (exp == null) continue;
+      hasFloat16 ||= exp.some((e) => e.dtype === DType.Float16);
+      distinctOps = mapSetUnion(distinctOps, exp.distinctOps());
+    }
+    if (hasFloat16) {
+      if (!device.features.has("shader-f16")) {
+        throw new Error("WebGPU device does not support shader-f16 feature");
+      }
+      this.emit("enable f16;");
+    }
+    this.emit(headerWgsl);
+    if (distinctOps.has(AluOp.Threefry2x32)) {
+      this.emit(threefrySrc);
+    }
+    if (distinctOps.has(AluOp.Erf) || distinctOps.has(AluOp.Erfc)) {
+      this.emit(erfSrc);
+    }
+    this.emit("");
+  }
+
+  /**
+   * Insert phony assignments, in case some inputs are not in use.
+   * <https://github.com/gpuweb/gpuweb/discussions/4582#discussioncomment-9146686>
+   */
+  emitPhonyAssignments(args: string[]): void {
+    if (args.length > 0) {
+      this.emit(args.map((arg) => `_ = &${arg};`).join(" "));
+    }
+  }
+
+  toString(): string {
+    return this.lines.join("\n");
+  }
+}
 
 export function dtypeToWgsl(dtype: DType, storage: boolean = false): string {
   switch (dtype) {
@@ -68,6 +126,180 @@ export function constToWgsl(dtype: DType, value: any): string {
     return "f16(" + value.toString() + ")";
   }
   throw new Error(`Unsupported const dtype: ${dtype}`);
+}
+
+/** Codegen for WebGPU expressions, linearizing AluOp into a kernel. */
+export class WgslExpCodegen {
+  #gensymCount = 0;
+  #references = new Map<AluExp, number>();
+  #seen = new Set<AluExp>();
+  #context = new Map<AluExp, string>();
+
+  constructor(
+    readonly wb: WgslBuilder,
+    readonly args: string[],
+  ) {}
+
+  #gensym() {
+    return `alu${this.#gensymCount++}`;
+  }
+
+  #isGensym(text: string) {
+    return text.match(/^alu[0-9]+$/);
+  }
+
+  /**
+   * Count references for an expression.
+   *
+   * Used to get an ahead-of-time reference count for each node in the AluExp.
+   * Expressions with reference count greater than 1 are stored in temporary
+   * variables to avoid recomputation.
+   */
+  countReferences(exp: AluExp): void {
+    this.#references.set(exp, (this.#references.get(exp) ?? 0) + 1);
+    if (!this.#seen.has(exp)) {
+      this.#seen.add(exp);
+      for (const src of exp.src) this.countReferences(src);
+    }
+  }
+
+  reset(): void {
+    this.#references.clear();
+    this.#seen.clear();
+    this.#context.clear();
+  }
+
+  /**
+   * Generate code for an expression.
+   *
+   * Calls itself recursively and eliminates common subexpressions by storing
+   * them in temporary variables, emitted to the current builder scope. This is
+   * a side-effect that leads to multiline code generation.
+   */
+  run(exp: AluExp): string {
+    if (this.#context.has(exp)) return this.#context.get(exp)!;
+    const { op, src, dtype, arg } = exp;
+
+    // Some of these cases early `return` to force-inline them.
+    let source = "";
+    if (AluGroup.Binary.has(op) || AluGroup.Compare.has(op)) {
+      const a = this.run(src[0]);
+      const b = this.run(src[1]);
+      if (op === AluOp.Add) {
+        if (dtype === DType.Bool) source = `(${a} || ${b})`;
+        else source = `(${a} + ${b})`;
+      } else if (op === AluOp.Sub) source = `(${a} - ${b})`;
+      else if (op === AluOp.Mul) {
+        if (dtype === DType.Bool) source = `(${a} && ${b})`;
+        else source = `(${a} * ${b})`;
+      } else if (op === AluOp.Idiv)
+        source = isFloatDtype(dtype) ? `trunc(${a} / ${b})` : `(${a} / ${b})`;
+      else if (op === AluOp.Mod) source = `(${a} % ${b})`;
+      else if (op === AluOp.Min) {
+        if (dtype === DType.Bool) source = `(${a} && ${b})`;
+        else source = `min(${strip1(a)}, ${strip1(b)})`;
+      } else if (op === AluOp.Max) {
+        if (dtype === DType.Bool) source = `(${a} || ${b})`;
+        else source = `max(${strip1(a)}, ${strip1(b)})`;
+      } else if (op === AluOp.BitCombine) {
+        if (arg === "and") source = `(${a} & ${b})`;
+        else if (arg === "or") source = `(${a} | ${b})`;
+        else source = dtype === DType.Bool ? `(${a} != ${b})` : `(${a} ^ ${b})`;
+      } else if (op === AluOp.BitShift) {
+        if (arg === "shl") source = `(${a} << ${b})`;
+        else source = `(${a} >> ${b})`;
+      } else if (op === AluOp.Cmplt) source = `(${a} < ${b})`;
+      else if (op === AluOp.Cmpne) {
+        // Edge case: WebGPU doesn't handle NaN correctly, it's unspecified.
+        // This is a reliable way I found to detect NaNs, since the spec says
+        // for `max()`: if one operand is a NaN, the other is returned.
+        if (isFloatDtype(src[0].dtype)) {
+          const x = this.#isGensym(a) ? a : this.#gensym();
+          if (x !== a) this.wb.emit(`let ${x} = ${a};`);
+          source = `(${x} != ${b} || min(${x}, ${dtypeToWgsl(src[0].dtype)}(inf())) != ${x})`;
+        } else {
+          source = `(${a} != ${b})`;
+        }
+      }
+    } else if (AluGroup.Unary.has(op)) {
+      if (op === AluOp.Reciprocal && src[0].op === AluOp.Sqrt) {
+        // Special case: 1/sqrt(x) is optimized as rsqrt(x)
+        const a = this.run(src[0].src[0]);
+        source = `inverseSqrt(${a})`;
+      } else {
+        const a = this.run(src[0]);
+        if (op === AluOp.Sin) source = `sin(${strip1(a)})`;
+        else if (op === AluOp.Cos) source = `cos(${strip1(a)})`;
+        else if (op === AluOp.Asin) source = `asin(${strip1(a)})`;
+        else if (op === AluOp.Atan) source = `atan(${strip1(a)})`;
+        else if (op === AluOp.Exp) source = `exp(${strip1(a)})`;
+        else if (op === AluOp.Log) source = `log(${strip1(a)})`;
+        else if (op === AluOp.Erf || op === AluOp.Erfc) {
+          const funcName = op === AluOp.Erf ? "erf" : "erfc";
+          if (dtype !== DType.Float32) {
+            // Always compute special functions in f32 for precision.
+            source = `${dtypeToWgsl(dtype)}(${funcName}(f32(${strip1(a)})))`;
+          } else {
+            source = `${funcName}(${strip1(a)})`;
+          }
+        } else if (op === AluOp.Sqrt) source = `sqrt(${strip1(a)})`;
+        else if (op === AluOp.Reciprocal) source = `(1.0 / ${a})`;
+        else if (op === AluOp.Floor) source = `floor(${strip1(a)})`;
+        else if (op === AluOp.Ceil) source = `ceil(${strip1(a)})`;
+        else if (op === AluOp.Cast) {
+          const srcTy = dtypeToWgsl(src[0].dtype);
+          const dstTy = dtypeToWgsl(dtype);
+          if (
+            isFloatDtype(src[0].dtype) &&
+            !(isFloatDtype(dtype) || dtype === DType.Bool)
+          ) {
+            // Edge case: Float->Int conversion with saturating upper bound.
+            const maxVal = maxValueWgsl(dtype);
+            const x = this.#isGensym(a) ? a : this.#gensym();
+            if (x !== a) this.wb.emit(`let ${x}: ${srcTy} = ${strip1(a)};`);
+            source = `select(${dstTy}(${x}), ${maxVal}, ${x} >= ${srcTy}(${maxVal}))`;
+          } else {
+            source = `${dstTy}(${strip1(a)})`;
+          }
+        } else if (op === AluOp.Bitcast)
+          source = `bitcast<${dtypeToWgsl(dtype)}>(${strip1(a)})`;
+      }
+    } else if (op === AluOp.Where) {
+      // select(f, t, cond) -> cond ? t : f
+      source = `select(${strip1(this.run(src[2]))}, ${strip1(this.run(src[1]))}, ${strip1(this.run(src[0]))})`;
+    } else if (op === AluOp.Threefry2x32) {
+      const x = this.#gensym(); // temporary to hold the `vec2<u32>(x0, x1)`
+      const [k0, k1, c0, c1] = src.map((x) => strip1(this.run(x)));
+      this.wb.emit(
+        `let ${x} = threefry2x32(vec2(${k0}, ${k1}), vec2(${c0}, ${c1}));`,
+      );
+      if (arg === "xor") source = `(${x}.x ^ ${x}.y)`;
+      else if (arg === 0) source = `${x}.x`;
+      else if (arg === 1) source = `${x}.y`;
+      else throw new UnsupportedOpError(op, dtype, "webgpu", arg);
+    } else if (op === AluOp.Const) {
+      return constToWgsl(dtype, arg);
+    } else if (op === AluOp.Special) {
+      return arg[0] as string;
+    } else if (op === AluOp.Variable) {
+      return arg as string;
+    } else if (op === AluOp.GlobalIndex) {
+      source = `${this.args[arg[0]]}[${strip1(this.run(src[0]))}]`;
+      if (dtype === DType.Bool) source = `(${source} != 0)`; // bool is represented as i32
+    }
+
+    if (!source) throw new UnsupportedOpError(op, dtype, "webgpu", arg);
+    const typeName = dtypeToWgsl(dtype);
+    if ((this.#references.get(exp) ?? 0) > 1) {
+      const name = this.#gensym();
+      this.#context.set(exp, name);
+      this.wb.emit(`let ${name}: ${typeName} = ${strip1(source)};`);
+      return name;
+    } else {
+      this.#context.set(exp, source);
+      return source;
+    }
+  }
 }
 
 export const gridOffsetY = 16384;

--- a/src/backend/webgpu/nullaryKernel.ts
+++ b/src/backend/webgpu/nullaryKernel.ts
@@ -1,0 +1,163 @@
+// Special code generation for nullary kernels, which don't take any arrays as
+// input. This includes constructors like `arange` and `full`.
+//
+// It's common for these functions to be used to create new arrays. But because
+// the constant inputs may differ, they often result in kernel recompiles, which
+// slows down performance in browsers.
+//
+// To fix this, we lift all constant inputs into _uniforms_.
+
+import {
+  calculateGrid,
+  dtypeToWgsl,
+  ShaderInfo,
+  WgslBuilder,
+  WgslExpCodegen,
+} from "./codegen";
+import { AluExp, AluOp, DType, Kernel } from "../../alu";
+import { findPow2, strip1 } from "../../utils";
+
+type ConstantUniform = {
+  name: string;
+  dtype: DType;
+  uniformDtype: DType;
+  value: number;
+};
+
+function uniformDtype(dtype: DType): DType {
+  if (dtype === DType.Float16) return DType.Float32;
+  if (dtype === DType.Bool) return DType.Int32;
+  return dtype;
+}
+
+function replacementFor({
+  name,
+  dtype,
+  uniformDtype,
+}: ConstantUniform): AluExp {
+  const value = AluExp.variable(uniformDtype, `uniforms.${name}`);
+  if (dtype === DType.Float16) return AluExp.cast(DType.Float16, value);
+  if (dtype === DType.Bool) return AluExp.cmpne(value, AluExp.i32(0));
+  return value;
+}
+
+function writeUniform(
+  view: DataView,
+  offset: number,
+  dtype: DType,
+  value: number,
+) {
+  switch (dtype) {
+    case DType.Float32:
+      view.setFloat32(offset, value, true);
+      break;
+    case DType.Int32:
+      view.setInt32(offset, value, true);
+      break;
+    case DType.Uint32:
+      view.setUint32(offset, value, true);
+      break;
+    default:
+      throw new Error(`Unsupported dtype for constant uniform: ${dtype}`);
+  }
+}
+
+function liftConstants(exp: AluExp): [AluExp, ConstantUniform[]] {
+  const uniforms: ConstantUniform[] = [];
+  const lifted = exp.rewrite((node) => {
+    if (node.op !== AluOp.Const || node.arg === 0) return;
+    const uniform: ConstantUniform = {
+      name: `c${uniforms.length}`,
+      dtype: node.dtype,
+      uniformDtype: uniformDtype(node.dtype),
+      value: node.arg,
+    };
+    uniforms.push(uniform);
+    return replacementFor(uniform);
+  });
+  return [lifted, uniforms];
+}
+
+function uniformsData(uniforms: ConstantUniform[]): Uint8Array<ArrayBuffer> {
+  const data = new Uint8Array(uniforms.length * 4);
+  const view = new DataView(data.buffer);
+  uniforms.forEach((u, i) =>
+    writeUniform(view, i * 4, u.uniformDtype, u.value),
+  );
+  return data;
+}
+
+export function nullaryKernelSource(
+  device: GPUDevice,
+  kernel: Kernel,
+): ShaderInfo | null {
+  if (kernel.nargs !== 0 || kernel.reduction) return null;
+
+  let exp = kernel.exp
+    .substitute({ gidx: AluExp.special(DType.Int32, "gidx", kernel.size) })
+    .simplify();
+  let uniforms: ConstantUniform[] = [];
+  [exp, uniforms] = liftConstants(exp);
+
+  const wb = new WgslBuilder();
+  wb.emitPreamble(device, [exp]);
+
+  if (uniforms.length > 0) {
+    wb.emit(
+      "struct Uniforms {",
+      wb.pushIndent,
+      ...uniforms.map((u) => `${u.name}: ${dtypeToWgsl(u.uniformDtype)},`),
+      wb.popIndent,
+      "}\n",
+    );
+  }
+
+  const resultTy = dtypeToWgsl(kernel.dtype, true);
+  wb.emit(
+    `@group(0) @binding(0) var<storage, read_write> result : array<${resultTy}>;`,
+  );
+  if (uniforms.length > 0) {
+    wb.emit(`@group(1) @binding(0) var<uniform> uniforms: Uniforms;`);
+  }
+
+  const workgroupSize = findPow2(kernel.size, 256);
+  const gridSize = Math.ceil(kernel.size / workgroupSize);
+  const [gridX, gridY] = calculateGrid(gridSize);
+  wb.emit(
+    "",
+    `@compute @workgroup_size(${workgroupSize})`,
+    "fn main(@builtin(global_invocation_id) id : vec3<u32>) {",
+    wb.pushIndent,
+  );
+  if (gridY === 1) {
+    wb.emit(
+      `if (id.x >= ${kernel.size}) { return; }`,
+      "let gidx: i32 = i32(id.x);",
+    );
+  } else {
+    const sizeX = gridX * workgroupSize;
+    wb.emit(
+      `if (${sizeX} * id.y + id.x >= ${kernel.size}) { return; }`,
+      `let gidx: i32 = i32(${sizeX} * id.y + id.x);`,
+    );
+  }
+
+  const gen = new WgslExpCodegen(wb, []);
+  gen.countReferences(exp);
+  let rhs = strip1(gen.run(exp));
+  if (resultTy !== dtypeToWgsl(exp.dtype)) rhs = `${resultTy}(${rhs})`;
+  wb.emit(`result[gidx] = ${rhs};`, wb.popIndent, "}");
+
+  return {
+    code: wb.toString(),
+    numInputs: 0,
+    numOutputs: 1,
+    hasUniform: uniforms.length > 0,
+    passes: [
+      {
+        grid: [gridX, gridY],
+        uniform: uniforms.length > 0 ? uniformsData(uniforms) : undefined,
+      },
+    ],
+  };
+}

--- a/website/src/routes/tts/inference.ts
+++ b/website/src/routes/tts/inference.ts
@@ -29,7 +29,7 @@ export async function playTTS(
     noiseClamp = null,
   }: Partial<PlayTTSOptions> = {},
 ): Promise<void> {
-  let sequence = model.flowLM.bosEmb.ref.reshape([1, -1]); // [1, 32]
+  let lastLatent = model.flowLM.bosEmb.ref.reshape([1, -1]); // [1, 32]
   let audioPromise: Promise<void> = Promise.resolve();
 
   if (seed === null) seed = Math.floor(Math.random() * 2 ** 32);
@@ -54,7 +54,7 @@ export async function playTTS(
         tree.ref(model.flowLM),
         flowLMState,
         stepKey,
-        step === 0 ? sequence.ref : sequence.ref.slice([-1]),
+        lastLatent.ref,
         step === 0 ? embeds.ref : null,
         flowLMState.kvCacheLen, // same as offset
         lsdDecodeSteps,
@@ -76,7 +76,9 @@ export async function playTTS(
         break;
       }
 
-      sequence = np.concatenate([sequence, latent]);
+      const prevLatent = lastLatent;
+      lastLatent = latent;
+      prevLatent.dispose();
 
       const timestamp = performance.now();
       console.log(
@@ -84,8 +86,7 @@ export async function playTTS(
       );
       lastTimestamp = timestamp;
 
-      let mimiInput = sequence.ref.slice([-1]);
-      mimiInput = mimiInput
+      const mimiInput = latent.ref
         .mul(model.flowLM.embStd.ref)
         .add(model.flowLM.embMean.ref);
 
@@ -93,7 +94,6 @@ export async function playTTS(
         tree.ref(model.mimi),
         mimiState,
         mimiInput,
-        step,
       );
       mimiState = newMimiState;
 
@@ -113,7 +113,7 @@ export async function playTTS(
       })();
     }
   } finally {
-    sequence.dispose();
+    lastLatent.dispose();
     tree.dispose([model, embeds]);
     await audioPromise;
   }

--- a/website/src/routes/tts/pocket-tts.ts
+++ b/website/src/routes/tts/pocket-tts.ts
@@ -601,6 +601,7 @@ export function runMimiEncode(
 export type MimiDecodeState = {
   kvCaches: KVCache[];
   kvCacheLen: number;
+  offset: number;
   initialConvState: np.Array;
   seanetStates: SEANetDecoderState;
 };
@@ -618,6 +619,7 @@ export function createMimiDecodeState(mimi: MimiModel): MimiDecodeState {
   return {
     kvCaches: mimi.decoderTransformer.map(() => emptyKVCache()),
     kvCacheLen: 0,
+    offset: 0,
     initialConvState: createConvTranspose1dState(mimi.upsample.convtr, 16, 512),
     seanetStates: createSEANetDecoderState(mimi.decoder),
   };
@@ -633,9 +635,14 @@ export function runMimiDecode(
     downsample,
     upsample,
   }: MimiModel,
-  { kvCaches, kvCacheLen, initialConvState, seanetStates }: MimiDecodeState,
+  {
+    kvCaches,
+    kvCacheLen,
+    offset,
+    initialConvState,
+    seanetStates,
+  }: MimiDecodeState,
   latent: np.Array, // [T, 32] - bottleneck representation
-  offset: number, // scalar, position offset
 ): [np.Array, MimiDecodeState] {
   tree.dispose([encoder, encoderTransformer, downsample]);
 
@@ -662,7 +669,7 @@ export function runMimiDecode(
       layer,
       kvCaches[i],
       x,
-      offset * 16,
+      offset,
       kvCacheLen,
       { context: 250, numHeads: 8 },
     );
@@ -674,6 +681,7 @@ export function runMimiDecode(
 
   // Maintain and update KV caches as needed.
   kvCacheLen += 16;
+  offset += 16;
   if (kvCaches[0].key.shape[0] !== 272) {
     // Pad it to a constant [272] in length, more than 250 context + 16 for next pass.
     const padAmount = 272 - kvCaches[0].key.shape[0];
@@ -695,7 +703,8 @@ export function runMimiDecode(
     x,
     {
       kvCaches,
-      kvCacheLen: kvCacheLen,
+      kvCacheLen,
+      offset,
       initialConvState,
       seanetStates,
     },


### PR DESCRIPTION
This allows us to avoid kernel recompiles in many cases where we have a "nullary" kernel that gets generated when converting JS number constants to arrays, or other similar operations.