### PR TITLE
Make WebGPU 3x faster on matvec

### DIFF
--- a/bench/matvec-webgpu.bench.ts
+++ b/bench/matvec-webgpu.bench.ts
@@ -1,0 +1,43 @@
+import {
+  blockUntilReady,
+  defaultDevice,
+  init,
+  numpy as np,
+  random,
+} from "@jax-js/jax";
+import { afterAll, bench, suite } from "vitest";
+
+const devices = await init("webgpu");
+const MATVEC_SIZES = [512, 1024, 2048, 4096] as const;
+
+suite.skipIf(!devices.includes("webgpu"))("webgpu fp32 matvec", async () => {
+  defaultDevice("webgpu");
+
+  const inputs = MATVEC_SIZES.map((n) => ({
+    n,
+    a: random.uniform(random.key(0), [n, n]),
+    x: random.uniform(random.key(1), [n]),
+  }));
+  await blockUntilReady(inputs.flatMap(({ a, x }) => [a, x]));
+
+  afterAll(() => {
+    for (const { a, x } of inputs) {
+      a.dispose();
+      x.dispose();
+    }
+  });
+
+  for (const { n, a, x } of inputs) {
+    bench(`${n}x${n} @ vector`, async () => {
+      const y = np.matvec(a.ref, x.ref);
+      await y.blockUntilReady();
+      y.dispose();
+    });
+
+    bench(`${n}x${n}.T @ vector`, async () => {
+      const y = np.matvec(a.ref.transpose(), x.ref);
+      await y.blockUntilReady();
+      y.dispose();
+    });
+  }
+});

