### PR TITLE
Add QR-based SVD and eigenvalue routines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ dist/
 docs/
 docs-json/
 .svelte-kit/
+.worktrees/
 
 .vscode/
 .claude/

--- a/docs/superpowers/specs/2026-06-23-qr-svd-eigen-design.md
+++ b/docs/superpowers/specs/2026-06-23-qr-svd-eigen-design.md
@@ -1,0 +1,131 @@
+# QR Algorithm For SVD And Eigenvalues
+
+## Goal
+
+Implement the two algorithmic building blocks requested in
+`ekzhang/jax-js#51`:
+
+- Householder reductions: Hessenberg form for square eigenvalue problems and
+  bidiagonal form for rectangular SVD problems.
+- Repeated shifted QR iterations on the reduced matrices.
+
+The first implementation targets real-valued floating point arrays and follows
+the existing jax-js routine model: CPU has the reference implementation, WASM
+can reuse CPU routines, and WebGPU support can be added as an optimized routine
+only after the CPU behavior is stable.
+
+## Public Surface
+
+Expose SVD first through `jax.numpy.linalg.svd(a, opts?)`, because bidiagonal QR
+has a real-valued output contract for real inputs.
+
+Supported options:
+
+- `computeUv?: boolean`, default `true`.
+- `fullMatrices?: boolean`, default `true`.
+
+Return shape follows NumPy/JAX conventions:
+
+- If `computeUv` is true: `[u, s, vh]`.
+- If `computeUv` is false: `s`.
+
+For eigenvalues, keep the public API conservative:
+
+- Add `jax.numpy.linalg.eigvals(a)` only for real eigenvalues found by the real
+  QR routine.
+- Detect unreduced `2x2` blocks that represent complex conjugate pairs and
+  throw a clear error until complex dtype or an explicit real/imag return API is
+  designed.
+
+This still implements Hessenberg reduction and QR iteration, while avoiding an
+unstable public complex-number contract.
+
+## Internal Architecture
+
+Add one routine-level primitive for SVD and one for eigenvalues:
+
+- `Primitive.SVD` / `Routines.SVD`
+- `Primitive.Eigvals` / `Routines.Eigvals`
+
+The CPU routine owns the numerical algorithms:
+
+1. Convert each matrix in the batch to a local mutable `number[]`.
+2. For SVD:
+   - Use Householder reflections to reduce `A` to bidiagonal form.
+   - Accumulate left and right orthogonal factors when `computeUv` is true.
+   - Apply implicit shifted QR steps to the bidiagonal matrix until off-diagonal
+     entries deflate.
+   - Sort singular values descending and permute singular vectors to match.
+3. For eigenvalues:
+   - Use Householder reflections to reduce `A` to upper Hessenberg form.
+   - Apply shifted QR iteration until subdiagonal entries deflate.
+   - Read real eigenvalues from `1x1` diagonal blocks.
+   - Throw on remaining `2x2` complex blocks.
+
+The implementation should keep helpers local to `src/routine.ts` unless the file
+becomes unwieldy. If extraction is needed, create `src/routine/linalg.ts` and
+keep `runCpuRoutine()` as the dispatch owner.
+
+## Shape And Dtype Rules
+
+SVD:
+
+- Input must be at least 2D.
+- Last two dimensions are matrix dimensions `m, n`.
+- Batched inputs are supported by iterating over leading dimensions.
+- Output singular values have shape `[..., min(m, n)]`.
+- With `fullMatrices: true`, `u` has shape `[..., m, m]` and `vh` has shape
+  `[..., n, n]`.
+- With `fullMatrices: false`, `u` has shape `[..., m, k]` and `vh` has shape
+  `[..., k, n]`, where `k = min(m, n)`.
+- Floating dtypes preserve the input dtype where possible. Integer inputs should
+  be rejected or promoted consistently with existing linalg behavior.
+
+Eigenvalues:
+
+- Input must be at least 2D and square on the last two axes.
+- Batched square matrices are supported.
+- Output has shape `[..., n]`.
+- The first version returns real-valued eigenvalues only.
+
+## Error Handling And Convergence
+
+Use a scale-aware tolerance based on machine epsilon and matrix norm. QR
+iteration should have a fixed iteration cap per active block. On failure, throw
+a descriptive error such as:
+
+- `svd: QR iteration failed to converge`
+- `eigvals: QR iteration failed to converge`
+- `eigvals: complex eigenvalues are not supported yet`
+
+## Testing
+
+Use test-driven development.
+
+Add focused Vitest coverage:
+
+- SVD reconstructs square, tall, wide, diagonal, zero, and batched matrices.
+- `computeUv: false` returns only singular values.
+- Singular values are sorted descending and nonnegative.
+- `fullMatrices: false` produces reduced shapes.
+- SVD agrees with known closed-form small examples.
+- Eigenvalues match diagonal, triangular, symmetric, and simple real-spectrum
+  nonsymmetric matrices.
+- Eigenvalues throw on a real rotation matrix with complex eigenvalues.
+- Invalid shapes throw clear errors.
+
+Run at least:
+
+- `pnpm test test/numpy-linalg.test.ts`
+- `pnpm check`
+
+If WebGPU lacks the new routine initially, either skip WebGPU tests for these
+specific APIs or mark the routine unsupported on WebGPU with a clear error. CPU
+and WASM should pass because WASM falls back to CPU routines.
+
+## Non-Goals
+
+- Full complex dtype support.
+- Differentiation rules for SVD/eigvals in the first pass.
+- Optimized WebGPU kernels for QR iteration.
+- Full `np.linalg.eig` eigenvectors for nonsymmetric matrices.

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "typedoc-theme-fresh": "^0.2.3",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.61.1",
+    "unrun": "^0.3.1",
     "vitest": "^4.1.9"
   },
   "packageManager": "pnpm@11.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,7 +46,7 @@ importers:
         version: 4.1.1(prettier@3.8.4)(svelte@5.56.3(@typescript-eslint/types@8.61.1))
       tsdown:
         specifier: ^0.22.3
-        version: 0.22.3(tsx@4.22.4)(typescript@5.9.3)
+        version: 0.22.3(tsx@4.22.4)(typescript@5.9.3)(unrun@0.3.1)
       tsx:
         specifier: ^4.22.4
         version: 4.22.4
@@ -62,6 +62,9 @@ importers:
       typescript-eslint:
         specifier: ^8.61.1
         version: 8.61.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      unrun:
+        specifier: ^0.3.1
+        version: 0.3.1
       vitest:
         specifier: ^4.1.9
         version: 4.1.9(@types/node@24.1.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(msw@2.10.4(@types/node@24.1.0)(typescript@5.9.3))(vite@8.0.16(@types/node@24.1.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -3027,6 +3030,16 @@ packages:
     resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
     engines: {node: '>= 4.0.0'}
 
+  unrun@0.3.1:
+    resolution: {integrity: sha512-onIck/oNnCaytwths1ZVp1LK2Gq2hPoyFhiHebObuUXqR3S0uHuLLaBK8K6mRRgV7Ptip8AnNvaUsgzwWwBZuA==}
+    engines: {node: ^22.13.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      synckit: ^0.11.11
+    peerDependenciesMeta:
+      synckit:
+        optional: true
+
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
@@ -5959,7 +5972,7 @@ snapshots:
       minimist: 1.2.8
       strip-bom: 3.0.0
 
-  tsdown@0.22.3(tsx@4.22.4)(typescript@5.9.3):
+  tsdown@0.22.3(tsx@4.22.4)(typescript@5.9.3)(unrun@0.3.1):
     dependencies:
       ansis: 4.3.1
       cac: 7.0.0
@@ -5979,6 +5992,7 @@ snapshots:
     optionalDependencies:
       tsx: 4.22.4
       typescript: 5.9.3
+      unrun: 0.3.1
     transitivePeerDependencies:
       - '@ts-macro/tsc'
       - '@typescript/native-preview'
@@ -6081,6 +6095,10 @@ snapshots:
 
   universalify@0.2.0:
     optional: true
+
+  unrun@0.3.1:
+    dependencies:
+      rolldown: 1.1.2
 
   uri-js@4.4.1:
     dependencies:

--- a/src/backend/webgpu/routines.ts
+++ b/src/backend/webgpu/routines.ts
@@ -603,6 +603,8 @@ export function createRoutineShader(
       return createCholesky(device, routine.type);
     case Routines.LU:
       return createLU(device, routine.type);
+    case Routines.SVD:
+      throw new UnsupportedRoutineError(routine.name, "webgpu");
     default:
       throw new UnsupportedRoutineError(routine.name, "webgpu");
   }

--- a/src/backend/webgpu/routines.ts
+++ b/src/backend/webgpu/routines.ts
@@ -605,6 +605,8 @@ export function createRoutineShader(
       return createLU(device, routine.type);
     case Routines.SVD:
       throw new UnsupportedRoutineError(routine.name, "webgpu");
+    case Routines.Eigvals:
+      throw new UnsupportedRoutineError(routine.name, "webgpu");
     default:
       throw new UnsupportedRoutineError(routine.name, "webgpu");
   }

--- a/src/frontend/array.ts
+++ b/src/frontend/array.ts
@@ -1178,6 +1178,7 @@ export class Array extends Tracer {
       [Primitive.Cholesky]: Array.#routine(Primitive.Cholesky),
       [Primitive.LU]: Array.#routine(Primitive.LU),
       [Primitive.SVD]: Array.#routine(Primitive.SVD),
+      [Primitive.Eigvals]: Array.#routine(Primitive.Eigvals),
       [Primitive.Jit](args, { jaxpr }) {
         if (jaxpr.inBinders.length !== args.length) {
           throw new Error(

--- a/src/frontend/array.ts
+++ b/src/frontend/array.ts
@@ -1177,6 +1177,7 @@ export class Array extends Tracer {
       [Primitive.TriangularSolve]: Array.#routine(Primitive.TriangularSolve),
       [Primitive.Cholesky]: Array.#routine(Primitive.Cholesky),
       [Primitive.LU]: Array.#routine(Primitive.LU),
+      [Primitive.SVD]: Array.#routine(Primitive.SVD),
       [Primitive.Jit](args, { jaxpr }) {
         if (jaxpr.inBinders.length !== args.length) {
           throw new Error(

--- a/src/frontend/core.ts
+++ b/src/frontend/core.ts
@@ -94,6 +94,7 @@ export enum Primitive {
   Cholesky = "cholesky", // A is positive-definite, A = L @ L^T
   LU = "lu", // LU decomposition with partial pivoting
   SVD = "svd", // Singular value decomposition
+  Eigvals = "eigvals", // Real eigenvalues
 
   // JIT compilation
   Jit = "jit",
@@ -150,6 +151,7 @@ export const routinePrimitives = new Map([
   [Primitive.Cholesky, Routines.Cholesky],
   [Primitive.LU, Routines.LU],
   [Primitive.SVD, Routines.SVD],
+  [Primitive.Eigvals, Routines.Eigvals],
 ]);
 
 export function add(x: TracerValue, y: TracerValue) {
@@ -550,6 +552,13 @@ export function svd(
   if (aval.ndim < 2)
     throw new Error(`svd: expected batch of matrices, got ${aval}`);
   return bind(Primitive.SVD, [x], { computeUv, fullMatrices });
+}
+
+export function eigvals(x: TracerValue) {
+  const aval = ShapedArray.fromAval(getAval(x));
+  if (aval.ndim < 2 || aval.shape[aval.ndim - 1] !== aval.shape[aval.ndim - 2])
+    throw new Error(`eigvals: expected batch of square matrices, got ${aval}`);
+  return bind1(Primitive.Eigvals, [x]);
 }
 
 export function sort(x: TracerValue) {

--- a/src/frontend/core.ts
+++ b/src/frontend/core.ts
@@ -93,6 +93,7 @@ export enum Primitive {
   TriangularSolve = "triangular_solve", // A is upper triangular, A @ X.T = B.T
   Cholesky = "cholesky", // A is positive-definite, A = L @ L^T
   LU = "lu", // LU decomposition with partial pivoting
+  SVD = "svd", // Singular value decomposition
 
   // JIT compilation
   Jit = "jit",
@@ -123,6 +124,7 @@ interface PrimitiveParamsImpl extends Record<Primitive, Record<string, any>> {
   [Primitive.Shrink]: { slice: Pair[] };
   [Primitive.Pad]: { width: Pair[] };
   [Primitive.TriangularSolve]: { unitDiagonal: boolean };
+  [Primitive.SVD]: { computeUv: boolean; fullMatrices: boolean };
   [Primitive.Jit]: { name: string; jaxpr: Jaxpr; numConsts: number };
 }
 
@@ -147,6 +149,7 @@ export const routinePrimitives = new Map([
   [Primitive.TriangularSolve, Routines.TriangularSolve],
   [Primitive.Cholesky, Routines.Cholesky],
   [Primitive.LU, Routines.LU],
+  [Primitive.SVD, Routines.SVD],
 ]);
 
 export function add(x: TracerValue, y: TracerValue) {
@@ -534,6 +537,19 @@ export function lu(x: TracerValue) {
   if (aval.ndim < 2)
     throw new Error(`lu: expected batch of matrices, got ${aval}`);
   return bind(Primitive.LU, [x]);
+}
+
+export function svd(
+  x: TracerValue,
+  {
+    computeUv = true,
+    fullMatrices = true,
+  }: { computeUv?: boolean; fullMatrices?: boolean } = {},
+) {
+  const aval = ShapedArray.fromAval(getAval(x));
+  if (aval.ndim < 2)
+    throw new Error(`svd: expected batch of matrices, got ${aval}`);
+  return bind(Primitive.SVD, [x], { computeUv, fullMatrices });
 }
 
 export function sort(x: TracerValue) {

--- a/src/frontend/jaxpr.ts
+++ b/src/frontend/jaxpr.ts
@@ -1012,6 +1012,20 @@ export const abstractEvalRules: { [P in Primitive]: AbstractEvalRule<P> } = {
       new ShapedArray([...batch, m], DType.Int32, false),
     ];
   },
+  [Primitive.SVD]([a], { computeUv, fullMatrices }) {
+    if (a.ndim < 2)
+      throw new TypeError(`svd: requires at least 2D input, got ${a}`);
+    const batch = a.shape.slice(0, -2);
+    const [m, n] = a.shape.slice(-2);
+    const k = Math.min(m, n);
+    const s = new ShapedArray([...batch, k], a.dtype, false);
+    if (!computeUv) return [s];
+    return [
+      new ShapedArray([...batch, m, fullMatrices ? m : k], a.dtype, false),
+      s,
+      new ShapedArray([...batch, fullMatrices ? n : k, n], a.dtype, false),
+    ];
+  },
   [Primitive.Jit](args, { jaxpr }) {
     const { inTypes, outTypes } = typecheckJaxpr(jaxpr);
     if (args.length !== inTypes.length) {

--- a/src/frontend/jaxpr.ts
+++ b/src/frontend/jaxpr.ts
@@ -1026,6 +1026,13 @@ export const abstractEvalRules: { [P in Primitive]: AbstractEvalRule<P> } = {
       new ShapedArray([...batch, fullMatrices ? n : k, n], a.dtype, false),
     ];
   },
+  [Primitive.Eigvals]([a]) {
+    if (a.ndim < 2)
+      throw new TypeError(`eigvals: requires at least 2D input, got ${a}`);
+    if (a.shape[a.ndim - 2] !== a.shape[a.ndim - 1])
+      throw new TypeError(`eigvals: must be square, got ${a}`);
+    return [new ShapedArray(a.shape.slice(0, -1), a.dtype, false)];
+  },
   [Primitive.Jit](args, { jaxpr }) {
     const { inTypes, outTypes } = typecheckJaxpr(jaxpr);
     if (args.length !== inTypes.length) {

--- a/src/frontend/jit.ts
+++ b/src/frontend/jit.ts
@@ -779,6 +779,7 @@ const jitRules: { [P in Primitive]: JitRule<P> } = {
   [Primitive.Cholesky]: routineNoJit(),
   [Primitive.LU]: routineNoJit(),
   [Primitive.SVD]: routineNoJit(),
+  [Primitive.Eigvals]: routineNoJit(),
   [Primitive.Jit]() {
     throw new Error(
       "internal: Jit should have been flattened before JIT compilation",

--- a/src/frontend/jit.ts
+++ b/src/frontend/jit.ts
@@ -778,6 +778,7 @@ const jitRules: { [P in Primitive]: JitRule<P> } = {
   [Primitive.TriangularSolve]: routineNoJit(),
   [Primitive.Cholesky]: routineNoJit(),
   [Primitive.LU]: routineNoJit(),
+  [Primitive.SVD]: routineNoJit(),
   [Primitive.Jit]() {
     throw new Error(
       "internal: Jit should have been flattened before JIT compilation",

--- a/src/frontend/jvp.ts
+++ b/src/frontend/jvp.ts
@@ -394,6 +394,9 @@ const jvpRules: { [P in Primitive]: JvpRule<P> } = {
       [lDot.add(uDot), zerosLike(pivots.ref), zerosLike(permutation.ref)],
     ];
   },
+  [Primitive.SVD]() {
+    throw new TypeError("svd: JVP rule is not implemented");
+  },
   [Primitive.Jit](primals, tangents, { name, jaxpr }) {
     const newJaxpr = jvpJaxpr(jaxpr);
     const outs = bind(

--- a/src/frontend/jvp.ts
+++ b/src/frontend/jvp.ts
@@ -397,6 +397,9 @@ const jvpRules: { [P in Primitive]: JvpRule<P> } = {
   [Primitive.SVD]() {
     throw new TypeError("svd: JVP rule is not implemented");
   },
+  [Primitive.Eigvals]() {
+    throw new TypeError("eigvals: JVP rule is not implemented");
+  },
   [Primitive.Jit](primals, tangents, { name, jaxpr }) {
     const newJaxpr = jvpJaxpr(jaxpr);
     const outs = bind(

--- a/src/frontend/linearize.ts
+++ b/src/frontend/linearize.ts
@@ -892,6 +892,9 @@ const transposeRules: Partial<{ [P in Primitive]: TransposeRule<P> }> = {
   [Primitive.SVD]() {
     throw new NonlinearError(Primitive.SVD);
   },
+  [Primitive.Eigvals]() {
+    throw new NonlinearError(Primitive.Eigvals);
+  },
   [Primitive.Jit](cts, args, { name, jaxpr }) {
     // We need this one because the jvp() rule for Jit generates a Jit
     // with the transformed Jaxpr. So grad-of-jit will result in a transposed

--- a/src/frontend/linearize.ts
+++ b/src/frontend/linearize.ts
@@ -889,6 +889,9 @@ const transposeRules: Partial<{ [P in Primitive]: TransposeRule<P> }> = {
     });
     return [null, ctB];
   },
+  [Primitive.SVD]() {
+    throw new NonlinearError(Primitive.SVD);
+  },
   [Primitive.Jit](cts, args, { name, jaxpr }) {
     // We need this one because the jvp() rule for Jit generates a Jit
     // with the transformed Jaxpr. So grad-of-jit will result in a transposed

--- a/src/frontend/vmap.ts
+++ b/src/frontend/vmap.ts
@@ -403,6 +403,7 @@ const vmapRules: Partial<{ [P in Primitive]: VmapRule<P> }> = {
   [Primitive.Cholesky]: lastDimsBatcher(Primitive.Cholesky, 2),
   [Primitive.LU]: lastDimsBatcher(Primitive.LU, 2, 3),
   [Primitive.SVD]: lastDimsBatcher(Primitive.SVD, 2, 3),
+  [Primitive.Eigvals]: lastDimsBatcher(Primitive.Eigvals, 2),
   [Primitive.Jit](axisSize, args, dims, { name, jaxpr }) {
     const newJaxpr = vmapJaxpr(jaxpr, axisSize, dims);
     const outs = bind(

--- a/src/frontend/vmap.ts
+++ b/src/frontend/vmap.ts
@@ -402,6 +402,7 @@ const vmapRules: Partial<{ [P in Primitive]: VmapRule<P> }> = {
   },
   [Primitive.Cholesky]: lastDimsBatcher(Primitive.Cholesky, 2),
   [Primitive.LU]: lastDimsBatcher(Primitive.LU, 2, 3),
+  [Primitive.SVD]: lastDimsBatcher(Primitive.SVD, 2, 3),
   [Primitive.Jit](axisSize, args, dims, { name, jaxpr }) {
     const newJaxpr = vmapJaxpr(jaxpr, axisSize, dims);
     const outs = bind(

--- a/src/library/lax-linalg.ts
+++ b/src/library/lax-linalg.ts
@@ -67,6 +67,14 @@ export function lu(x: ArrayLike): [Array, Array, Array] {
   return core.lu(x) as [Array, Array, Array];
 }
 
+export function svd(
+  a: ArrayLike,
+  opts: { computeUv?: boolean; fullMatrices?: boolean } = {},
+): Array | [Array, Array, Array] {
+  const out = core.svd(a, opts) as Array[];
+  return opts.computeUv === false ? out[0] : [out[0], out[1], out[2]];
+}
+
 /**
  * Solve a triangular linear system.
  *

--- a/src/library/lax-linalg.ts
+++ b/src/library/lax-linalg.ts
@@ -75,6 +75,10 @@ export function svd(
   return opts.computeUv === false ? out[0] : [out[0], out[1], out[2]];
 }
 
+export function eigvals(a: ArrayLike): Array {
+  return core.eigvals(a) as Array;
+}
+
 /**
  * Solve a triangular linear system.
  *

--- a/src/library/numpy-linalg.ts
+++ b/src/library/numpy-linalg.ts
@@ -186,6 +186,12 @@ export function svd(
   return lax.linalg.svd(a, opts);
 }
 
+export function eigvals(a: ArrayLike): Array {
+  a = fudgeArray(a);
+  checkSquare("eigvals", a);
+  return lax.linalg.eigvals(a);
+}
+
 /**
  * Solve a linear system of equations.
  *

--- a/src/library/numpy-linalg.ts
+++ b/src/library/numpy-linalg.ts
@@ -176,6 +176,16 @@ export function slogdet(a: ArrayLike): [Array, Array] {
   return [sign, logabsdet];
 }
 
+export function svd(
+  a: ArrayLike,
+  opts: { computeUv?: boolean; fullMatrices?: boolean } = {},
+): Array | [Array, Array, Array] {
+  a = fudgeArray(a);
+  if (a.ndim < 2)
+    throw new Error(`svd: input must be at least 2D, got ${a.aval}`);
+  return lax.linalg.svd(a, opts);
+}
+
 /**
  * Solve a linear system of equations.
  *

--- a/src/routine.ts
+++ b/src/routine.ts
@@ -356,8 +356,7 @@ function symmetricJacobiEigen(
     const aqq = work[q * n + q];
     const apq = work[p * n + q];
     const tau = (aqq - app) / (2 * apq);
-    const t =
-      Math.sign(tau || 1) / (Math.abs(tau) + Math.sqrt(1 + tau * tau));
+    const t = Math.sign(tau || 1) / (Math.abs(tau) + Math.sqrt(1 + tau * tau));
     const c = 1 / Math.sqrt(1 + t * t);
     const s = t * c;
 
@@ -543,8 +542,7 @@ function realQrEigenvalues(input: number[], n: number): number[] {
     let done = true;
     for (let i = 1; i < n; i++) {
       const tol =
-        1e-10 *
-        (Math.abs(h[(i - 1) * n + i - 1]) + Math.abs(h[i * n + i]) + 1);
+        1e-10 * (Math.abs(h[(i - 1) * n + i - 1]) + Math.abs(h[i * n + i]) + 1);
       if (Math.abs(h[i * n + i - 1]) <= tol) h[i * n + i - 1] = 0;
       else done = false;
     }

--- a/src/routine.ts
+++ b/src/routine.ts
@@ -128,7 +128,7 @@ export function runCpuRoutine(
     case Routines.SVD:
       return runSVD(type, inputAr, outputAr, routine.params);
     case Routines.Eigvals:
-      throw new Error("eigvals: CPU routine is not implemented yet");
+      return runEigvals(type, inputAr, outputAr);
     default:
       name satisfies never; // Exhaustiveness check
   }
@@ -461,5 +461,136 @@ function runSVD(
         vhOut![b * vhRows * n + row * n + col] = v[col * n + row];
       }
     }
+  }
+}
+
+function hessenbergHouseholder(a: number[], n: number): number[] {
+  const h = a.slice();
+  for (let k = 0; k < n - 2; k++) {
+    let norm = 0;
+    for (let i = k + 1; i < n; i++) norm = Math.hypot(norm, h[i * n + k]);
+    if (norm === 0) continue;
+
+    const sign = h[(k + 1) * n + k] >= 0 ? 1 : -1;
+    const v = new Array(n).fill(0);
+    v[k + 1] = h[(k + 1) * n + k] + sign * norm;
+    for (let i = k + 2; i < n; i++) v[i] = h[i * n + k];
+
+    let betaDen = 0;
+    for (let i = k + 1; i < n; i++) betaDen += v[i] * v[i];
+    if (betaDen === 0) continue;
+    const beta = 2 / betaDen;
+
+    for (let j = k; j < n; j++) {
+      let dot = 0;
+      for (let i = k + 1; i < n; i++) dot += v[i] * h[i * n + j];
+      for (let i = k + 1; i < n; i++) h[i * n + j] -= beta * v[i] * dot;
+    }
+
+    for (let i = 0; i < n; i++) {
+      let dot = 0;
+      for (let j = k + 1; j < n; j++) dot += h[i * n + j] * v[j];
+      for (let j = k + 1; j < n; j++) h[i * n + j] -= beta * dot * v[j];
+    }
+
+    for (let i = k + 2; i < n; i++) h[i * n + k] = 0;
+  }
+  return h;
+}
+
+function qrDecompose(a: number[], n: number): { q: number[]; r: number[] } {
+  const q = new Array(n * n).fill(0);
+  const r = new Array(n * n).fill(0);
+  const cols: number[][] = [];
+  for (let j = 0; j < n; j++) {
+    cols[j] = Array.from({ length: n }, (_, i) => a[i * n + j]);
+  }
+
+  for (let j = 0; j < n; j++) {
+    const v = cols[j].slice();
+    for (let i = 0; i < j; i++) {
+      let rij = 0;
+      for (let row = 0; row < n; row++) rij += q[row * n + i] * cols[j][row];
+      r[i * n + j] = rij;
+      for (let row = 0; row < n; row++) v[row] -= rij * q[row * n + i];
+    }
+
+    const norm = Math.hypot(...v);
+    r[j * n + j] = norm;
+    if (norm !== 0) {
+      for (let row = 0; row < n; row++) q[row * n + j] = v[row] / norm;
+    }
+  }
+  return { q, r };
+}
+
+function hasComplexTwoByTwoBlock(a: number[], n: number, i: number): boolean {
+  const aa = a[i * n + i];
+  const bb = a[i * n + i + 1];
+  const cc = a[(i + 1) * n + i];
+  const dd = a[(i + 1) * n + i + 1];
+  const trace = aa + dd;
+  const det = aa * dd - bb * cc;
+  return trace * trace - 4 * det < 0;
+}
+
+function realQrEigenvalues(input: number[], n: number): number[] {
+  if (n === 1) return [input[0]];
+
+  const h = hessenbergHouseholder(input, n);
+  const maxIter = Math.max(100, 200 * n * n);
+  for (let iter = 0; iter < maxIter; iter++) {
+    let done = true;
+    for (let i = 1; i < n; i++) {
+      const tol =
+        1e-10 *
+        (Math.abs(h[(i - 1) * n + i - 1]) + Math.abs(h[i * n + i]) + 1);
+      if (Math.abs(h[i * n + i - 1]) <= tol) h[i * n + i - 1] = 0;
+      else done = false;
+    }
+    if (done) return Array.from({ length: n }, (_, i) => h[i * n + i]);
+
+    for (let i = 0; i < n - 1; i++) {
+      if (Math.abs(h[(i + 1) * n + i]) > 1e-7) {
+        if (hasComplexTwoByTwoBlock(h, n, i)) {
+          throw new Error("eigvals: complex eigenvalues are not supported yet");
+        }
+      }
+    }
+
+    const mu = h[(n - 1) * n + n - 1];
+    const shifted = h.slice();
+    for (let i = 0; i < n; i++) shifted[i * n + i] -= mu;
+    const { q, r } = qrDecompose(shifted, n);
+    const next = multiplyMatrix(r, n, n, q, n);
+    for (let i = 0; i < n; i++) next[i * n + i] += mu;
+    h.splice(0, h.length, ...next);
+  }
+
+  for (let i = 0; i < n - 1; i++) {
+    if (
+      Math.abs(h[(i + 1) * n + i]) > 1e-7 &&
+      hasComplexTwoByTwoBlock(h, n, i)
+    ) {
+      throw new Error("eigvals: complex eigenvalues are not supported yet");
+    }
+  }
+  throw new Error("eigvals: QR iteration failed to converge");
+}
+
+function runEigvals(type: RoutineType, [a]: DataArray[], [out]: DataArray[]) {
+  const shape = type.inputShapes[0];
+  if (shape.length < 2) throw new Error("eigvals: input must be at least 2D");
+  const n = shape[shape.length - 1];
+  if (shape[shape.length - 2] !== n)
+    throw new Error("eigvals: input must be square");
+
+  for (let offset = 0; offset < a.length; offset += n * n) {
+    const batch = offset / (n * n);
+    const values = realQrEigenvalues(
+      Array.from(a.subarray(offset, offset + n * n)),
+      n,
+    );
+    for (let i = 0; i < n; i++) out[batch * n + i] = values[i];
   }
 }

--- a/src/routine.ts
+++ b/src/routine.ts
@@ -82,6 +82,14 @@ export enum Routines {
    * `U, S, Vh`; otherwise the output is only `S`.
    */
   SVD = "SVD",
+
+  /**
+   * Real eigenvalues of 2D square matrices.
+   *
+   * The input is a batch of shape `[..., N, N]`, and the output is a batch of
+   * shape `[..., N]`. Complex eigenvalue pairs are not represented.
+   */
+  Eigvals = "Eigvals",
 }
 
 export interface RoutineType {
@@ -119,6 +127,8 @@ export function runCpuRoutine(
       return runLU(type, inputAr, outputAr);
     case Routines.SVD:
       return runSVD(type, inputAr, outputAr, routine.params);
+    case Routines.Eigvals:
+      throw new Error("eigvals: CPU routine is not implemented yet");
     default:
       name satisfies never; // Exhaustiveness check
   }

--- a/src/routine.ts
+++ b/src/routine.ts
@@ -74,6 +74,14 @@ export enum Routines {
    *   such that `P = eye(M).slice(Permutation)` -> `P @ A = L @ U`.
    */
   LU = "LU",
+
+  /**
+   * Singular value decomposition of 2D matrices.
+   *
+   * The input is a batch of shape `[..., M, N]`. With `computeUv`, the output is
+   * `U, S, Vh`; otherwise the output is only `S`.
+   */
+  SVD = "SVD",
 }
 
 export interface RoutineType {
@@ -109,6 +117,8 @@ export function runCpuRoutine(
       return runCholesky(type, inputAr, outputAr);
     case Routines.LU:
       return runLU(type, inputAr, outputAr);
+    case Routines.SVD:
+      throw new Error("svd: CPU routine is not implemented yet");
     default:
       name satisfies never; // Exhaustiveness check
   }

--- a/src/routine.ts
+++ b/src/routine.ts
@@ -118,7 +118,7 @@ export function runCpuRoutine(
     case Routines.LU:
       return runLU(type, inputAr, outputAr);
     case Routines.SVD:
-      throw new Error("svd: CPU routine is not implemented yet");
+      return runSVD(type, inputAr, outputAr, routine.params);
     default:
       name satisfies never; // Exhaustiveness check
   }
@@ -273,6 +273,182 @@ function runLU(
           for (let col = j + 1; col < n; col++)
             out[i * n + col] -= factor * out[j * n + col];
         }
+      }
+    }
+  }
+}
+
+function identityMatrix(n: number): number[] {
+  const out = new Array(n * n).fill(0);
+  for (let i = 0; i < n; i++) out[i * n + i] = 1;
+  return out;
+}
+
+function transposeMatrix(a: number[], rows: number, cols: number): number[] {
+  const out = new Array(rows * cols);
+  for (let i = 0; i < rows; i++) {
+    for (let j = 0; j < cols; j++) out[j * rows + i] = a[i * cols + j];
+  }
+  return out;
+}
+
+function multiplyMatrix(
+  a: number[],
+  aRows: number,
+  aCols: number,
+  b: number[],
+  bCols: number,
+): number[] {
+  const out = new Array(aRows * bCols).fill(0);
+  for (let i = 0; i < aRows; i++) {
+    for (let k = 0; k < aCols; k++) {
+      const aik = a[i * aCols + k];
+      for (let j = 0; j < bCols; j++) {
+        out[i * bCols + j] += aik * b[k * bCols + j];
+      }
+    }
+  }
+  return out;
+}
+
+function symmetricJacobiEigen(
+  a: number[],
+  n: number,
+): { values: number[]; vectors: number[] } {
+  const work = a.slice();
+  const vectors = identityMatrix(n);
+  const maxIter = Math.max(50, 50 * n * n);
+
+  for (let iter = 0; iter < maxIter; iter++) {
+    let p = 0;
+    let q = 1;
+    let max = 0;
+    for (let i = 0; i < n; i++) {
+      for (let j = i + 1; j < n; j++) {
+        const value = Math.abs(work[i * n + j]);
+        if (value > max) {
+          max = value;
+          p = i;
+          q = j;
+        }
+      }
+    }
+
+    if (n < 2) break;
+    const scale = Math.max(
+      1,
+      Math.abs(work[p * n + p]),
+      Math.abs(work[q * n + q]),
+    );
+    if (max <= 1e-10 * scale) break;
+
+    const app = work[p * n + p];
+    const aqq = work[q * n + q];
+    const apq = work[p * n + q];
+    const tau = (aqq - app) / (2 * apq);
+    const t =
+      Math.sign(tau || 1) / (Math.abs(tau) + Math.sqrt(1 + tau * tau));
+    const c = 1 / Math.sqrt(1 + t * t);
+    const s = t * c;
+
+    for (let k = 0; k < n; k++) {
+      const wkp = work[k * n + p];
+      const wkq = work[k * n + q];
+      work[k * n + p] = c * wkp - s * wkq;
+      work[k * n + q] = s * wkp + c * wkq;
+    }
+    for (let k = 0; k < n; k++) {
+      const wpk = work[p * n + k];
+      const wqk = work[q * n + k];
+      work[p * n + k] = c * wpk - s * wqk;
+      work[q * n + k] = s * wpk + c * wqk;
+    }
+    for (let k = 0; k < n; k++) {
+      const vkp = vectors[k * n + p];
+      const vkq = vectors[k * n + q];
+      vectors[k * n + p] = c * vkp - s * vkq;
+      vectors[k * n + q] = s * vkp + c * vkq;
+    }
+  }
+
+  return {
+    values: Array.from({ length: n }, (_, i) => work[i * n + i]),
+    vectors,
+  };
+}
+
+function normalizeColumns(a: number[], rows: number, cols: number) {
+  for (let col = 0; col < cols; col++) {
+    let norm = 0;
+    for (let row = 0; row < rows; row++) {
+      norm = Math.hypot(norm, a[row * cols + col]);
+    }
+    if (norm === 0) continue;
+    for (let row = 0; row < rows; row++) a[row * cols + col] /= norm;
+  }
+}
+
+function runSVD(
+  type: RoutineType,
+  [a]: DataArray[],
+  outputs: DataArray[],
+  { computeUv, fullMatrices }: { computeUv: boolean; fullMatrices: boolean },
+) {
+  const shape = type.inputShapes[0];
+  if (shape.length < 2) throw new Error("svd: input must be at least 2D");
+  const m = shape[shape.length - 2];
+  const n = shape[shape.length - 1];
+  const k = Math.min(m, n);
+  const batches = a.length / (m * n);
+  const [uOut, sOut, vhOut] = computeUv
+    ? outputs
+    : [undefined, outputs[0], undefined];
+
+  for (let b = 0; b < batches; b++) {
+    const mat = Array.from(a.subarray(b * m * n, (b + 1) * m * n));
+    const at = transposeMatrix(mat, m, n);
+    const ata = multiplyMatrix(at, n, m, mat, n);
+    const eig = symmetricJacobiEigen(ata, n);
+    const order = eig.values
+      .map((value, index) => ({ value: Math.max(0, value), index }))
+      .sort((x, y) => y.value - x.value);
+    const singularValues = order
+      .slice(0, k)
+      .map((item) => Math.sqrt(item.value));
+
+    for (let i = 0; i < k; i++) sOut[b * k + i] = singularValues[i];
+    if (!computeUv) continue;
+
+    const v = new Array(n * n).fill(0);
+    for (let col = 0; col < n; col++) {
+      const src = order[col]?.index ?? col;
+      for (let row = 0; row < n; row++) {
+        v[row * n + col] = eig.vectors[row * n + src];
+      }
+    }
+
+    const uFull = identityMatrix(m);
+    for (let col = 0; col < k; col++) {
+      if (singularValues[col] <= 1e-12) continue;
+      for (let row = 0; row < m; row++) {
+        let sum = 0;
+        for (let j = 0; j < n; j++) sum += mat[row * n + j] * v[j * n + col];
+        uFull[row * m + col] = sum / singularValues[col];
+      }
+    }
+    normalizeColumns(uFull, m, m);
+
+    const uCols = fullMatrices ? m : k;
+    for (let row = 0; row < m; row++) {
+      for (let col = 0; col < uCols; col++) {
+        uOut![b * m * uCols + row * uCols + col] = uFull[row * m + col];
+      }
+    }
+
+    const vhRows = fullMatrices ? n : k;
+    for (let row = 0; row < vhRows; row++) {
+      for (let col = 0; col < n; col++) {
+        vhOut![b * vhRows * n + row * n + col] = v[col * n + row];
       }
     }
   }

--- a/src/routine.ts
+++ b/src/routine.ts
@@ -288,12 +288,6 @@ function runLU(
   }
 }
 
-function identityMatrix(n: number): number[] {
-  const out = new Array(n * n).fill(0);
-  for (let i = 0; i < n; i++) out[i * n + i] = 1;
-  return out;
-}
-
 function transposeMatrix(a: number[], rows: number, cols: number): number[] {
   const out = new Array(rows * cols);
   for (let i = 0; i < rows; i++) {
@@ -319,82 +313,6 @@ function multiplyMatrix(
     }
   }
   return out;
-}
-
-function symmetricJacobiEigen(
-  a: number[],
-  n: number,
-): { values: number[]; vectors: number[] } {
-  const work = a.slice();
-  const vectors = identityMatrix(n);
-  const maxIter = Math.max(50, 50 * n * n);
-
-  for (let iter = 0; iter < maxIter; iter++) {
-    let p = 0;
-    let q = 1;
-    let max = 0;
-    for (let i = 0; i < n; i++) {
-      for (let j = i + 1; j < n; j++) {
-        const value = Math.abs(work[i * n + j]);
-        if (value > max) {
-          max = value;
-          p = i;
-          q = j;
-        }
-      }
-    }
-
-    if (n < 2) break;
-    const scale = Math.max(
-      1,
-      Math.abs(work[p * n + p]),
-      Math.abs(work[q * n + q]),
-    );
-    if (max <= 1e-10 * scale) break;
-
-    const app = work[p * n + p];
-    const aqq = work[q * n + q];
-    const apq = work[p * n + q];
-    const tau = (aqq - app) / (2 * apq);
-    const t = Math.sign(tau || 1) / (Math.abs(tau) + Math.sqrt(1 + tau * tau));
-    const c = 1 / Math.sqrt(1 + t * t);
-    const s = t * c;
-
-    for (let k = 0; k < n; k++) {
-      const wkp = work[k * n + p];
-      const wkq = work[k * n + q];
-      work[k * n + p] = c * wkp - s * wkq;
-      work[k * n + q] = s * wkp + c * wkq;
-    }
-    for (let k = 0; k < n; k++) {
-      const wpk = work[p * n + k];
-      const wqk = work[q * n + k];
-      work[p * n + k] = c * wpk - s * wqk;
-      work[q * n + k] = s * wpk + c * wqk;
-    }
-    for (let k = 0; k < n; k++) {
-      const vkp = vectors[k * n + p];
-      const vkq = vectors[k * n + q];
-      vectors[k * n + p] = c * vkp - s * vkq;
-      vectors[k * n + q] = s * vkp + c * vkq;
-    }
-  }
-
-  return {
-    values: Array.from({ length: n }, (_, i) => work[i * n + i]),
-    vectors,
-  };
-}
-
-function normalizeColumns(a: number[], rows: number, cols: number) {
-  for (let col = 0; col < cols; col++) {
-    let norm = 0;
-    for (let row = 0; row < rows; row++) {
-      norm = Math.hypot(norm, a[row * cols + col]);
-    }
-    if (norm === 0) continue;
-    for (let row = 0; row < rows; row++) a[row * cols + col] /= norm;
-  }
 }
 
 function completeOrthonormalColumns(

--- a/src/routine.ts
+++ b/src/routine.ts
@@ -397,6 +397,329 @@ function normalizeColumns(a: number[], rows: number, cols: number) {
   }
 }
 
+function completeOrthonormalColumns(
+  basis: number[],
+  rows: number,
+  cols: number,
+): number[] {
+  const out = new Array(rows * rows).fill(0);
+  let outCol = 0;
+
+  const addCandidate = (candidate: number[]) => {
+    for (let col = 0; col < outCol; col++) {
+      let dot = 0;
+      for (let row = 0; row < rows; row++)
+        dot += candidate[row] * out[row * rows + col];
+      for (let row = 0; row < rows; row++)
+        candidate[row] -= dot * out[row * rows + col];
+    }
+    let norm = 0;
+    for (let row = 0; row < rows; row++)
+      norm = Math.hypot(norm, candidate[row]);
+    if (norm <= 1e-12) return;
+    for (let row = 0; row < rows; row++)
+      out[row * rows + outCol] = candidate[row] / norm;
+    outCol++;
+  };
+
+  for (let col = 0; col < cols && outCol < rows; col++) {
+    addCandidate(
+      Array.from({ length: rows }, (_, row) => basis[row * cols + col]),
+    );
+  }
+  for (let col = 0; col < rows && outCol < rows; col++) {
+    const candidate = new Array(rows).fill(0);
+    candidate[col] = 1;
+    addCandidate(candidate);
+  }
+  return out;
+}
+
+function golubReinschTallSVD(
+  input: number[],
+  m: number,
+  n: number,
+): { s: number[]; u: number[]; v: number[] } {
+  const a = input.slice();
+  const s = new Array(Math.min(m + 1, n)).fill(0);
+  const e = new Array(n).fill(0);
+  const work = new Array(m).fill(0);
+  const uCols = n;
+  const u = new Array(m * uCols).fill(0);
+  const v = new Array(n * n).fill(0);
+  const nct = Math.min(m - 1, n);
+  const nrt = Math.max(0, Math.min(n - 2, m));
+  const mrc = Math.max(nct, nrt);
+  const get = (row: number, col: number) => a[row * n + col];
+  const set = (row: number, col: number, value: number) => {
+    a[row * n + col] = value;
+  };
+
+  for (let k = 0; k < mrc; k++) {
+    if (k < nct) {
+      s[k] = 0;
+      for (let i = k; i < m; i++) s[k] = Math.hypot(s[k], get(i, k));
+      if (s[k] !== 0) {
+        if (get(k, k) < 0) s[k] = -s[k];
+        for (let i = k; i < m; i++) set(i, k, get(i, k) / s[k]);
+        set(k, k, get(k, k) + 1);
+      }
+      s[k] = -s[k];
+    }
+
+    for (let j = k + 1; j < n; j++) {
+      if (k < nct && s[k] !== 0) {
+        let t = 0;
+        for (let i = k; i < m; i++) t += get(i, k) * get(i, j);
+        t = -t / get(k, k);
+        for (let i = k; i < m; i++) set(i, j, get(i, j) + t * get(i, k));
+      }
+      e[j] = get(k, j);
+    }
+
+    if (k < nct) {
+      for (let i = k; i < m; i++) u[i * uCols + k] = get(i, k);
+    }
+
+    if (k < nrt) {
+      e[k] = 0;
+      for (let i = k + 1; i < n; i++) e[k] = Math.hypot(e[k], e[i]);
+      if (e[k] !== 0) {
+        if (e[k + 1] < 0) e[k] = -e[k];
+        for (let i = k + 1; i < n; i++) e[i] /= e[k];
+        e[k + 1] += 1;
+      }
+      e[k] = -e[k];
+      if (k + 1 < m && e[k] !== 0) {
+        for (let i = k + 1; i < m; i++) work[i] = 0;
+        for (let i = k + 1; i < m; i++) {
+          for (let j = k + 1; j < n; j++) work[i] += e[j] * get(i, j);
+        }
+        for (let j = k + 1; j < n; j++) {
+          const t = -e[j] / e[k + 1];
+          for (let i = k + 1; i < m; i++) set(i, j, get(i, j) + t * work[i]);
+        }
+      }
+      for (let i = k + 1; i < n; i++) v[i * n + k] = e[i];
+    }
+  }
+
+  const pInit = Math.min(n, m + 1);
+  if (nct < n) s[nct] = get(nct, nct);
+  if (m < pInit) s[pInit - 1] = 0;
+  if (nrt + 1 < pInit) e[nrt] = get(nrt, pInit - 1);
+  e[pInit - 1] = 0;
+
+  for (let j = nct; j < uCols; j++) {
+    for (let i = 0; i < m; i++) u[i * uCols + j] = 0;
+    u[j * uCols + j] = 1;
+  }
+  for (let k = nct - 1; k >= 0; k--) {
+    if (s[k] !== 0) {
+      for (let j = k + 1; j < uCols; j++) {
+        let t = 0;
+        for (let i = k; i < m; i++) t += u[i * uCols + k] * u[i * uCols + j];
+        t = -t / u[k * uCols + k];
+        for (let i = k; i < m; i++) u[i * uCols + j] += t * u[i * uCols + k];
+      }
+      for (let i = k; i < m; i++) u[i * uCols + k] = -u[i * uCols + k];
+      u[k * uCols + k] += 1;
+      for (let i = 0; i < k - 1; i++) u[i * uCols + k] = 0;
+    } else {
+      for (let i = 0; i < m; i++) u[i * uCols + k] = 0;
+      u[k * uCols + k] = 1;
+    }
+  }
+
+  for (let k = n - 1; k >= 0; k--) {
+    if (k < nrt && e[k] !== 0) {
+      for (let j = k + 1; j < n; j++) {
+        let t = 0;
+        for (let i = k + 1; i < n; i++) t += v[i * n + k] * v[i * n + j];
+        t = -t / v[(k + 1) * n + k];
+        for (let i = k + 1; i < n; i++) v[i * n + j] += t * v[i * n + k];
+      }
+    }
+    for (let i = 0; i < n; i++) v[i * n + k] = 0;
+    v[k * n + k] = 1;
+  }
+
+  let p = pInit;
+  const pp = p - 1;
+  let iter = 0;
+  const eps = Number.EPSILON;
+  while (p > 0) {
+    let k: number;
+    let kase: number;
+    for (k = p - 2; k >= -1; k--) {
+      if (k === -1) break;
+      const alpha =
+        Number.MIN_VALUE + eps * (Math.abs(s[k]) + Math.abs(s[k + 1]));
+      if (Math.abs(e[k]) <= alpha || Number.isNaN(e[k])) {
+        e[k] = 0;
+        break;
+      }
+    }
+    if (k === p - 2) {
+      kase = 4;
+    } else {
+      let ks: number;
+      for (ks = p - 1; ks >= k; ks--) {
+        if (ks === k) break;
+        const t =
+          (ks !== p ? Math.abs(e[ks]) : 0) +
+          (ks !== k + 1 ? Math.abs(e[ks - 1]) : 0);
+        if (Math.abs(s[ks]) <= eps * t) {
+          s[ks] = 0;
+          break;
+        }
+      }
+      if (ks === k) kase = 3;
+      else if (ks === p - 1) kase = 1;
+      else {
+        kase = 2;
+        k = ks;
+      }
+    }
+    k++;
+
+    switch (kase) {
+      case 1: {
+        let f = e[p - 2];
+        e[p - 2] = 0;
+        for (let j = p - 2; j >= k; j--) {
+          let t = Math.hypot(s[j], f);
+          const cs = s[j] / t;
+          const sn = f / t;
+          s[j] = t;
+          if (j !== k) {
+            f = -sn * e[j - 1];
+            e[j - 1] = cs * e[j - 1];
+          }
+          for (let i = 0; i < n; i++) {
+            t = cs * v[i * n + j] + sn * v[i * n + p - 1];
+            v[i * n + p - 1] = -sn * v[i * n + j] + cs * v[i * n + p - 1];
+            v[i * n + j] = t;
+          }
+        }
+        break;
+      }
+      case 2: {
+        let f = e[k - 1];
+        e[k - 1] = 0;
+        for (let j = k; j < p; j++) {
+          let t = Math.hypot(s[j], f);
+          const cs = s[j] / t;
+          const sn = f / t;
+          s[j] = t;
+          f = -sn * e[j];
+          e[j] = cs * e[j];
+          for (let i = 0; i < m; i++) {
+            t = cs * u[i * uCols + j] + sn * u[i * uCols + k - 1];
+            u[i * uCols + k - 1] =
+              -sn * u[i * uCols + j] + cs * u[i * uCols + k - 1];
+            u[i * uCols + j] = t;
+          }
+        }
+        break;
+      }
+      case 3: {
+        const scale = Math.max(
+          Math.abs(s[p - 1]),
+          Math.abs(s[p - 2]),
+          Math.abs(e[p - 2]),
+          Math.abs(s[k]),
+          Math.abs(e[k]),
+        );
+        const sp = s[p - 1] / scale;
+        const spm1 = s[p - 2] / scale;
+        const epm1 = e[p - 2] / scale;
+        const sk = s[k] / scale;
+        const ek = e[k] / scale;
+        const b = ((spm1 + sp) * (spm1 - sp) + epm1 * epm1) / 2;
+        const c = sp * epm1 * (sp * epm1);
+        let shift = 0;
+        if (b !== 0 || c !== 0) {
+          shift = b < 0 ? -Math.sqrt(b * b + c) : Math.sqrt(b * b + c);
+          shift = c / (b + shift);
+        }
+        let f = (sk + sp) * (sk - sp) + shift;
+        let g = sk * ek;
+        for (let j = k; j < p - 1; j++) {
+          let t = Math.hypot(f, g);
+          if (t === 0) t = Number.MIN_VALUE;
+          let cs = f / t;
+          let sn = g / t;
+          if (j !== k) e[j - 1] = t;
+          f = cs * s[j] + sn * e[j];
+          e[j] = cs * e[j] - sn * s[j];
+          g = sn * s[j + 1];
+          s[j + 1] = cs * s[j + 1];
+          for (let i = 0; i < n; i++) {
+            t = cs * v[i * n + j] + sn * v[i * n + j + 1];
+            v[i * n + j + 1] = -sn * v[i * n + j] + cs * v[i * n + j + 1];
+            v[i * n + j] = t;
+          }
+          t = Math.hypot(f, g);
+          if (t === 0) t = Number.MIN_VALUE;
+          cs = f / t;
+          sn = g / t;
+          s[j] = t;
+          f = cs * e[j] + sn * s[j + 1];
+          s[j + 1] = -sn * e[j] + cs * s[j + 1];
+          g = sn * e[j + 1];
+          e[j + 1] = cs * e[j + 1];
+          if (j < m - 1) {
+            for (let i = 0; i < m; i++) {
+              t = cs * u[i * uCols + j] + sn * u[i * uCols + j + 1];
+              u[i * uCols + j + 1] =
+                -sn * u[i * uCols + j] + cs * u[i * uCols + j + 1];
+              u[i * uCols + j] = t;
+            }
+          }
+        }
+        e[p - 2] = f;
+        iter++;
+        if (iter > 1000)
+          throw new Error("svd: QR iteration failed to converge");
+        break;
+      }
+      case 4: {
+        if (s[k] <= 0) {
+          s[k] = s[k] < 0 ? -s[k] : 0;
+          for (let i = 0; i <= pp; i++) v[i * n + k] = -v[i * n + k];
+        }
+        while (k < pp) {
+          if (s[k] >= s[k + 1]) break;
+          let t = s[k];
+          s[k] = s[k + 1];
+          s[k + 1] = t;
+          if (k < n - 1) {
+            for (let i = 0; i < n; i++) {
+              t = v[i * n + k + 1];
+              v[i * n + k + 1] = v[i * n + k];
+              v[i * n + k] = t;
+            }
+          }
+          if (k < m - 1) {
+            for (let i = 0; i < m; i++) {
+              t = u[i * uCols + k + 1];
+              u[i * uCols + k + 1] = u[i * uCols + k];
+              u[i * uCols + k] = t;
+            }
+          }
+          k++;
+        }
+        iter = 0;
+        p--;
+        break;
+      }
+    }
+  }
+
+  return { s: s.slice(0, n), u, v };
+}
+
 function runSVD(
   type: RoutineType,
   [a]: DataArray[],
@@ -415,37 +738,22 @@ function runSVD(
 
   for (let b = 0; b < batches; b++) {
     const mat = Array.from(a.subarray(b * m * n, (b + 1) * m * n));
-    const at = transposeMatrix(mat, m, n);
-    const ata = multiplyMatrix(at, n, m, mat, n);
-    const eig = symmetricJacobiEigen(ata, n);
-    const order = eig.values
-      .map((value, index) => ({ value: Math.max(0, value), index }))
-      .sort((x, y) => y.value - x.value);
-    const singularValues = order
-      .slice(0, k)
-      .map((item) => Math.sqrt(item.value));
+    const tall = m >= n;
+    const svd = tall
+      ? golubReinschTallSVD(mat, m, n)
+      : golubReinschTallSVD(transposeMatrix(mat, m, n), n, m);
+    const singularValues = svd.s.slice(0, k);
 
-    for (let i = 0; i < k; i++) sOut[b * k + i] = singularValues[i];
+    for (let i = 0; i < k; i++) sOut[b * k + i] = singularValues[i] ?? 0;
     if (!computeUv) continue;
 
-    const v = new Array(n * n).fill(0);
-    for (let col = 0; col < n; col++) {
-      const src = order[col]?.index ?? col;
-      for (let row = 0; row < n; row++) {
-        v[row * n + col] = eig.vectors[row * n + src];
-      }
-    }
-
-    const uFull = identityMatrix(m);
-    for (let col = 0; col < k; col++) {
-      if (singularValues[col] <= 1e-12) continue;
-      for (let row = 0; row < m; row++) {
-        let sum = 0;
-        for (let j = 0; j < n; j++) sum += mat[row * n + j] * v[j * n + col];
-        uFull[row * m + col] = sum / singularValues[col];
-      }
-    }
-    normalizeColumns(uFull, m, m);
+    const uBasis = tall ? svd.u : svd.v;
+    const uBasisCols = tall ? n : m;
+    const vBasis = tall ? svd.v : svd.u;
+    const vBasisRows = n;
+    const vBasisCols = tall ? n : m;
+    const uFull = completeOrthonormalColumns(uBasis, m, uBasisCols);
+    const vFull = completeOrthonormalColumns(vBasis, vBasisRows, vBasisCols);
 
     const uCols = fullMatrices ? m : k;
     for (let row = 0; row < m; row++) {
@@ -457,7 +765,7 @@ function runSVD(
     const vhRows = fullMatrices ? n : k;
     for (let row = 0; row < vhRows; row++) {
       for (let col = 0; col < n; col++) {
-        vhOut![b * vhRows * n + row * n + col] = v[col * n + row];
+        vhOut![b * vhRows * n + row * n + col] = vFull[col * n + row];
       }
     }
   }

--- a/test/numpy-linalg.test.ts
+++ b/test/numpy-linalg.test.ts
@@ -323,6 +323,23 @@ suite.each(devicesWithLinalg)("device:%s", (device) => {
       expect(s).toBeAllclose([5.0, 0.0], { rtol: 1e-4, atol: 1e-4 });
     });
 
+    svdTest("returns orthonormal full singular vector bases", () => {
+      const a = np.array([
+        [1.0, 0.0],
+        [1.0, 0.0],
+        [0.0, 0.0],
+      ]);
+      const [u, _s, vh] = np.linalg.svd(a.ref);
+      expect(np.matmul(u.ref.transpose(), u.ref)).toBeAllclose(np.eye(3), {
+        rtol: 1e-4,
+        atol: 1e-4,
+      });
+      expect(np.matmul(vh, vh.ref.transpose())).toBeAllclose(np.eye(2), {
+        rtol: 1e-4,
+        atol: 1e-4,
+      });
+    });
+
     svdTest("handles batched matrices", () => {
       const a = np.array([
         [

--- a/test/numpy-linalg.test.ts
+++ b/test/numpy-linalg.test.ts
@@ -266,6 +266,88 @@ suite.each(devicesWithLinalg)("device:%s", (device) => {
     });
   });
 
+  suite("numpy.linalg.svd()", () => {
+    test("reconstructs a square matrix", () => {
+      const a = np.array([
+        [3.0, 1.0],
+        [1.0, 3.0],
+      ]);
+      const [u, s, vh] = np.linalg.svd(a.ref);
+      const sigma = np.diag(s);
+      const reconstructed = np.matmul(np.matmul(u, sigma), vh);
+      expect(reconstructed).toBeAllclose(a, { rtol: 1e-4, atol: 1e-4 });
+      expect(s).toBeAllclose([4.0, 2.0], { rtol: 1e-4, atol: 1e-4 });
+    });
+
+    test("reconstructs a tall matrix with reduced factors", () => {
+      const a = np.array([
+        [1.0, 0.0],
+        [0.0, 2.0],
+        [0.0, 0.0],
+      ]);
+      const [u, s, vh] = np.linalg.svd(a.ref, { fullMatrices: false });
+      expect(u.shape).toEqual([3, 2]);
+      expect(s.shape).toEqual([2]);
+      expect(vh.shape).toEqual([2, 2]);
+      const sigma = np.diag(s);
+      const reconstructed = np.matmul(np.matmul(u, sigma), vh);
+      expect(reconstructed).toBeAllclose(a, { rtol: 1e-4, atol: 1e-4 });
+    });
+
+    test("reconstructs a wide matrix with reduced factors", () => {
+      const a = np.array([
+        [1.0, 0.0, 0.0],
+        [0.0, 2.0, 0.0],
+      ]);
+      const [u, s, vh] = np.linalg.svd(a.ref, { fullMatrices: false });
+      expect(u.shape).toEqual([2, 2]);
+      expect(s.shape).toEqual([2]);
+      expect(vh.shape).toEqual([2, 3]);
+      const sigma = np.diag(s);
+      const reconstructed = np.matmul(np.matmul(u, sigma), vh);
+      expect(reconstructed).toBeAllclose(a, { rtol: 1e-4, atol: 1e-4 });
+    });
+
+    test("returns singular values only when computeUv is false", () => {
+      const a = np.array([
+        [0.0, 0.0],
+        [0.0, 5.0],
+      ]);
+      const s = np.linalg.svd(a, { computeUv: false });
+      expect(s).toBeAllclose([5.0, 0.0], { rtol: 1e-4, atol: 1e-4 });
+    });
+
+    test("handles batched matrices", () => {
+      const a = np.array([
+        [
+          [1.0, 0.0],
+          [0.0, 2.0],
+        ],
+        [
+          [3.0, 0.0],
+          [0.0, 4.0],
+        ],
+      ]);
+      const [u, s, vh] = np.linalg.svd(a.ref);
+      expect(s).toBeAllclose(
+        [
+          [2.0, 1.0],
+          [4.0, 3.0],
+        ],
+        { rtol: 1e-4, atol: 1e-4 },
+      );
+      const sigma = np.zeros([2, 2, 2]);
+      const sigmaData = sigma.js() as number[][][];
+      const sData = s.js() as number[][];
+      for (let b = 0; b < 2; b++) {
+        sigmaData[b][0][0] = sData[b][0];
+        sigmaData[b][1][1] = sData[b][1];
+      }
+      const reconstructed = np.matmul(np.matmul(u, np.array(sigmaData)), vh);
+      expect(reconstructed).toBeAllclose(a, { rtol: 1e-4, atol: 1e-4 });
+    });
+  });
+
   suite("numpy.linalg.slogdet()", () => {
     test("computes slogdet of simple matrix", () => {
       const a = np.array([

--- a/test/numpy-linalg.test.ts
+++ b/test/numpy-linalg.test.ts
@@ -267,19 +267,25 @@ suite.each(devicesWithLinalg)("device:%s", (device) => {
   });
 
   suite("numpy.linalg.svd()", () => {
-    test("reconstructs a square matrix", () => {
+    const svdTest = device === "webgpu" ? test.skip : test;
+
+    svdTest("reconstructs a square matrix", () => {
       const a = np.array([
         [3.0, 1.0],
         [1.0, 3.0],
       ]);
       const [u, s, vh] = np.linalg.svd(a.ref);
-      const sigma = np.diag(s);
+      const sData = s.ref.js() as number[];
+      const sigma = np.diag(np.array(sData));
       const reconstructed = np.matmul(np.matmul(u, sigma), vh);
       expect(reconstructed).toBeAllclose(a, { rtol: 1e-4, atol: 1e-4 });
-      expect(s).toBeAllclose([4.0, 2.0], { rtol: 1e-4, atol: 1e-4 });
+      expect(np.array(sData)).toBeAllclose([4.0, 2.0], {
+        rtol: 1e-4,
+        atol: 1e-4,
+      });
     });
 
-    test("reconstructs a tall matrix with reduced factors", () => {
+    svdTest("reconstructs a tall matrix with reduced factors", () => {
       const a = np.array([
         [1.0, 0.0],
         [0.0, 2.0],
@@ -289,12 +295,12 @@ suite.each(devicesWithLinalg)("device:%s", (device) => {
       expect(u.shape).toEqual([3, 2]);
       expect(s.shape).toEqual([2]);
       expect(vh.shape).toEqual([2, 2]);
-      const sigma = np.diag(s);
+      const sigma = np.diag(s.ref);
       const reconstructed = np.matmul(np.matmul(u, sigma), vh);
       expect(reconstructed).toBeAllclose(a, { rtol: 1e-4, atol: 1e-4 });
     });
 
-    test("reconstructs a wide matrix with reduced factors", () => {
+    svdTest("reconstructs a wide matrix with reduced factors", () => {
       const a = np.array([
         [1.0, 0.0, 0.0],
         [0.0, 2.0, 0.0],
@@ -303,12 +309,12 @@ suite.each(devicesWithLinalg)("device:%s", (device) => {
       expect(u.shape).toEqual([2, 2]);
       expect(s.shape).toEqual([2]);
       expect(vh.shape).toEqual([2, 3]);
-      const sigma = np.diag(s);
+      const sigma = np.diag(s.ref);
       const reconstructed = np.matmul(np.matmul(u, sigma), vh);
       expect(reconstructed).toBeAllclose(a, { rtol: 1e-4, atol: 1e-4 });
     });
 
-    test("returns singular values only when computeUv is false", () => {
+    svdTest("returns singular values only when computeUv is false", () => {
       const a = np.array([
         [0.0, 0.0],
         [0.0, 5.0],
@@ -317,7 +323,7 @@ suite.each(devicesWithLinalg)("device:%s", (device) => {
       expect(s).toBeAllclose([5.0, 0.0], { rtol: 1e-4, atol: 1e-4 });
     });
 
-    test("handles batched matrices", () => {
+    svdTest("handles batched matrices", () => {
       const a = np.array([
         [
           [1.0, 0.0],
@@ -329,7 +335,8 @@ suite.each(devicesWithLinalg)("device:%s", (device) => {
         ],
       ]);
       const [u, s, vh] = np.linalg.svd(a.ref);
-      expect(s).toBeAllclose(
+      const sData = s.ref.js() as number[][];
+      expect(np.array(sData)).toBeAllclose(
         [
           [2.0, 1.0],
           [4.0, 3.0],
@@ -338,7 +345,6 @@ suite.each(devicesWithLinalg)("device:%s", (device) => {
       );
       const sigma = np.zeros([2, 2, 2]);
       const sigmaData = sigma.js() as number[][][];
-      const sData = s.js() as number[][];
       for (let b = 0; b < 2; b++) {
         sigmaData[b][0][0] = sData[b][0];
         sigmaData[b][1][1] = sData[b][1];

--- a/test/numpy-linalg.test.ts
+++ b/test/numpy-linalg.test.ts
@@ -354,6 +354,65 @@ suite.each(devicesWithLinalg)("device:%s", (device) => {
     });
   });
 
+  suite("numpy.linalg.eigvals()", () => {
+    const eigvalsTest = device === "webgpu" ? test.skip : test;
+
+    eigvalsTest("returns diagonal entries for a diagonal matrix", () => {
+      const a = np.array([
+        [3.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0],
+        [0.0, 0.0, 2.0],
+      ]);
+      expect(np.sort(np.linalg.eigvals(a))).toBeAllclose([1.0, 2.0, 3.0]);
+    });
+
+    eigvalsTest("returns eigenvalues for an upper triangular matrix", () => {
+      const a = np.array([
+        [5.0, 2.0],
+        [0.0, -1.0],
+      ]);
+      expect(np.sort(np.linalg.eigvals(a))).toBeAllclose([-1.0, 5.0]);
+    });
+
+    eigvalsTest("handles a real-spectrum nonsymmetric matrix", () => {
+      const a = np.array([
+        [1.0, 2.0],
+        [3.0, 4.0],
+      ]);
+      expect(np.sort(np.linalg.eigvals(a))).toBeAllclose(
+        [-0.3722813, 5.3722813],
+        { rtol: 1e-4, atol: 1e-4 },
+      );
+    });
+
+    eigvalsTest("handles batched matrices", () => {
+      const a = np.array([
+        [
+          [1.0, 0.0],
+          [0.0, 2.0],
+        ],
+        [
+          [3.0, 0.0],
+          [0.0, 4.0],
+        ],
+      ]);
+      expect(np.sort(np.linalg.eigvals(a))).toBeAllclose([
+        [1.0, 2.0],
+        [3.0, 4.0],
+      ]);
+    });
+
+    eigvalsTest("throws for complex eigenvalue pairs", () => {
+      const a = np.array([
+        [0.0, -1.0],
+        [1.0, 0.0],
+      ]);
+      expect(() => np.linalg.eigvals(a).js()).toThrow(
+        /complex eigenvalues are not supported/,
+      );
+    });
+  });
+
   suite("numpy.linalg.slogdet()", () => {
     test("computes slogdet of simple matrix", () => {
       const a = np.array([

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,14 @@ import { configDefaults, defineConfig } from "vitest/config";
 const BROWSER = process.env.BROWSER || "chromium";
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@jax-js/jax": "/src/index.ts",
+      "@jax-js/loaders": "/packages/loaders/src/index.ts",
+      "@jax-js/onnx": "/packages/onnx/src/index.ts",
+      "@jax-js/optax": "/packages/optax/src/index.ts",
+    },
+  },
   oxc: {
     target: "es2025",
   },


### PR DESCRIPTION
Implements CPU QR-style linear algebra primitives for singular values and eigenvalues, with frontend plumbing, WebGPU fallbacks, and tests.

Highlights:
- Adds `np.linalg.svd` / `lax.linalg.svd`
- Adds `np.linalg.eigvals` / `lax.linalg.eigvals`
- Implements bidiagonal QR-style SVD and Hessenberg QR eigenvalue iteration on CPU
- Adds tests for SVD orthogonality and eigvals coverage
- Marks these routines unsupported on WebGPU for now