### PR TITLE
Add more random samplers

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -16,10 +16,10 @@ Other features just aren't implemented yet. But those can probably be added easi
 
 In the tables below, we use a color legend to refer to functions in JAX:
 
-- 🟢 = supported **(~54%)**
+- 🟢 = supported **(~58%)**
 - 🟡 = supported, with API limitations **(~2%)**
-- 🟠 = not supported, easy to add (<1 day) **(~32%)**
-- 🔴 = not supported **(~12%)**
+- 🟠 = not supported, easy to add (<1 day) **(~29%)**
+- 🔴 = not supported **(~11%)**
 - ⚪️ = not applicable, will not be supported (see notes)
 
 ## [`jax`](https://docs.jax.dev/en/latest/jax.html)

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -567,49 +567,49 @@ jax-js implements the same PRNG, with bitwise identical outputs. However, most s
 | `clone`         | ⚪️      | use `.ref`                    |
 | `PRNGKey`       | ⚪️      | legacy                        |
 
-**Samplers:** These are all 🟠 assuming that sampling from distributions is usually easier than
-modeling their transcendental CDFs (e.g., normal via Box-Muller).
+**Samplers:** Many samplers are implemented via transformations of simpler distributions rather than
+bitwise-identical JAX algorithms (e.g., normal via Box-Muller).
 
-| API                    | Support | Notes |
-| ---------------------- | ------- | ----- |
-| `ball`                 | 🟠      |       |
-| `bernoulli`            | 🟢      |       |
-| `beta`                 | 🟠      |       |
-| `binomial`             | 🟠      |       |
-| `bits`                 | 🟢      |       |
-| `categorical`          | 🟢      |       |
-| `cauchy`               | 🟢      |       |
-| `chisquare`            | 🟠      |       |
-| `choice`               | 🟠      |       |
-| `dirichlet`            | 🟠      |       |
-| `double_sided_maxwell` | 🟠      |       |
-| `exponential`          | 🟢      |       |
-| `f`                    | 🟠      |       |
-| `gamma`                | 🟠      |       |
-| `generalized_normal`   | 🟠      |       |
-| `geometric`            | 🟠      |       |
-| `gumbel`               | 🟢      |       |
-| `laplace`              | 🟢      |       |
-| `loggamma`             | 🟠      |       |
-| `logistic`             | 🟠      |       |
-| `lognormal`            | 🟠      |       |
-| `maxwell`              | 🟠      |       |
-| `multinomial`          | 🟠      |       |
-| `multivariate_normal`  | 🟢      |       |
-| `normal`               | 🟢      |       |
-| `orthogonal`           | 🟠      |       |
-| `pareto`               | 🟠      |       |
-| `permutation`          | 🟠      |       |
-| `poisson`              | 🟠      |       |
-| `rademacher`           | 🟠      |       |
-| `randint`              | 🟠      |       |
-| `rayleigh`             | 🟠      |       |
-| `t`                    | 🟠      |       |
-| `triangular`           | 🟠      |       |
-| `truncated_normal`     | 🟠      |       |
-| `uniform`              | 🟢      |       |
-| `wald`                 | 🟠      |       |
-| `weibull_min`          | 🟠      |       |
+| API                    | Support | Notes                   |
+| ---------------------- | ------- | ----------------------- |
+| `ball`                 | 🟢      | p=2 only                |
+| `bernoulli`            | 🟢      |                         |
+| `beta`                 | 🟠      |                         |
+| `binomial`             | 🟠      |                         |
+| `bits`                 | 🟢      |                         |
+| `categorical`          | 🟢      |                         |
+| `cauchy`               | 🟢      |                         |
+| `chisquare`            | 🟠      |                         |
+| `choice`               | 🟢      | basic replacement cases |
+| `dirichlet`            | 🟠      |                         |
+| `double_sided_maxwell` | 🟢      |                         |
+| `exponential`          | 🟢      |                         |
+| `f`                    | 🟠      |                         |
+| `gamma`                | 🟠      |                         |
+| `generalized_normal`   | 🟠      |                         |
+| `geometric`            | 🟢      |                         |
+| `gumbel`               | 🟢      |                         |
+| `laplace`              | 🟢      |                         |
+| `loggamma`             | 🟠      |                         |
+| `logistic`             | 🟢      |                         |
+| `lognormal`            | 🟢      |                         |
+| `maxwell`              | 🟢      |                         |
+| `multinomial`          | 🟠      |                         |
+| `multivariate_normal`  | 🟢      |                         |
+| `normal`               | 🟢      |                         |
+| `orthogonal`           | 🟠      |                         |
+| `pareto`               | 🟢      |                         |
+| `permutation`          | 🟢      |                         |
+| `poisson`              | 🟠      |                         |
+| `rademacher`           | 🟢      |                         |
+| `randint`              | 🟢      | uses modulo reduction   |
+| `rayleigh`             | 🟢      |                         |
+| `t`                    | 🟠      |                         |
+| `triangular`           | 🟢      |                         |
+| `truncated_normal`     | 🟠      |                         |
+| `uniform`              | 🟢      |                         |
+| `wald`                 | 🟠      |                         |
+| `weibull_min`          | 🟢      |                         |
 
 ## [`jax.nn` module](https://docs.jax.dev/en/latest/jax.nn.html)
 