--- a/src/backend/webgpu.ts
+++ b/src/backend/webgpu.ts
@@ -7,6 +7,7 @@ import {
   calculateGrid,
   constToWgsl,
   dtypeToWgsl,
+  reduceOpWgsl,
   ShaderInfo,
   WgslBuilder,
   WgslExpCodegen,
@@ -318,30 +319,74 @@ function pipelineSource(device: GPUDevice, kernel: Kernel): ShaderInfo {
     `@group(0) @binding(${nargs}) var<storage, read_write> result : array<${resultTy}>;`,
   );
 
-  const workgroupSize = findPow2(tune.threadCount, 256);
+  const groupCount = re ? (tune.size.groups ?? 1) : 1;
+  const groupedReduction = re && groupCount > 1;
+  if (groupedReduction && tune.threadCount % groupCount !== 0) {
+    throw new Error("WebGPU grouped reduction has invalid thread count");
+  }
+  if (groupedReduction && groupCount > device.limits.maxComputeWorkgroupSizeX) {
+    throw new Error("WebGPU grouped reduction exceeds workgroup size limit");
+  }
+  const workgroupSize = groupedReduction
+    ? groupCount
+    : findPow2(tune.threadCount, 256);
 
   // Determine grid size, may need to be 3D due to limits on X.
   // maxComputeWorkgroupsPerDimension ~ 65535, so we use 16384 when exceeded.
-  const gridSize = Math.ceil(tune.threadCount / workgroupSize);
+  const gridSize = groupedReduction
+    ? tune.threadCount / groupCount
+    : Math.ceil(tune.threadCount / workgroupSize);
   const [gridX, gridY] = calculateGrid(gridSize);
 
-  wb.emit(
-    "",
-    `@compute @workgroup_size(${workgroupSize})`,
-    "fn main(@builtin(global_invocation_id) id : vec3<u32>) {",
-    wb.pushIndent,
-  );
-  if (gridY === 1) {
+  if (groupedReduction) {
+    const partialTy = dtypeToWgsl(re.dtype);
+    for (let i = 0; i < (tune.size.upcast ?? 1); i++) {
+      wb.emit(
+        `var<workgroup> partial${i}: array<${partialTy}, ${groupCount}>;`,
+      );
+    }
+  }
+
+  wb.emit("", `@compute @workgroup_size(${workgroupSize})`);
+  if (groupedReduction) {
     wb.emit(
-      `if (id.x >= ${tune.threadCount}) { return; }`,
-      "let gidx: i32 = i32(id.x);",
+      "fn main(",
+      wb.pushIndent,
+      "@builtin(local_invocation_id) lid : vec3<u32>,",
+      "@builtin(workgroup_id) wg_id : vec3<u32>,",
+      wb.popIndent,
+      ") {",
+      wb.pushIndent,
     );
+    if (gridY === 1) {
+      wb.emit(
+        `if (wg_id.x >= ${gridSize}u) { return; }`,
+        "let gidx: i32 = i32(wg_id.x);",
+      );
+    } else {
+      wb.emit(
+        `if (${gridX}u * wg_id.y + wg_id.x >= ${gridSize}u) { return; }`,
+        `let gidx: i32 = i32(${gridX}u * wg_id.y + wg_id.x);`,
+      );
+    }
+    wb.emit("let group: i32 = i32(lid.x);");
   } else {
-    const sizeX = gridX * workgroupSize;
     wb.emit(
-      `if (${sizeX} * id.y + id.x >= ${tune.threadCount}) { return; }`,
-      `let gidx: i32 = i32(${sizeX} * id.y + id.x);`,
+      "fn main(@builtin(global_invocation_id) id : vec3<u32>) {",
+      wb.pushIndent,
     );
+    if (gridY === 1) {
+      wb.emit(
+        `if (id.x >= ${tune.threadCount}) { return; }`,
+        "let gidx: i32 = i32(id.x);",
+      );
+    } else {
+      const sizeX = gridX * workgroupSize;
+      wb.emit(
+        `if (${sizeX} * id.y + id.x >= ${tune.threadCount}) { return; }`,
+        `let gidx: i32 = i32(${sizeX} * id.y + id.x);`,
+      );
+    }
   }
 
   wb.emitPhonyAssignments(args);
@@ -353,9 +398,6 @@ function pipelineSource(device: GPUDevice, kernel: Kernel): ShaderInfo {
     if (resultTy !== dtypeToWgsl(tune.exp.dtype)) rhs = `${resultTy}(${rhs})`;
     wb.emit(`result[gidx] = ${rhs};`);
   } else {
-    if ((tune.size.groups ?? 1) > 1) {
-      throw new Error("WebGPU backend does not support group optimization yet");
-    }
     const unroll = tune.size.unroll ?? 1;
     const upcast = tune.size.upcast ?? 1;
 
@@ -423,6 +465,26 @@ function pipelineSource(device: GPUDevice, kernel: Kernel): ShaderInfo {
     }
     wb.emit(wb.popIndent, "}");
 
+    if (groupedReduction) {
+      for (let i = 0; i < upcast; i++)
+        wb.emit(`partial${i}[lid.x] = ${acc[i]};`);
+      wb.emit("workgroupBarrier();");
+      for (let stride = groupCount / 2; stride >= 1; stride /= 2) {
+        wb.emit(`if (lid.x < ${stride}u) {`, wb.pushIndent);
+        for (let i = 0; i < upcast; i++) {
+          wb.emit(
+            `partial${i}[lid.x] = ${reduceOpWgsl(
+              re.op,
+              re.dtype,
+              `partial${i}[lid.x]`,
+              `partial${i}[lid.x + ${stride}u]`,
+            )};`,
+          );
+        }
+        wb.emit(wb.popIndent, "}", "workgroupBarrier();");
+      }
+    }
+
     // Exited the reduction loop scope. Erase any local variables.
     gen.reset();
 
@@ -442,6 +504,10 @@ function pipelineSource(device: GPUDevice, kernel: Kernel): ShaderInfo {
       );
       gen.countReferences(fusionExps[i]);
     }
+    if (groupedReduction) {
+      wb.emit("if (lid.x == 0u) {", wb.pushIndent);
+      for (let i = 0; i < upcast; i++) wb.emit(`${acc[i]} = partial${i}[0u];`);
+    }
     for (let i = 0; i < upcast; i++) {
       const index = strip1(gen.run(outputIdxExps[i]));
       let rhs = strip1(gen.run(fusionExps[i]));
@@ -449,6 +515,7 @@ function pipelineSource(device: GPUDevice, kernel: Kernel): ShaderInfo {
         rhs = `${resultTy}(${rhs})`;
       wb.emit(`result[${index}] = ${rhs};`);
     }
+    if (groupedReduction) wb.emit(wb.popIndent, "}");
   }
 
   wb.emit(wb.popIndent, "}");

--- a/src/backend/webgpu/codegen.ts
+++ b/src/backend/webgpu/codegen.ts
@@ -128,6 +128,21 @@ export function constToWgsl(dtype: DType, value: any): string {
   throw new Error(`Unsupported const dtype: ${dtype}`);
 }
 
+export function reduceOpWgsl(
+  op: AluOp,
+  dtype: DType,
+  a: string,
+  b: string,
+): string {
+  if (op === AluOp.Add) return `(${a} + ${b})`;
+  if (op === AluOp.Mul) return `(${a} * ${b})`;
+  if (op === AluOp.Min)
+    return dtype === DType.Bool ? `(${a} && ${b})` : `min(${a}, ${b})`;
+  if (op === AluOp.Max)
+    return dtype === DType.Bool ? `(${a} || ${b})` : `max(${a}, ${b})`;
+  throw new Error(`Unsupported reduction op: ${op}`);
+}
+
 /** Codegen for WebGPU expressions, linearizing AluOp into a kernel. */
 export class WgslExpCodegen {
   #gensymCount = 0;

--- a/src/tuner.ts
+++ b/src/tuner.ts
@@ -187,6 +187,32 @@ class TuneDims {
       this.upcast++;
     }
   }
+
+  applyGroup(axis: number, amount: number) {
+    if (axis < this.reduce || axis >= this.unroll) {
+      throw new Error("Can only group reduction axes");
+    }
+    const length = this.st.shape[axis];
+    if (length % amount !== 0)
+      throw new Error(`Group by ${amount} on axis length ${length}`);
+
+    this.st = this.st
+      .reshape([
+        ...this.st.shape.slice(0, axis),
+        length / amount,
+        amount,
+        ...this.st.shape.slice(axis + 1),
+      ])
+      .permute([
+        ...range(this.reduce),
+        axis + 1,
+        ...range(this.reduce, axis + 1),
+        ...range(axis + 2, this.st.shape.length + 1),
+      ]);
+    this.reduce++;
+    this.unroll++;
+    this.upcast++;
+  }
 }
 
 /** Tuning step that does not apply any optimization. */
@@ -294,6 +320,28 @@ export function tuneWebgpu(kernel: Kernel): TuneResult {
     } else {
       break;
     }
+  }
+
+  // Group optimization for matvec, splitting k into multiple threads inside a
+  // workgroup to increase occupancy.
+  const groupCandidateSts = sts.map((st) => st.compose(dim.st));
+  const groupCandidateHasContiguousInputs = groupCandidateSts.every((st) => {
+    const hasOutputStride = st.lastStrides
+      .slice(0, dim.groups)
+      .some((stride) => stride !== 0);
+    return !hasOutputStride || Math.abs(st.lastStrides[dim.reduce]) <= 1;
+  });
+  if (
+    reduction.op === AluOp.Add &&
+    reduction.dtype === DType.Float32 &&
+    groupCandidateHasContiguousInputs &&
+    prod(dim.st.shape.slice(0, dim.groups)) < 4096 &&
+    prod(dim.st.shape.slice(dim.reduce, dim.unroll)) >= 512
+  ) {
+    const axis = dim.reduce;
+    let amount = 16;
+    while (amount > 1 && dim.st.shape[axis] % amount !== 0) amount /= 2;
+    if (amount > 1) dim.applyGroup(axis, amount);
   }
 
   // Try to do loop unrolling on the reduce axis, with an upcast limit.


### PR DESCRIPTION
Uses "grouping" - have multiple threads in the workgroup contribute to computing each element of the output vector. This improves occupancy for matvec, and we get to around 30 GFLOPs/s on a 4096x4096 matrix-vector product.