### PR TITLE
bugfix: SharedArrayBuffer not found in Wasm

### DIFF
--- a/src/backend/wasm.ts
+++ b/src/backend/wasm.ts
@@ -575,7 +575,7 @@ export class WasmBackend implements Backend {
     const buffer = this.#getBuffer(slot);
     if (start === undefined) start = 0;
     if (count === undefined) count = buffer.byteLength - start;
-    if (buffer.buffer instanceof SharedArrayBuffer) {
+    if (hasSharedArrayBuffer() && buffer.buffer instanceof SharedArrayBuffer) {
       // For SharedArrayBuffer, we need to copy the data to ArrayBuffer.
       return new Uint8Array(buffer.slice(start, start + count));
     } else {


### PR DESCRIPTION
This was throwing an exception in `instanceof` since the class needs to be present at runtime. SharedArrayBuffer is only available in cross-origin isolated contexts