--- a/src/library/random.ts
+++ b/src/library/random.ts
@@ -9,6 +9,7 @@ import { topK } from "./lax";
 import {
   absolute,
   argmax,
+  argsort,
   array,
   Array,
   ArrayLike,
@@ -16,6 +17,8 @@ import {
   cos,
   DType,
   einsum,
+  exp,
+  floor,
   log,
   log1p,
   negative,
@@ -23,8 +26,11 @@ import {
   sqrt,
   stack,
   tan,
+  where,
 } from "./numpy";
 import { cholesky } from "./numpy-linalg";
+
+const JsArray = globalThis.Array;
 
 function validateKeyShape(key: Array, scalar = false): number[] {
   if (key.ndim === 0) {
@@ -125,6 +131,35 @@ export const uniform = jit(
     } else {
       return rand.mul(maxval - minval).add(minval);
     }
+  },
+  { staticArgnums: [1, 2] },
+);
+
+// Other distributions (alphabetical order).
+
+/**
+ * @function
+ * Sample points uniformly from the Euclidean unit ball in `d` dimensions.
+ *
+ * Only the Euclidean `p=2` case is currently supported.
+ */
+export const ball = jit(
+  function ball(
+    key: Array,
+    d: number,
+    { p = 2, shape = [] }: { p?: number; shape?: number[] } = {},
+  ): Array {
+    if (!Number.isInteger(d) || d <= 0) {
+      throw new Error(`ball: dimension must be a positive integer, got ${d}`);
+    }
+    if (p !== 2) {
+      throw new Error("ball: only the Euclidean p=2 case is supported");
+    }
+    const [k1, k2] = split(key, 2);
+    const z = normal(k1, [...shape, d]);
+    const norm = sqrt(z.ref.mul(z.ref).sum(-1, { keepdims: true }));
+    const radius = exp(log(uniform(k2, [...shape, 1])).mul(1 / d));
+    return z.div(norm).mul(radius);
   },
   { staticArgnums: [1, 2] },
 );
@@ -236,6 +271,79 @@ export const cauchy = jit(
 );
 
 /**
+ * Sample from a population with optional replacement and optional probabilities.
+ *
+ * This implements the common JAX-compatible cases: integer populations and
+ * array populations along `axis`. Probabilities `p`, if provided, are sampled
+ * via `categorical(log(p))`.
+ */
+export function choice(
+  key: Array,
+  a: number | ArrayLike,
+  {
+    shape = [],
+    replace = true,
+    p,
+    axis = 0,
+  }: { shape?: number[]; replace?: boolean; p?: ArrayLike; axis?: number } = {},
+): Array {
+  let n: number;
+  let values: Array | null = null;
+  if (typeof a === "number") {
+    if (!Number.isInteger(a) || a < 0) {
+      throw new Error(`choice: a must be a non-negative integer, got ${a}`);
+    }
+    n = a;
+  } else {
+    values = fudgeArray(a);
+    axis = checkAxis(axis, values.ndim);
+    n = values.shape[axis];
+  }
+
+  let indices: Array;
+  if (p !== undefined) {
+    indices = categorical(key, log(p), { shape, replace });
+  } else if (replace) {
+    indices = randint(key, { minval: 0, maxval: n, shape });
+  } else {
+    const k = shape.reduce((acc, x) => acc * x, 1);
+    if (k > n) {
+      throw new Error(
+        `Number of samples without replacement (${k}) cannot exceed population size (${n}).`,
+      );
+    }
+    indices = permutation(key, n).slice([0, k]).reshape(shape);
+  }
+
+  if (values === null) return indices;
+  const index: any[] = JsArray(axis).fill([]);
+  index.push(indices);
+  return values.slice(...index);
+}
+
+/**
+ * @function
+ * Sample double-sided Maxwell random values with the provided location and scale.
+ */
+export const doubleSidedMaxwell = jit(
+  function doubleSidedMaxwell(
+    key: Array,
+    loc: ArrayLike,
+    scale: ArrayLike,
+    shape: number[] = [],
+  ): Array {
+    loc = fudgeArray(loc);
+    scale = fudgeArray(scale);
+    const [k1, k2] = split(key, 2);
+    return rademacher(k1, { shape, dtype: DType.Float32 })
+      .mul(maxwell(k2, shape))
+      .mul(scale)
+      .add(loc);
+  },
+  { staticArgnums: [3] },
+);
+
+/**
  * @function
  * Sample exponential random values according to `p(x) = exp(-x)`.
  */
@@ -245,6 +353,27 @@ export const exponential = jit(
     return negative(log1p(negative(u))) as Array; // log(1-u) to avoid log(0)
   },
   { staticArgnums: [1] },
+);
+
+/**
+ * @function
+ * Sample geometric random values: the number of trials until first success.
+ */
+export const geometric = jit(
+  function geometric(
+    key: Array,
+    p: ArrayLike,
+    {
+      shape = [],
+      dtype = DType.Int32,
+    }: { shape?: number[]; dtype?: DType } = {},
+  ): Array {
+    p = fudgeArray(p);
+    return floor(log1p(negative(uniform(key, shape))).div(log1p(negative(p))))
+      .add(1)
+      .astype(dtype);
+  },
+  { staticArgnums: [2] },
 );
 
 /**
@@ -281,6 +410,48 @@ export const laplace = jit(
     // when centered is close to ±0.5
     const absVal = absolute(centered);
     return s.mul(log1p(absVal.mul(-2)).mul(-1));
+  },
+  { staticArgnums: [1] },
+);
+
+/**
+ * @function
+ * Sample from a logistic distribution with location 0 and scale 1.
+ *
+ * Uses inverse transform sampling: `x = log(u) - log(1-u)`.
+ */
+export const logistic = jit(
+  function logistic(key: Array, shape: number[] = []): Array {
+    const u = uniform(key, shape);
+    return log(u.ref).sub(log1p(negative(u)));
+  },
+  { staticArgnums: [1] },
+);
+
+/**
+ * @function
+ * Sample log-normal random values: `exp(sigma * normal(key, shape))`.
+ */
+export const lognormal = jit(
+  function lognormal(
+    key: Array,
+    sigma: ArrayLike = 1,
+    shape: number[] = [],
+  ): Array {
+    sigma = fudgeArray(sigma);
+    return exp(normal(key, shape).mul(sigma));
+  },
+  { staticArgnums: [2] },
+);
+
+/**
+ * @function
+ * Sample Maxwell-distributed random values.
+ */
+export const maxwell = jit(
+  function maxwell(key: Array, shape: number[] = []): Array {
+    const z = normal(key, [...shape, 3]);
+    return sqrt(z.ref.mul(z).sum(-1));
   },
   { staticArgnums: [1] },
 );
@@ -351,4 +522,163 @@ export const normal = jit(
     return radius.mul(cos(theta)) as Array;
   },
   { staticArgnums: [1] },
+);
+
+/**
+ * @function
+ * Sample from a Pareto distribution with shape parameter `b` and support [1, ∞).
+ */
+export const pareto = jit(
+  function pareto(key: Array, b: ArrayLike, shape: number[] = []): Array {
+    b = fudgeArray(b);
+    return exp(exponential(key, shape).div(b));
+  },
+  { staticArgnums: [2] },
+);
+
+/**
+ * Return a random permutation of an integer range or of an array along `axis`.
+ */
+export function permutation(
+  key: Array,
+  x: number | ArrayLike,
+  axis: number = 0,
+): Array {
+  if (typeof x === "number") {
+    if (!Number.isInteger(x) || x < 0) {
+      throw new Error(
+        `permutation: x must be a non-negative integer, got ${x}`,
+      );
+    }
+    return argsort(uniform(key, [x])).astype(DType.Int32);
+  }
+
+  const arr = fudgeArray(x);
+  axis = checkAxis(axis, arr.ndim);
+  const perm = permutation(key, arr.shape[axis]);
+  const index: any[] = JsArray(axis).fill([]);
+  index.push(perm);
+  return arr.slice(...index);
+}
+
+/**
+ * @function
+ * Sample Rademacher random values, uniformly from {-1, 1}.
+ */
+export const rademacher = jit(
+  function rademacher(
+    key: Array,
+    {
+      shape = [],
+      dtype = DType.Int32,
+    }: { shape?: number[]; dtype?: DType } = {},
+  ): Array {
+    if (dtype === DType.Uint32 || dtype === DType.Bool) {
+      throw new Error(`rademacher: unsupported dtype ${dtype}`);
+    }
+    const one = array(1, { dtype, device: key.device });
+    const minusOne = array(-1, { dtype, device: key.device });
+    return where(bernoulli(key, 0.5, shape), one, minusOne);
+  },
+  { staticArgnums: [1] },
+);
+
+/**
+ * @function
+ * Sample integer values uniformly from `[minval, maxval)`.
+ *
+ * This uses modulo reduction of uniform 32-bit random bits. For ranges that do
+ * not divide 2^32, this introduces a very small modulo bias.
+ */
+export const randint = jit(
+  function randint(
+    key: Array,
+    {
+      minval,
+      maxval,
+      shape = [],
+      dtype = DType.Int32,
+    }: { minval: number; maxval: number; shape?: number[]; dtype?: DType },
+  ): Array {
+    if (!Number.isInteger(minval) || !Number.isInteger(maxval)) {
+      throw new Error("randint: minval and maxval must be integers");
+    }
+    if (minval >= maxval) {
+      throw new Error(`Invalid range: [${minval}, ${maxval}).`);
+    }
+    if (dtype !== DType.Int32 && dtype !== DType.Uint32) {
+      throw new Error(`randint: dtype must be int32 or uint32, got ${dtype}`);
+    }
+    if (dtype === DType.Uint32 && minval < 0) {
+      throw new Error("randint: uint32 dtype requires minval >= 0");
+    }
+    const range = maxval - minval;
+    return bits(key, shape).mod(range).astype(dtype).add(minval) as Array;
+  },
+  { staticArgnums: [1] },
+);
+
+/**
+ * @function
+ * Sample Rayleigh random values with the provided scale parameter.
+ */
+export const rayleigh = jit(
+  function rayleigh(
+    key: Array,
+    scale: ArrayLike = 1,
+    shape: number[] = [],
+  ): Array {
+    scale = fudgeArray(scale);
+    return sqrt(exponential(key, shape).mul(2)).mul(scale);
+  },
+  { staticArgnums: [2] },
+);
+
+/**
+ * @function
+ * Sample triangular random values on `[left, right]` with the given mode.
+ */
+export const triangular = jit(
+  function triangular(
+    key: Array,
+    left: ArrayLike,
+    mode: ArrayLike,
+    right: ArrayLike,
+    shape: number[] = [],
+  ): Array {
+    left = fudgeArray(left);
+    mode = fudgeArray(mode);
+    right = fudgeArray(right);
+
+    const u = uniform(key, shape);
+    const width = right.ref.sub(left.ref);
+    const leftSpan = mode.ref.sub(left.ref);
+    const rightSpan = right.ref.sub(mode);
+    const cutoff = leftSpan.ref.div(width.ref);
+    const cond = u.ref.less(cutoff);
+    const lower = left.add(sqrt(u.ref.mul(width.ref).mul(leftSpan)));
+    const upper = right.sub(sqrt(negative(u).add(1).mul(width).mul(rightSpan)));
+    return where(cond, lower, upper);
+  },
+  { staticArgnums: [4] },
+);
+
+/**
+ * @function
+ * Sample Weibull minimum random values.
+ *
+ * Uses `scale * exponential(key) ** (1 / concentration)`.
+ */
+export const weibullMin = jit(
+  function weibullMin(
+    key: Array,
+    scale: ArrayLike,
+    concentration: ArrayLike,
+    shape: number[] = [],
+  ): Array {
+    scale = fudgeArray(scale);
+    concentration = fudgeArray(concentration);
+    return scale.mul(exp(log(exponential(key, shape)).div(concentration)));
+  },
+  { staticArgnums: [3] },
 );

