### PR TITLE
Performance and JIT improvements

### DIFF
--- a/src/backend/wasm/codegen.ts
+++ b/src/backend/wasm/codegen.ts
@@ -302,9 +302,14 @@ export function codegenWasm(kernel: Kernel): WasmCodegenResult {
               : ({ kind: "contiguous", tileSize: Infinity } as const),
         }))
       : [];
+  const canStoreSimdPartials =
+    hasIdentityEpilogue ||
+    (re !== undefined &&
+      kernel.dtype === re.dtype &&
+      byteWidth(kernel.dtype) === 4);
   const simdTilePlan =
-    useSimd && re && hasIdentityEpilogue
-      ? reductionTilePlan(kernel, expStrides)
+    useSimd && re
+      ? reductionTilePlan(kernel, expStrides, canStoreSimdPartials)
       : null;
   const kSimdTilePlan =
     reductionHasLaneGather && useKSimdReduction
@@ -415,22 +420,87 @@ export function codegenWasm(kernel: Kernel): WasmCodegenResult {
       return local;
     };
 
-    const emitLoopWhileLt = (
-      index: number,
-      emitBound: () => void,
+    const emitLoopWithBreaks = (
+      emitBreaks: () => void,
       emitBody: () => void,
     ) => {
       cg.loop(cg.void);
       cg.block(cg.void);
-      cg.local.get(index);
-      emitBound();
-      cg.i32.ge_u();
-      cg.br_if(0);
+      emitBreaks();
       emitBody();
       cg.br(1);
       cg.end();
       cg.end();
     };
+
+    const emitLoopWhileLt = (
+      index: number,
+      emitBound: () => void,
+      emitBody: () => void,
+    ) =>
+      emitLoopWithBreaks(() => {
+        cg.local.get(index);
+        emitBound();
+        cg.i32.ge_u();
+        cg.br_if(0);
+      }, emitBody);
+
+    const emitLoopWhileLtAndConstLt = (
+      index: number,
+      emitBound: () => void,
+      constBound: number,
+      emitBody: () => void,
+    ) =>
+      emitLoopWithBreaks(() => {
+        cg.local.get(index);
+        emitBound();
+        cg.i32.ge_u();
+        cg.br_if(0);
+        cg.local.get(index);
+        cg.i32.const(constBound);
+        cg.i32.ge_u();
+        cg.br_if(0);
+      }, emitBody);
+
+    const emitLoopWhileBlockFits = (
+      index: number,
+      blockSize: number,
+      emitBound: () => void,
+      constBound: number,
+      emitBody: () => void,
+    ) =>
+      emitLoopWithBreaks(() => {
+        emitLocalPlusConst(index, blockSize);
+        emitBound();
+        cg.i32.gt_u();
+        cg.br_if(0);
+        emitLocalPlusConst(index, blockSize);
+        cg.i32.const(constBound);
+        cg.i32.gt_u();
+        cg.br_if(0);
+      }, emitBody);
+
+    const emitRowTileLoop = (
+      rowOffset: number,
+      rowTileBase: number,
+      tileRows: number,
+      tileSize: number,
+      emitBody: () => void,
+    ) =>
+      emitLoopWithBreaks(() => {
+        cg.local.get(rowOffset);
+        cg.i32.const(tileRows);
+        cg.i32.ge_u();
+        cg.br_if(0);
+        cg.local.get(rowTileBase);
+        cg.local.get(rowOffset);
+        cg.i32.const(tileSize);
+        cg.i32.mul();
+        cg.i32.add();
+        cg.local.get(paramEnd);
+        cg.i32.ge_u();
+        cg.br_if(0);
+      }, emitBody);
 
     const emitLoopWhileLocalLt = (
       index: number,
@@ -563,42 +633,63 @@ export function codegenWasm(kernel: Kernel): WasmCodegenResult {
         emitLoopWhileConstLt(ridx, re.size, emitReductionLoopBody);
       else emitLoopWhileLocalLt(ridx, ridxEnd, emitReductionLoopBody);
 
-      if (hasIdentityEpilogue) {
+      const storeRawAccumulators = () => {
         for (let i = 0; i < gidxs.length; i++) {
           emitOutputAddress(gidxs[i]);
           cg.local.get(vecAccs[i]);
           cg.v128.store(4);
         }
+      };
+
+      if (hasIdentityEpilogue) {
+        storeRawAccumulators();
         return;
       }
 
-      const laneGidx = cg.local.declare(cg.i32);
-      const laneAcc = cg.local.declare(reIsInt ? cg.i32 : cg.f32);
-      for (let i = 0; i < gidxs.length; i++) {
-        for (let lane = 0; lane < simdLanes; lane++) {
-          cg.local.get(kernel.nargs);
-          cg.local.get(gidxs[i]);
-          if (lane > 0) {
-            cg.i32.const(lane);
+      const storeEpilogueAccumulators = () => {
+        const laneGidx = cg.local.declare(cg.i32);
+        const laneAcc = cg.local.declare(reIsInt ? cg.i32 : cg.f32);
+        for (let i = 0; i < gidxs.length; i++) {
+          for (let lane = 0; lane < simdLanes; lane++) {
+            cg.local.get(kernel.nargs);
+            cg.local.get(gidxs[i]);
+            if (lane > 0) {
+              cg.i32.const(lane);
+              cg.i32.add();
+            }
+
+            cg.local.tee(laneGidx);
+            cg.i32.const(byteWidth(kernel.dtype));
+            cg.i32.mul();
             cg.i32.add();
+
+            cg.local.get(vecAccs[i]);
+            if (reIsInt) cg.i32x4.extract_lane(lane);
+            else cg.f32x4.extract_lane(lane);
+            cg.local.set(laneAcc);
+            translateExp(cg, funcs, tune.epilogue!, {
+              acc: laneAcc,
+              gidx: laneGidx,
+            });
+
+            dty(cg, null, kernel.dtype).store(
+              Math.log2(byteWidth(kernel.dtype)),
+            );
           }
-
-          cg.local.tee(laneGidx);
-          cg.i32.const(byteWidth(kernel.dtype));
-          cg.i32.mul();
-          cg.i32.add();
-
-          cg.local.get(vecAccs[i]);
-          if (reIsInt) cg.i32x4.extract_lane(lane);
-          else cg.f32x4.extract_lane(lane);
-          cg.local.set(laneAcc);
-          translateExp(cg, funcs, tune.epilogue!, {
-            acc: laneAcc,
-            gidx: laneGidx,
-          });
-
-          dty(cg, null, kernel.dtype).store(Math.log2(byteWidth(kernel.dtype)));
         }
+      };
+
+      if (ridxEnd !== undefined) {
+        cg.local.get(ridxEnd);
+        cg.i32.const(re.size);
+        cg.i32.lt_u();
+        cg.if(cg.void);
+        storeRawAccumulators();
+        cg.else();
+        storeEpilogueAccumulators();
+        cg.end();
+      } else {
+        storeEpilogueAccumulators();
       }
     };
 
@@ -641,20 +732,6 @@ export function codegenWasm(kernel: Kernel): WasmCodegenResult {
       }
 
       return { pointerMaps, uniquePointers };
-    };
-
-    const emitSimdReductionStep = () => {
-      const groups = [{ gidx, row: 0, vector: 0 }];
-      const { pointerMaps, uniquePointers } = initializePointerMaps(
-        groups,
-        simdReductionPointerCandidates,
-        (candidate, group, i) =>
-          pointerShareKey(candidate, group.row, group.vector, i),
-        (group) => ({ gidx: group.gidx }),
-      );
-      emitSimdReductionForGidxs([gidx], pointerMaps, uniquePointers);
-
-      bumpLocal(gidx, simdLanes);
     };
 
     const emitElementwiseSimdStep = () => {
@@ -768,19 +845,26 @@ export function codegenWasm(kernel: Kernel): WasmCodegenResult {
         setLocalConst(colTile, 0);
         emitLoopWhileConstLt(colTile, plan.tileSize, () => {
           setLocalConst(rowOffset, 0);
-          emitLoopWhileConstLt(rowOffset, plan.tileRows, () => {
-            copyLocal(col, colTile);
-            emitLoopWhileLt(
-              col,
-              () => emitLocalPlusConst(colTile, plan.tileCols),
-              () => {
-                setRowBase(rowBase, rowTileBase, rowOffset, plan.tileSize);
-                emitBlock();
-                bumpLocal(col, plan.microCols);
-              },
-            );
-            bumpLocal(rowOffset, plan.microRows);
-          });
+          emitRowTileLoop(
+            rowOffset,
+            rowTileBase,
+            plan.tileRows,
+            plan.tileSize,
+            () => {
+              copyLocal(col, colTile);
+              emitLoopWhileLtAndConstLt(
+                col,
+                () => emitLocalPlusConst(colTile, plan.tileCols),
+                plan.tileSize,
+                () => {
+                  setRowBase(rowBase, rowTileBase, rowOffset, plan.tileSize);
+                  emitBlock();
+                  bumpLocal(col, plan.microCols);
+                },
+              );
+              bumpLocal(rowOffset, plan.microRows);
+            },
+          );
           bumpLocal(colTile, plan.tileCols);
         });
         bumpLocal(gidx, plan.tileRows * plan.tileSize);
@@ -796,10 +880,10 @@ export function codegenWasm(kernel: Kernel): WasmCodegenResult {
       const rowOffset = cg.local.declare(cg.i32);
       const rowBase = cg.local.declare(cg.i32);
 
-      const emitRowBlock = () => {
+      const emitRowBlock = (microVectors: number) => {
         const groups: ReductionGroup[] = [];
         for (let row = 0; row < plan.microRows; row++) {
-          for (let vector = 0; vector < plan.microVectors; vector++) {
+          for (let vector = 0; vector < microVectors; vector++) {
             groups.push({
               gidx: declareTileGidx(
                 rowBase,
@@ -841,19 +925,39 @@ export function codegenWasm(kernel: Kernel): WasmCodegenResult {
             cg.local.set(tileEnd);
 
             setLocalConst(rowOffset, 0);
-            emitLoopWhileConstLt(rowOffset, plan.tileRows, () => {
-              copyLocal(col, colTile);
-              emitLoopWhileLt(
-                col,
-                () => emitLocalPlusConst(colTile, plan.tileVectors * simdLanes),
-                () => {
-                  setRowBase(rowBase, rowTileBase, rowOffset, plan.tileSize);
-                  emitRowBlock();
-                  bumpLocal(col, plan.microVectors * simdLanes);
-                },
-              );
-              bumpLocal(rowOffset, plan.microRows);
-            });
+            emitRowTileLoop(
+              rowOffset,
+              rowTileBase,
+              plan.tileRows,
+              plan.tileSize,
+              () => {
+                copyLocal(col, colTile);
+                emitLoopWhileBlockFits(
+                  col,
+                  plan.microVectors * simdLanes,
+                  () =>
+                    emitLocalPlusConst(colTile, plan.tileVectors * simdLanes),
+                  plan.tileSize,
+                  () => {
+                    setRowBase(rowBase, rowTileBase, rowOffset, plan.tileSize);
+                    emitRowBlock(plan.microVectors);
+                    bumpLocal(col, plan.microVectors * simdLanes);
+                  },
+                );
+                emitLoopWhileLtAndConstLt(
+                  col,
+                  () =>
+                    emitLocalPlusConst(colTile, plan.tileVectors * simdLanes),
+                  plan.tileSize,
+                  () => {
+                    setRowBase(rowBase, rowTileBase, rowOffset, plan.tileSize);
+                    emitRowBlock(1);
+                    bumpLocal(col, simdLanes);
+                  },
+                );
+                bumpLocal(rowOffset, plan.microRows);
+              },
+            );
             bumpLocal(kTile, plan.tileK);
           });
           bumpLocal(colTile, plan.tileVectors * simdLanes);
@@ -870,25 +974,25 @@ export function codegenWasm(kernel: Kernel): WasmCodegenResult {
     };
 
     if (kSimdTilePlan) {
-      emitGuardedFastPath(kSimdTilePlan.tileRows * kSimdTilePlan.tileSize, () =>
-        emitKSimdReductionLoop(kSimdTilePlan),
+      emitGuardedFastPath(
+        kSimdTilePlan.microRows * kSimdTilePlan.tileSize,
+        () => emitKSimdReductionLoop(kSimdTilePlan),
       );
     }
 
     if (useSimd) {
       if (simdTilePlan) {
-        emitGuardedFastPath(simdTilePlan.tileRows * simdTilePlan.tileSize, () =>
-          emitTiledSimdReductionLoop(simdTilePlan),
+        emitGuardedFastPath(
+          simdTilePlan.microRows * simdTilePlan.tileSize,
+          () => emitTiledSimdReductionLoop(simdTilePlan),
         );
       }
 
-      emitGuardedFastPath(simdLanes, () => {
-        emitLoopWhileLocalLt(
-          gidx,
-          paramEnd,
-          re ? emitSimdReductionStep : emitElementwiseSimdStep,
-        );
-      });
+      if (!re) {
+        emitGuardedFastPath(simdLanes, () => {
+          emitLoopWhileLocalLt(gidx, paramEnd, emitElementwiseSimdStep);
+        });
+      }
     }
 
     emitLoopWhileLocalLt(gidx, paramEnd, () => {

--- a/src/backend/wasm/tilePlan.ts
+++ b/src/backend/wasm/tilePlan.ts
@@ -1,4 +1,5 @@
 import { AluExp, AluOp, byteWidth, DType, Kernel } from "../../alu";
+import { findPow2, gcd } from "../../utils";
 
 export const simdLanes = 4;
 
@@ -41,8 +42,7 @@ const TILED_SIMD_MICRO_ROWS = 4;
 const TILED_SIMD_MICRO_VECTORS = 4;
 const K_SIMD_MICRO_ROWS = 4;
 const K_SIMD_MICRO_COLS = 4;
-const K_SIMD_UNROLL = 4;
-const TILE_AXIS_PARTS = 8;
+const K_SIMD_MAX_UNROLL = 4;
 
 function isSymbol(exp: AluExp, name: string): boolean {
   return (
@@ -120,13 +120,6 @@ function divisorAtMost(value: number, limit: number): number {
   return 1;
 }
 
-function tileAxisLimit(axisSize: number, maxTileSize: number): number {
-  return Math.min(
-    maxTileSize,
-    Math.max(1, Math.floor(axisSize / TILE_AXIS_PARTS)),
-  );
-}
-
 function commonTileSize(
   kernelSize: number,
   strideMap: Map<AluExp, StrideResult>,
@@ -152,18 +145,27 @@ function commonTileSize(
 }
 
 function tiledRows(kernelSize: number, tileSize: number): number {
-  const rowCount = kernelSize / tileSize;
-  return divisorAtMost(rowCount, tileAxisLimit(rowCount, TILED_SIMD_ROWS));
+  const rowCount = Math.floor(kernelSize / tileSize);
+  return findPow2(0, Math.max(1, Math.min(rowCount / 2, TILED_SIMD_ROWS)));
 }
 
-function tiledColumns(tileSize: number, laneWidth = 1): number {
-  return divisorAtMost(
-    tileSize / laneWidth,
+function tiledColumns(tileSize: number, laneWidth: number): number {
+  const columns = tileSize / laneWidth;
+  return findPow2(
+    0,
     Math.max(
       1,
-      Math.floor(tileAxisLimit(tileSize, TILED_SIMD_COLUMNS) / laneWidth),
+      Math.min(columns / 2, Math.floor(TILED_SIMD_COLUMNS / laneWidth)),
     ),
   );
+}
+
+function microTile(tile: number, axis: number, limit: number): number {
+  return divisorAtMost(gcd(tile, axis), limit);
+}
+
+function microTileWithTail(tile: number, limit: number): number {
+  return Math.max(1, Math.min(tile, limit));
 }
 
 function periodicStride(exp: AluExp, kind: "broadcast" | "contiguous") {
@@ -277,10 +279,11 @@ export function reductionPointerCandidates(
 export function reductionTilePlan(
   kernel: Kernel,
   strideMap: Map<AluExp, StrideResult>,
+  canStorePartial: boolean = true,
 ): ReductionTilePlan | null {
   if (!kernel.reduction) return null;
 
-  const tileSize = commonTileSize(kernel.size, strideMap, simdLanes);
+  const tileSize = commonTileSize(kernel.size, strideMap, simdLanes, simdLanes);
   if (tileSize === null) return null;
 
   const tileRows = tiledRows(kernel.size, tileSize);
@@ -289,9 +292,15 @@ export function reductionTilePlan(
     tileSize,
     tileRows,
     tileVectors,
-    tileK: divisorAtMost(kernel.reduction.size, TILED_SIMD_K),
-    microRows: divisorAtMost(tileRows, TILED_SIMD_MICRO_ROWS),
-    microVectors: divisorAtMost(tileVectors, TILED_SIMD_MICRO_VECTORS),
+    tileK: canStorePartial
+      ? divisorAtMost(kernel.reduction.size, TILED_SIMD_K)
+      : kernel.reduction.size,
+    microRows: microTile(
+      tileRows,
+      Math.floor(kernel.size / tileSize),
+      TILED_SIMD_MICRO_ROWS,
+    ),
+    microVectors: microTileWithTail(tileVectors, TILED_SIMD_MICRO_VECTORS),
   };
 }
 
@@ -300,20 +309,28 @@ export function reductionKTilePlan(
   strideMap: Map<AluExp, StrideResult>,
 ): ReductionKTilePlan | null {
   if (!kernel.reduction) return null;
-  if (kernel.reduction.size % (simdLanes * K_SIMD_UNROLL) !== 0) return null;
+  if (kernel.reduction.size % simdLanes !== 0) return null;
 
   const tileSize = commonTileSize(kernel.size, strideMap, 1, 1);
   if (tileSize === null) return null;
 
+  const kUnroll = divisorAtMost(
+    kernel.reduction.size / simdLanes,
+    K_SIMD_MAX_UNROLL,
+  );
   const tileRows = tiledRows(kernel.size, tileSize);
-  const tileCols = tiledColumns(tileSize);
+  const tileCols = tiledColumns(tileSize, 1);
   return {
     tileSize,
     tileRows,
     tileCols,
-    microRows: divisorAtMost(tileRows, K_SIMD_MICRO_ROWS),
-    microCols: divisorAtMost(tileCols, K_SIMD_MICRO_COLS),
-    kUnroll: K_SIMD_UNROLL,
+    microRows: microTile(
+      tileRows,
+      Math.floor(kernel.size / tileSize),
+      K_SIMD_MICRO_ROWS,
+    ),
+    microCols: microTile(tileCols, tileSize, K_SIMD_MICRO_COLS),
+    kUnroll,
   };
 }
 

--- a/src/frontend/jit.ts
+++ b/src/frontend/jit.ts
@@ -885,6 +885,67 @@ function splitGraphDataflow(backend: Backend, jaxpr: Jaxpr): Set<Var> {
     }
   }
 
+  // If a computed value is broadcast into a dot-style reduction, materialize it
+  // before the reduction. Otherwise it gets recomputed once for each output
+  // element that reuses it, e.g. softmax(scores) inside attention @ V, or
+  // an activation function from previous MLP layer.
+  const viewPrimitives = [
+    Primitive.Transpose,
+    Primitive.Broadcast,
+    Primitive.Reshape,
+    Primitive.Flip,
+    Primitive.Shrink,
+    Primitive.Pad,
+  ];
+  const materializeForReusedReduction = new Set<Var>();
+  const reductionInputHasReuse = (
+    shape: number[],
+    promoted: number[],
+  ): boolean => {
+    const offset = promoted.length - shape.length;
+    for (let axis = 0; axis < promoted.length - 1; axis++) {
+      const dim = axis < offset ? 1 : shape[axis - offset];
+      if (dim === 1 && promoted[axis] > 1) return true;
+    }
+    return false;
+  };
+  const markNonViewProducer = (v: Var): void => {
+    let current = v;
+    while (true) {
+      const defn = varToDefn.get(current);
+      if (defn === undefined) return;
+      const eqn = jaxpr.eqns[defn];
+      if (!viewPrimitives.includes(eqn.primitive)) break;
+      const input = eqn.inputs.find((input) => input instanceof Var);
+      if (!input) return;
+      current = input;
+    }
+    materializeForReusedReduction.add(current);
+  };
+  for (const eqn of jaxpr.eqns) {
+    let inputShapes: [number[], number[]] | null = null;
+    if (eqn.primitive === Primitive.Dot) {
+      inputShapes = [eqn.inputs[0].aval.shape, eqn.inputs[1].aval.shape];
+    } else if (eqn.primitive === Primitive.Conv) {
+      const [lhs, rhs] = prepareConv(
+        ShapeTracker.fromShape(eqn.inputs[0].aval.shape),
+        ShapeTracker.fromShape(eqn.inputs[1].aval.shape),
+        eqn.params as PrimitiveParams<Primitive.Conv>,
+      );
+      inputShapes = [lhs.shape, rhs.shape];
+    }
+    if (!inputShapes) continue;
+    const promoted = generalBroadcast(inputShapes[0], inputShapes[1]);
+    for (const [i, input] of eqn.inputs.entries()) {
+      if (
+        input instanceof Var &&
+        reductionInputHasReuse(inputShapes[i], promoted)
+      ) {
+        markNonViewProducer(input);
+      }
+    }
+  }
+
   // Move backwards through the program and compute "black" endpoints.
   //
   // Black nodes are the endpoints where we dispatch a kernel to the backend
@@ -929,6 +990,7 @@ function splitGraphDataflow(backend: Backend, jaxpr: Jaxpr): Set<Var> {
       reductionEndpointEqns.has(i) ||
       heterogeneousViewPrimitives.includes(eqn.primitive) ||
       routinePrimitives.has(eqn.primitive) ||
+      eqn.outBinders.some((v) => materializeForReusedReduction.has(v)) ||
       eqn.outBinders.some((v) => blackNodes.has(v))
     ) {
       for (const v of eqn.outBinders) {

--- a/website/src/routes/whisper/model.ts
+++ b/website/src/routes/whisper/model.ts
@@ -373,13 +373,13 @@ function encoderConv(
   let x = lax
     .conv(features, conv1.weight.ref, [1], [[1, 1]])
     .add(conv1.bias.ref.reshape([1, conv1.bias.shape[0], 1]));
-  x = nn.gelu(x);
+  x = nn.gelu(x, { approximate: false });
   x = lax
     .conv(x, conv2.weight.ref, [2], [[1, 1]])
     .add(conv2.bias.ref.reshape([1, conv2.bias.shape[0], 1]));
   const dtype = x.dtype;
   return nn
-    .gelu(x)
+    .gelu(x, { approximate: false })
     .slice(0)
     .transpose()
     .add(embedPositions.weight.ref.astype(dtype));
@@ -401,7 +401,9 @@ function encoderLayer(
   return x.ref.add(
     runLinear(
       layer.fc2,
-      nn.gelu(runLinear(layer.fc1, runLayerNorm(layer.finalLayerNorm, x))),
+      nn.gelu(runLinear(layer.fc1, runLayerNorm(layer.finalLayerNorm, x)), {
+        approximate: false,
+      }),
     ),
   );
 }
@@ -435,7 +437,9 @@ function decoderLayerStep(
     x.ref.add(
       runLinear(
         layer.fc2,
-        nn.gelu(runLinear(layer.fc1, runLayerNorm(layer.finalLayerNorm, x))),
+        nn.gelu(runLinear(layer.fc1, runLayerNorm(layer.finalLayerNorm, x)), {
+          approximate: false,
+        }),
       ),
     ),
     nextSelfCache,


### PR DESCRIPTION
- Improve tile plan for Wasm get good perf on matrices with dimensions not divisible by 16 (now only 4 is needed, just for the SIMD axis)
- Speed up operations, especially for Whisper in Wasm by materializing computed values before reuse in Conv or Dot so they aren't recomputed
- Use exact (non-approximate) gelu in whisper for correctness