### PR TITLE
Work around Firefox's 100ms WebGPU completion poll

### DIFF
--- a/src/backend/webgpu.ts
+++ b/src/backend/webgpu.ts
@@ -46,6 +46,14 @@ export class WebGPUBackend implements Backend {
   #reusableZsb: GPUBuffer;
   #bufferPool = new Map<number, GPUBuffer[]>();
 
+  // Dispatches are recorded into one shared encoder and submitted lazily (next
+  // microtask, or before a readback), so a frame's many submits collapse to one.
+  // Each submit is an IPC round-trip to the GPU process on Firefox.
+  #batchEncoder: GPUCommandEncoder | null = null;
+  // Buffers freed while a batch is open; recycled once it's submitted, since
+  // recorded commands may still reference them.
+  #deferredReleases: { buffer: GPUBuffer; size: number }[] = [];
+
   constructor(readonly device: GPUDevice) {
     if (DEBUG >= 3 && device.adapterInfo) {
       console.info(
@@ -132,6 +140,8 @@ export class WebGPUBackend implements Backend {
     if (start === undefined) start = 0;
     if (count === undefined) count = size - start;
 
+    this.flush(); // flush batched compute so the copy sees current data
+
     // Need a GPUBuffer with MAP_READ usage when transfering data to host.
     const paddedSize = Math.ceil(count / 4) * 4;
     const staging = this.#createBuffer(paddedSize, { read: true });
@@ -157,6 +167,7 @@ export class WebGPUBackend implements Backend {
     if (buffer === this.#reusableZsb) return new Uint8Array();
     if (start === undefined) start = 0;
     if (count === undefined) count = size - start;
+    this.flush();
     return this.syncReader.read(buffer, start, count);
   }
 
@@ -211,7 +222,32 @@ export class WebGPUBackend implements Backend {
   ): void {
     const inputBuffers = inputs.map((slot) => this.#getBuffer(slot).buffer);
     const outputBuffers = outputs.map((slot) => this.#getBuffer(slot).buffer);
-    pipelineSubmit(this.device, exe, inputBuffers, outputBuffers);
+    if (!this.#batchEncoder) {
+      this.#batchEncoder = this.device.createCommandEncoder();
+      queueMicrotask(() => this.flush());
+    }
+    const traced = pipelineRecord(
+      this.device,
+      this.#batchEncoder,
+      exe,
+      inputBuffers,
+      outputBuffers,
+    );
+    // Tracing needs a timestamp per dispatch, so don't batch.
+    if (traced) this.flush();
+  }
+
+  /** Submit any recorded-but-unflushed compute to the queue. */
+  flush(): void {
+    if (this.#batchEncoder) {
+      this.device.queue.submit([this.#batchEncoder.finish()]);
+      this.#batchEncoder = null;
+    }
+    // mid batch buffers safe to reuse
+    for (const { buffer, size } of this.#deferredReleases) {
+      this.#releaseBufferNow(buffer, size);
+    }
+    this.#deferredReleases.length = 0;
   }
 
   #getBuffer(slot: Slot): { buffer: GPUBuffer; size: number } {
@@ -229,6 +265,15 @@ export class WebGPUBackend implements Backend {
   }
 
   #releaseBuffer(buffer: GPUBuffer, size: number): void {
+    // deffering the recycle here cause an open batch may still reference it
+    if (this.#batchEncoder) {
+      this.#deferredReleases.push({ buffer, size });
+      return;
+    }
+    this.#releaseBufferNow(buffer, size);
+  }
+
+  #releaseBufferNow(buffer: GPUBuffer, size: number): void {
     if (size > MAX_REUSABLE_BUFFER_BYTES) {
       buffer.destroy();
       return;
@@ -528,14 +573,17 @@ function pipelineSource(device: GPUDevice, kernel: Kernel): ShaderInfo {
   };
 }
 
-function pipelineSubmit(
+// Record an executable's passes into `commandEncoder`. Returns true if any
+// tracing timestamps were written, so the caller can flush right away.
+function pipelineRecord(
   device: GPUDevice,
+  commandEncoder: GPUCommandEncoder,
   exe: Executable<ShaderDispatch[]>,
   inputs: GPUBuffer[],
   outputs: GPUBuffer[],
-) {
+): boolean {
   const { data: pipelines, source } = exe;
-  const commandEncoder = device.createCommandEncoder();
+  let traced = false;
   for (const { pipeline, ...shader } of pipelines) {
     if (
       inputs.length !== shader.numInputs ||
@@ -551,6 +599,7 @@ function pipelineSubmit(
     if (filteredPasses.length === 0) continue; // No work to do.
 
     const slot = maybeAcquireTracingSlot(device);
+    if (slot) traced = true;
     const bindGroup = device.createBindGroup({
       layout: pipeline.getBindGroupLayout(0),
       entries: [
@@ -609,7 +658,7 @@ function pipelineSubmit(
     }
   }
 
-  device.queue.submit([commandEncoder.finish()]);
+  return traced;
 }
 
 function combineUniforms(

--- a/src/backend/webgpu.ts
+++ b/src/backend/webgpu.ts
@@ -12,6 +12,7 @@ import {
   WgslBuilder,
   WgslExpCodegen,
 } from "./webgpu/codegen";
+import { mapAsyncRead } from "./webgpu/firefoxPoll";
 import { nullaryKernelSource } from "./webgpu/nullaryKernel";
 import { SyncReader } from "./webgpu/reader";
 import { createRoutineShader } from "./webgpu/routines";
@@ -140,7 +141,7 @@ export class WebGPUBackend implements Backend {
       commandEncoder.copyBufferToBuffer(buffer, start, staging, 0, paddedSize);
       this.device.queue.submit([commandEncoder.finish()]);
 
-      await staging.mapAsync(GPUMapMode.READ);
+      await mapAsyncRead(this.device, staging);
       const arrayBuffer = staging.getMappedRange();
       return new Uint8Array(arrayBuffer.slice(), 0, count);
     } finally {

--- a/src/backend/webgpu/firefoxPoll.ts
+++ b/src/backend/webgpu/firefoxPoll.ts
@@ -1,0 +1,83 @@
+// Firefox drives WebGPU completion from a 100 ms timer (`POLL_TIME_MS` in
+// dom/webgpu/ipc/WebGPUParent.cpp, line 38), so awaiting `mapAsync()` takes about ~100  ms
+// even when nothing was submitted. Mozilla tracks this as bug 1870699,
+// https://bugzilla.mozilla.org/show_bug.cgi?id=1870699, "Don't
+// poll WebGPU from a timer".
+//
+// A comment there says submitting continuously gets you an implicit poll for
+// free, and that dropping the timer to 5 ms took one CTS test from 12s to 1.2s:
+// https://bugzilla.mozilla.org/show_bug.cgi?id=1870699#c6
+// So while waiting on a map, we submit empty command buffers to trigger those
+// polls ourselves.
+//
+// The rates below are tuned on a Macbook M1 Max to nudge every 1 ms while checking on
+// every task, which brought the wait down to ~1.4 ms. Being too eager kind of backfires
+// though — submitting on every yield floods the IPC channel until the GPU
+// process just hangs or has a long wait time.
+//
+// Checking frequency is a bit separate from nudge frequency, since `setTimeout` can't see a
+// completion sooner than its ~5 ms clamp and adds ~10 ms of overhead per wait on its own.
+//
+// Your mileage may vary on other machines, so these numbers are worth revisiting.
+//
+// There's already work underway upstream to poll on a background thread only
+// while GPU work is in flight, so this should be deletable before long.
+
+const NUDGE_INTERVAL_MS = 1;
+// Checking on every task is only cheap while the wait is short.
+const BUSY_MS = 20;
+const BACKOFF_MS = 5;
+// A lost device never resolves the map, so stop submitting into it eventually.
+const DEADLINE_MS = 1000;
+
+const isFirefox =
+  typeof navigator !== "undefined" &&
+  navigator.userAgent.includes("Firefox") &&
+  !navigator.userAgent.includes("Seamonkey");
+
+// Resolves on the next task, without `setTimeout`'s clamp.
+let channel: MessageChannel | undefined;
+const resolvers: (() => void)[] = [];
+function yieldTask(): Promise<void> {
+  const port = (channel ??= (() => {
+    const created = new MessageChannel();
+    created.port1.onmessage = () => resolvers.shift()?.();
+    created.port1.start();
+    return created;
+  })()).port2;
+  return new Promise((resolve) => {
+    resolvers.push(resolve);
+    port.postMessage(0);
+  });
+}
+
+/** Map a staging buffer for reading, without Firefox's ~100 ms poll latency. */
+export async function mapAsyncRead(
+  device: GPUDevice,
+  staging: GPUBuffer,
+): Promise<void> {
+  const mapped = staging.mapAsync(GPUMapMode.READ);
+  if (!isFirefox) return mapped;
+
+  let settled = false;
+  // `finally` so a rejected map stops the loop too.
+  const tracked = mapped.finally(() => {
+    settled = true;
+  });
+  // An already-complete map shouldn't pay for a submit.
+  await yieldTask();
+
+  const start = performance.now();
+  let lastNudge = -Infinity;
+  while (!settled) {
+    const elapsed = performance.now() - start;
+    if (elapsed >= DEADLINE_MS) break;
+    if (performance.now() - lastNudge >= NUDGE_INTERVAL_MS) {
+      lastNudge = performance.now();
+      device.queue.submit([device.createCommandEncoder().finish()]);
+    }
+    if (elapsed < BUSY_MS) await yieldTask();
+    else await new Promise((resolve) => setTimeout(resolve, BACKOFF_MS));
+  }
+  return tracked;
+}

--- a/src/frontend/array.ts
+++ b/src/frontend/array.ts
@@ -872,6 +872,7 @@ export class Array extends Tracer {
       for (const p of pending) p.submit();
     }
     const backend = this.#backend as import("../backend/webgpu").WebGPUBackend;
+    backend.flush(); // flush batched work so the buffer is current
     const { buffer } = backend.buffers.get(this.#source as Slot)!;
     this.dispose();
     return buffer;
@@ -887,6 +888,7 @@ export class Array extends Tracer {
       p.submit();
     }
     const backend = this.#backend as import("../backend/webgpu").WebGPUBackend;
+    backend.flush();
     const { buffer } = backend.buffers.get(this.#source as Slot)!;
     this.dispose();
     return buffer;


### PR DESCRIPTION
Fixes #123 (includes profiling and a why for Firefox paying per dispatch).

Instead of each kernel doing its own `queue.submit()`, this records dispatches into one shared
`GPUCommandEncoder` and submits on the next microtask (or before a readback). `Backend.dispatch`
already allows deferral so that ordering still holds, and nothing about what's computed changes...just
how often we cross into the GPU process. 

> NOTE: buffers freed mid-batch are recycled into the pool only after the batch submits, so I restricted resuce while a recorded command still references it.

All tests base on latest, but I might still be missing something so would love your thoughts.