--- a/test/random.test.ts
+++ b/test/random.test.ts
@@ -401,6 +401,184 @@ suite.each(devices)("device:%s", (device) => {
       expect(variance).toBeCloseTo(Math.PI ** 2 / 6, 1);
     });
 
+    test("randint distribution", () => {
+      const samples: number[] = random
+        .randint(random.key(1201), { minval: -3, maxval: 7, shape: [5000] })
+        .js();
+      const counts = Array(10).fill(0);
+      for (const x of samples) {
+        expect(Number.isInteger(x)).toBe(true);
+        expect(x).toBeGreaterThanOrEqual(-3);
+        expect(x).toBeLessThan(7);
+        counts[x + 3]++;
+      }
+      for (const count of counts)
+        expect(count / samples.length).toBeCloseTo(0.1, 1);
+    });
+
+    test("rademacher distribution", () => {
+      const count = 5000;
+      const samples: number[] = random
+        .rademacher(random.key(1202), { shape: [count] })
+        .js();
+      const mean = samples.reduce((a, b) => a + b, 0) / count;
+      for (const x of samples) expect([-1, 1]).toContain(x);
+      expect(mean).toBeWithinRange(-0.08, 0.08);
+    });
+
+    test("logistic distribution", () => {
+      const count = 10000;
+      const samples: number[] = random.logistic(random.key(1203), [count]).js();
+      const mean = samples.reduce((a, b) => a + b, 0) / count;
+      const variance =
+        samples.reduce((a, b) => a + (b - mean) ** 2, 0) / (count - 1);
+      expect(mean).toBeWithinRange(-0.1, 0.1);
+      expect(variance).toBeWithinRange(3.0, 3.6); // pi^2 / 3
+    });
+
+    test("lognormal distribution", () => {
+      const count = 10000;
+      const samples: number[] = random
+        .lognormal(random.key(1204), 1, [count])
+        .js();
+      const mean = samples.reduce((a, b) => a + b, 0) / count;
+      expect(samples.every((x) => x > 0)).toBe(true);
+      expect(mean).toBeWithinRange(1.45, 1.85); // exp(1/2)
+    });
+
+    test("rayleigh distribution", () => {
+      const count = 10000;
+      const scale = 2;
+      const samples: number[] = random
+        .rayleigh(random.key(1205), scale, [count])
+        .js();
+      const mean = samples.reduce((a, b) => a + b, 0) / count;
+      expect(samples.every((x) => x >= 0)).toBe(true);
+      expect(mean).toBeWithinRange(2.35, 2.65); // scale * sqrt(pi / 2)
+    });
+
+    test("pareto distribution", () => {
+      const count = 10000;
+      const samples: number[] = random
+        .pareto(random.key(1206), 3, [count])
+        .js();
+      const mean = samples.reduce((a, b) => a + b, 0) / count;
+      expect(samples.every((x) => x >= 1)).toBe(true);
+      expect(mean).toBeWithinRange(1.35, 1.65); // b / (b - 1)
+    });
+
+    test("weibullMin distribution", () => {
+      const count = 10000;
+      const samples: number[] = random
+        .weibullMin(random.key(1207), 2, 1, [count])
+        .js();
+      const mean = samples.reduce((a, b) => a + b, 0) / count;
+      expect(samples.every((x) => x >= 0)).toBe(true);
+      expect(mean).toBeWithinRange(1.8, 2.2); // concentration=1 => exponential(scale)
+    });
+
+    test("geometric distribution", () => {
+      const count = 10000;
+      const samples: number[] = random
+        .geometric(random.key(1208), 0.25, { shape: [count] })
+        .js();
+      const mean = samples.reduce((a, b) => a + b, 0) / count;
+      for (const x of samples) {
+        expect(Number.isInteger(x)).toBe(true);
+        expect(x).toBeGreaterThanOrEqual(1);
+      }
+      expect(mean).toBeWithinRange(3.7, 4.3); // 1 / p
+    });
+
+    test("triangular distribution", () => {
+      const count = 10000;
+      const samples: number[] = random
+        .triangular(random.key(1209), -1, 0, 2, [count])
+        .js();
+      const mean = samples.reduce((a, b) => a + b, 0) / count;
+      expect(samples.every((x) => x >= -1 && x <= 2)).toBe(true);
+      expect(mean).toBeWithinRange(0.23, 0.43); // (left + mode + right) / 3
+    });
+
+    test("maxwell distribution", () => {
+      const count = 10000;
+      const samples: number[] = random.maxwell(random.key(1210), [count]).js();
+      const mean = samples.reduce((a, b) => a + b, 0) / count;
+      expect(samples.every((x) => x >= 0)).toBe(true);
+      expect(mean).toBeWithinRange(1.45, 1.75); // 2 * sqrt(2 / pi)
+    });
+
+    test("doubleSidedMaxwell distribution", () => {
+      const count = 10000;
+      const samples: number[] = random
+        .doubleSidedMaxwell(random.key(1211), 0, 1, [count])
+        .js();
+      const mean = samples.reduce((a, b) => a + b, 0) / count;
+      const absMean = samples.reduce((a, b) => a + Math.abs(b), 0) / count;
+      expect(mean).toBeWithinRange(-0.12, 0.12);
+      expect(absMean).toBeWithinRange(1.45, 1.75);
+    });
+
+    test("ball distribution", () => {
+      const count = 5000;
+      const d = 3;
+      const samples: number[][] = random
+        .ball(random.key(1212), d, { shape: [count] })
+        .js();
+      expect(samples).toHaveLength(count);
+      expect(samples[0]).toHaveLength(d);
+      let meanRadius2 = 0;
+      for (const x of samples) {
+        const r2 = x.reduce((a, b) => a + b * b, 0);
+        expect(r2).toBeLessThanOrEqual(1.0001);
+        meanRadius2 += r2;
+      }
+      meanRadius2 /= count;
+      expect(meanRadius2).toBeWithinRange(0.55, 0.65); // d / (d + 2)
+    });
+
+    test("choice with replacement", () => {
+      const samples: number[] = random
+        .choice(random.key(1213), 5, { shape: [200] })
+        .js();
+      for (const x of samples) {
+        expect(Number.isInteger(x)).toBe(true);
+        expect(x).toBeGreaterThanOrEqual(0);
+        expect(x).toBeLessThan(5);
+      }
+
+      const values = np.array([10, 20, 30, 40, 50]);
+      const picked: number[] = random
+        .choice(random.key(1214), values, { shape: [200] })
+        .js();
+      for (const x of picked) expect([10, 20, 30, 40, 50]).toContain(x);
+    });
+
+    // Permutation and sampling without replacement rely on argsort, unsupported on webgl.
+    if (device !== "webgl") {
+      test("permutation", () => {
+        const p: number[] = random.permutation(random.key(1215), 8).js();
+        expect(p.toSorted((a, b) => a - b)).toEqual([0, 1, 2, 3, 4, 5, 6, 7]);
+
+        const values = np.array([10, 20, 30, 40]);
+        const permuted: number[] = random
+          .permutation(random.key(1216), values)
+          .js();
+        expect(permuted.toSorted((a, b) => a - b)).toEqual([10, 20, 30, 40]);
+      });
+
+      test("choice without replacement", () => {
+        const samples: number[] = random
+          .choice(random.key(1217), 6, { shape: [4], replace: false })
+          .js();
+        expect(new Set(samples).size).toBe(4);
+        for (const x of samples) {
+          expect(x).toBeGreaterThanOrEqual(0);
+          expect(x).toBeLessThan(6);
+        }
+      });
+    }
+
     if (device === "cpu" || device === "wasm") {
       // TODO: cholesky not yet supported on webgpu
       test("multivariate normal distribution", () => {


### PR DESCRIPTION
 ## Summary                                                                                                                       
                                                                                                                                    
Adds several easy `jax.random` samplers implemented via existing primitives / transformed distributions:                         
                                                                                                                                
- `ball`                                                                                                                         
- `choice`                                                                                                                       
- `doubleSidedMaxwell`                                                                                                           
- `geometric`                                                                                                                    
- `logistic`                                                                                                                     
- `lognormal`                                                                                                                    
- `maxwell`                                                                                                                      
- `pareto`                                                                                                                       
- `permutation`                                                                                                                  
- `rademacher`                                                                                                                   
- `randint`                                                                                                                      
- `rayleigh`                                                                                                                     
- `triangular`                                                                                                                   
- `weibullMin`                                                                                                                   
                                                                                                                                
Also updates `FEATURES.md` support status and adds distribution/property tests.                                                  
                                                                                                                                
## Notes                                                                                                                         
                                                                                                                                
- Functions after `uniform()` are organized alphabetically.                                                                      
- Multi-static-argument APIs use params objects where appropriate, e.g. `randint(key, { minval, maxval, shape })`.               
- JS exports remain camelCase; no underscored re-exports were added.                                                             
                                                                                                                                
## Test plan                                                                                                                     
                                                                                                                                
- `pnpm check`                                                                                                                   
- `pnpm test --run test/random.test.ts --reporter=dot`    