### PR TITLE
Add more ONNX operator support (+24 ops)

### DIFF
--- a/packages/onnx/src/model.test.ts
+++ b/packages/onnx/src/model.test.ts
@@ -65,6 +65,14 @@ function intTensorInfo(name: string, shape: number[]) {
   return tensorInfo(name, shape, TensorProto_DataType.INT32);
 }
 
+function uintTensorInfo(name: string, shape: number[]) {
+  return tensorInfo(name, shape, TensorProto_DataType.UINT32);
+}
+
+function boolTensorInfo(name: string, shape: number[]) {
+  return tensorInfo(name, shape, TensorProto_DataType.BOOL);
+}
+
 /**
  * Helper to create a constant tensor initializer.
  */
@@ -91,6 +99,14 @@ function intAttr(name: string, value: number) {
     name,
     type: AttributeProto_AttributeType.INT,
     i: BigInt(value),
+  });
+}
+
+function intsAttr(name: string, value: number[]) {
+  return create(AttributeProtoSchema, {
+    name,
+    type: AttributeProto_AttributeType.INTS,
+    ints: value.map(BigInt),
   });
 }
 
@@ -247,6 +263,99 @@ test("should evaluate MatMul", async () => {
   expect(await result.C.data()).toEqual(new Float32Array([22, 28, 49, 64]));
 });
 
+test("should evaluate Trilu", async () => {
+  const model = create(ModelProtoSchema, {
+    irVersion: 8n,
+    opsetImport: [create(OperatorSetIdProtoSchema, { version: 14n })],
+    graph: create(GraphProtoSchema, {
+      name: "trilu_graph",
+      input: [floatTensorInfo("X", [2, 3])],
+      output: [floatTensorInfo("Y", [2, 3])],
+      initializer: [int64Initializer("K", [], [-1])],
+      node: [
+        create(NodeProtoSchema, {
+          opType: "Trilu",
+          input: ["X", "K"],
+          output: ["Y"],
+          attribute: [intAttr("upper", 0)],
+        }),
+      ],
+    }),
+  });
+
+  const onnxModel = new ONNXModel(toBinary(ModelProtoSchema, model));
+  onTestFinished(() => onnxModel.dispose());
+
+  const x = np.array([1, 2, 3, 4, 5, 6]).reshape([2, 3]);
+  const result = onnxModel.run({ X: x });
+
+  expect(await result.Y.data()).toEqual(new Float32Array([0, 0, 0, 4, 0, 0]));
+});
+
+test("should evaluate EyeLike", async () => {
+  const model = create(ModelProtoSchema, {
+    irVersion: 8n,
+    opsetImport: [create(OperatorSetIdProtoSchema, { version: 14n })],
+    graph: create(GraphProtoSchema, {
+      name: "eyelike_graph",
+      input: [floatTensorInfo("X", [2, 4])],
+      output: [intTensorInfo("Y", [2, 4])],
+      node: [
+        create(NodeProtoSchema, {
+          opType: "EyeLike",
+          input: ["X"],
+          output: ["Y"],
+          attribute: [
+            intAttr("dtype", TensorProto_DataType.INT32),
+            intAttr("k", 1),
+          ],
+        }),
+      ],
+    }),
+  });
+
+  const onnxModel = new ONNXModel(toBinary(ModelProtoSchema, model));
+  onTestFinished(() => onnxModel.dispose());
+
+  const x = np.zeros([2, 4]);
+  const result = onnxModel.run({ X: x });
+
+  expect(await result.Y.data()).toEqual(
+    new Int32Array([0, 1, 0, 0, 0, 0, 1, 0]),
+  );
+});
+
+test("should evaluate LpNormalization", async () => {
+  const model = create(ModelProtoSchema, {
+    irVersion: 8n,
+    opsetImport: [create(OperatorSetIdProtoSchema, { version: 14n })],
+    graph: create(GraphProtoSchema, {
+      name: "lp_normalization_graph",
+      input: [floatTensorInfo("X", [2, 3])],
+      output: [floatTensorInfo("Y", [2, 3])],
+      node: [
+        create(NodeProtoSchema, {
+          opType: "LpNormalization",
+          input: ["X"],
+          output: ["Y"],
+          attribute: [intAttr("axis", 1), intAttr("p", 2)],
+        }),
+      ],
+    }),
+  });
+
+  const onnxModel = new ONNXModel(toBinary(ModelProtoSchema, model));
+  onTestFinished(() => onnxModel.dispose());
+
+  const x = np.array([3, 4, 0, 0, 0, 0]).reshape([2, 3]);
+  const result = onnxModel.run({ X: x });
+
+  expect(result.Y).toBeAllclose([
+    [0.6, 0.8, 0],
+    [0, 0, 0],
+  ]);
+});
+
 test("should evaluate Relu", async () => {
   const model = create(ModelProtoSchema, {
     irVersion: 8n,
@@ -272,6 +381,313 @@ test("should evaluate Relu", async () => {
   const result = onnxModel.run({ X: x });
 
   expect(await result.Y.data()).toEqual(new Float32Array([0, 0, 0, 1, 2, 3]));
+});
+
+test("should evaluate ONNX activation elementwise ops", async () => {
+  const model = create(ModelProtoSchema, {
+    irVersion: 8n,
+    opsetImport: [create(OperatorSetIdProtoSchema, { version: 18n })],
+    graph: create(GraphProtoSchema, {
+      name: "activation_elementwise_graph",
+      input: [floatTensorInfo("X", [5])],
+      output: [
+        floatTensorInfo("hard_sigmoid", [5]),
+        floatTensorInfo("hard_swish", [5]),
+        floatTensorInfo("selu", [5]),
+        floatTensorInfo("prelu", [5]),
+        floatTensorInfo("thresholded_relu", [5]),
+        floatTensorInfo("shrink", [5]),
+      ],
+      initializer: [floatInitializer("slope", [1], [0.25])],
+      node: [
+        create(NodeProtoSchema, {
+          opType: "HardSigmoid",
+          input: ["X"],
+          output: ["hard_sigmoid"],
+          attribute: [floatAttr("alpha", 0.5), floatAttr("beta", 0.25)],
+        }),
+        create(NodeProtoSchema, {
+          opType: "HardSwish",
+          input: ["X"],
+          output: ["hard_swish"],
+        }),
+        create(NodeProtoSchema, {
+          opType: "Selu",
+          input: ["X"],
+          output: ["selu"],
+          attribute: [floatAttr("alpha", 2), floatAttr("gamma", 0.5)],
+        }),
+        create(NodeProtoSchema, {
+          opType: "PRelu",
+          input: ["X", "slope"],
+          output: ["prelu"],
+        }),
+        create(NodeProtoSchema, {
+          opType: "ThresholdedRelu",
+          input: ["X"],
+          output: ["thresholded_relu"],
+          attribute: [floatAttr("alpha", 1)],
+        }),
+        create(NodeProtoSchema, {
+          opType: "Shrink",
+          input: ["X"],
+          output: ["shrink"],
+          attribute: [floatAttr("lambd", 1), floatAttr("bias", 0.5)],
+        }),
+      ],
+    }),
+  });
+
+  const onnxModel = new ONNXModel(toBinary(ModelProtoSchema, model));
+  onTestFinished(() => onnxModel.dispose());
+
+  const x = np.array([-2, -1, 0, 1, 2]);
+  const result = onnxModel.run({ X: x });
+
+  expect(result.hard_sigmoid).toBeAllclose([0, 0, 0.25, 0.75, 1]);
+  expect(result.hard_swish).toBeAllclose([-1 / 3, -1 / 3, 0, 2 / 3, 5 / 3]);
+  expect(result.selu).toBeAllclose([
+    Math.exp(-2) - 1,
+    Math.exp(-1) - 1,
+    0,
+    0.5,
+    1,
+  ]);
+  expect(result.prelu).toBeAllclose([-0.5, -0.25, 0, 1, 2]);
+  expect(await result.thresholded_relu.data()).toEqual(
+    new Float32Array([0, 0, 0, 0, 2]),
+  );
+  expect(result.shrink).toBeAllclose([-1.5, 0, 0, 0, 1.5]);
+});
+
+test("should evaluate logical, numeric classification, and extrema elementwise ops", async () => {
+  const model = create(ModelProtoSchema, {
+    irVersion: 8n,
+    opsetImport: [create(OperatorSetIdProtoSchema, { version: 20n })],
+    graph: create(GraphProtoSchema, {
+      name: "logical_numeric_elementwise_graph",
+      input: [
+        boolTensorInfo("A", [4]),
+        boolTensorInfo("B", [4]),
+        floatTensorInfo("X", [6]),
+        floatTensorInfo("F", [4]),
+        floatTensorInfo("M1", [3]),
+        floatTensorInfo("M2", [3]),
+        floatTensorInfo("M3", [3]),
+      ],
+      output: [
+        boolTensorInfo("and", [4]),
+        boolTensorInfo("or", [4]),
+        boolTensorInfo("xor", [4]),
+        floatTensorInfo("rounded", [6]),
+        boolTensorInfo("pos_inf", [4]),
+        boolTensorInfo("nan", [4]),
+        floatTensorInfo("min", [3]),
+        floatTensorInfo("max", [3]),
+      ],
+      node: [
+        create(NodeProtoSchema, {
+          opType: "And",
+          input: ["A", "B"],
+          output: ["and"],
+        }),
+        create(NodeProtoSchema, {
+          opType: "Or",
+          input: ["A", "B"],
+          output: ["or"],
+        }),
+        create(NodeProtoSchema, {
+          opType: "Xor",
+          input: ["A", "B"],
+          output: ["xor"],
+        }),
+        create(NodeProtoSchema, {
+          opType: "Round",
+          input: ["X"],
+          output: ["rounded"],
+        }),
+        create(NodeProtoSchema, {
+          opType: "IsInf",
+          input: ["F"],
+          output: ["pos_inf"],
+          attribute: [
+            intAttr("detect_negative", 0),
+            intAttr("detect_positive", 1),
+          ],
+        }),
+        create(NodeProtoSchema, {
+          opType: "IsNaN",
+          input: ["F"],
+          output: ["nan"],
+        }),
+        create(NodeProtoSchema, {
+          opType: "Min",
+          input: ["M1", "M2", "M3"],
+          output: ["min"],
+        }),
+        create(NodeProtoSchema, {
+          opType: "Max",
+          input: ["M1", "M2", "M3"],
+          output: ["max"],
+        }),
+      ],
+    }),
+  });
+
+  const onnxModel = new ONNXModel(toBinary(ModelProtoSchema, model));
+  onTestFinished(() => onnxModel.dispose());
+
+  const result = onnxModel.run({
+    A: np.array([true, true, false, false]),
+    B: np.array([true, false, true, false]),
+    X: np.array([-0, -4.5, -1.5, 1.5, 2.5, 3.2]),
+    F: np.array([-Infinity, Infinity, NaN, 0]),
+    M1: np.array([1, 5, -2]),
+    M2: np.array([2, 4, -3]),
+    M3: np.array([0, 6, -1]),
+  });
+
+  expect(await result.and.data()).toEqual(new Int32Array([1, 0, 0, 0]));
+  expect(await result.or.data()).toEqual(new Int32Array([1, 1, 1, 0]));
+  expect(await result.xor.data()).toEqual(new Int32Array([0, 1, 1, 0]));
+
+  const rounded = await result.rounded.data();
+  expect(Object.is(rounded[0], -0)).toBe(true);
+  expect(rounded.slice(1)).toEqual(new Float32Array([-4, -2, 2, 2, 3]));
+
+  expect(await result.pos_inf.data()).toEqual(new Int32Array([0, 1, 0, 0]));
+  expect(await result.nan.data()).toEqual(new Int32Array([0, 0, 1, 0]));
+  expect(await result.min.data()).toEqual(new Float32Array([0, 4, -3]));
+  expect(await result.max.data()).toEqual(new Float32Array([2, 6, -1]));
+});
+
+test("should evaluate bitwise elementwise ops and BitCast", async () => {
+  const model = create(ModelProtoSchema, {
+    irVersion: 8n,
+    opsetImport: [create(OperatorSetIdProtoSchema, { version: 18n })],
+    graph: create(GraphProtoSchema, {
+      name: "bitwise_elementwise_graph",
+      input: [
+        uintTensorInfo("U", [3]),
+        uintTensorInfo("V", [3]),
+        intTensorInfo("I", [2]),
+      ],
+      output: [
+        uintTensorInfo("and", [3]),
+        uintTensorInfo("or", [3]),
+        uintTensorInfo("xor", [3]),
+        uintTensorInfo("not", [3]),
+        uintTensorInfo("left", [3]),
+        uintTensorInfo("right", [3]),
+        floatTensorInfo("bitcast", [2]),
+      ],
+      node: [
+        create(NodeProtoSchema, {
+          opType: "BitwiseAnd",
+          input: ["U", "V"],
+          output: ["and"],
+        }),
+        create(NodeProtoSchema, {
+          opType: "BitwiseOr",
+          input: ["U", "V"],
+          output: ["or"],
+        }),
+        create(NodeProtoSchema, {
+          opType: "BitwiseXor",
+          input: ["U", "V"],
+          output: ["xor"],
+        }),
+        create(NodeProtoSchema, {
+          opType: "BitwiseNot",
+          input: ["U"],
+          output: ["not"],
+        }),
+        create(NodeProtoSchema, {
+          opType: "BitShift",
+          input: ["U", "V"],
+          output: ["left"],
+          attribute: [stringAttr("direction", "LEFT")],
+        }),
+        create(NodeProtoSchema, {
+          opType: "BitShift",
+          input: ["U", "V"],
+          output: ["right"],
+          attribute: [stringAttr("direction", "RIGHT")],
+        }),
+        create(NodeProtoSchema, {
+          opType: "BitCast",
+          input: ["I"],
+          output: ["bitcast"],
+          attribute: [intAttr("to", TensorProto_DataType.FLOAT)],
+        }),
+      ],
+    }),
+  });
+
+  const onnxModel = new ONNXModel(toBinary(ModelProtoSchema, model));
+  onTestFinished(() => onnxModel.dispose());
+
+  const result = onnxModel.run({
+    U: np.array([1, 6, 0xffffffff], { dtype: np.uint32 }),
+    V: np.array([2, 1, 4], { dtype: np.uint32 }),
+    I: np.array([1065353216, -1082130432], { dtype: np.int32 }),
+  });
+
+  expect(await result.and.data()).toEqual(new Uint32Array([0, 0, 4]));
+  expect(await result.or.data()).toEqual(new Uint32Array([3, 7, 0xffffffff]));
+  expect(await result.xor.data()).toEqual(new Uint32Array([3, 7, 0xfffffffb]));
+  expect(await result.not.data()).toEqual(
+    new Uint32Array([0xfffffffe, 0xfffffff9, 0]),
+  );
+  expect(await result.left.data()).toEqual(
+    new Uint32Array([4, 12, 0xfffffff0]),
+  );
+  expect(await result.right.data()).toEqual(
+    new Uint32Array([0, 3, 0x0fffffff]),
+  );
+  expect(await result.bitcast.data()).toEqual(new Float32Array([1, -1]));
+});
+
+test("should evaluate MeanVarianceNormalization", async () => {
+  const model = create(ModelProtoSchema, {
+    irVersion: 8n,
+    opsetImport: [create(OperatorSetIdProtoSchema, { version: 13n })],
+    graph: create(GraphProtoSchema, {
+      name: "mean_variance_normalization_graph",
+      input: [floatTensorInfo("X", [1, 2, 2, 2])],
+      output: [floatTensorInfo("Y", [1, 2, 2, 2])],
+      node: [
+        create(NodeProtoSchema, {
+          opType: "MeanVarianceNormalization",
+          input: ["X"],
+          output: ["Y"],
+          attribute: [intsAttr("axes", [0, 2, 3])],
+        }),
+      ],
+    }),
+  });
+
+  const onnxModel = new ONNXModel(toBinary(ModelProtoSchema, model));
+  onTestFinished(() => onnxModel.dispose());
+
+  const x = np.array([1, 2, 3, 4, 2, 4, 6, 8]).reshape([1, 2, 2, 2]);
+  const result = onnxModel.run({ X: x });
+
+  expect(result.Y).toBeAllclose(
+    [
+      [
+        [
+          [-1.3416408, -0.4472136],
+          [0.4472136, 1.3416408],
+        ],
+        [
+          [-1.3416408, -0.4472136],
+          [0.4472136, 1.3416408],
+        ],
+      ],
+    ],
+    { atol: 1e-5 },
+  );
 });
 
 test("should evaluate Reshape", async () => {

--- a/packages/onnx/src/ops.ts
+++ b/packages/onnx/src/ops.ts
@@ -8,6 +8,7 @@
 
 export * from "./ops/convolution";
 export * from "./ops/elementwise";
+export * from "./ops/linalg";
 export * from "./ops/movement";
 export * from "./ops/reduction";
 export * from "./ops/utility";

--- a/packages/onnx/src/ops/elementwise.ts
+++ b/packages/onnx/src/ops/elementwise.ts
@@ -19,6 +19,10 @@ function isIntegerDtype(dtype: DType): boolean {
   return dtype === np.int32 || dtype === np.uint32 || dtype === np.bool;
 }
 
+function isBitwiseDtype(dtype: DType): boolean {
+  return dtype === np.int32 || dtype === np.uint32;
+}
+
 function wrapFn(
   fn: (...args: np.Array[]) => np.Array,
   staticFn?: (...args: number[]) => number,
@@ -58,6 +62,15 @@ function wrapFn(
   };
 }
 
+function wrapBitwiseFn(fn: (...args: np.Array[]) => np.Array) {
+  return (inputs: Operand[]): Operand[] => {
+    if (!inputs.every((op) => isBitwiseDtype(op.dtype))) {
+      throw new Error("ONNX bitwise operators only support integer tensors");
+    }
+    return [fn(...inputs.map(operandToJax))];
+  };
+}
+
 export const Add = wrapFn(np.add, (a, b) => a + b);
 export const Sub = wrapFn(np.subtract, (a, b) => a - b);
 export const Mul = wrapFn(np.multiply, (a, b) => a * b);
@@ -71,6 +84,19 @@ export const Reciprocal = wrapFn(np.reciprocal);
 export const Floor = wrapFn(np.floor);
 export const Ceil = wrapFn(np.ceil);
 export const Identity = wrapFn((x) => x);
+
+export function Round([xOp]: Operand[]): Operand[] {
+  const x = operandToJax(xOp);
+  return [np.where(x.ref.equal(0), x.ref, np.round(x))];
+}
+
+export function Min(inputs: Operand[]): Operand[] {
+  return [inputs.map(operandToJax).reduce((a, b) => np.minimum(a, b))];
+}
+
+export function Max(inputs: Operand[]): Operand[] {
+  return [inputs.map(operandToJax).reduce((a, b) => np.maximum(a, b))];
+}
 
 export const Equal = wrapFn(np.equal, (a, b) => Number(a === b), np.bool);
 export const Less = wrapFn(np.less, (a, b) => Number(a < b), np.bool);
@@ -91,8 +117,56 @@ export const Clip = wrapFn(np.clip);
 
 export const IsNaN = wrapFn(np.isnan);
 
+export function IsInf(
+  [xOp]: Operand[],
+  {
+    detect_negative = 1,
+    detect_positive = 1,
+  }: { detect_negative?: number; detect_positive?: number },
+): Operand[] {
+  const x = operandToJax(xOp);
+  if (detect_negative && detect_positive) return [np.isinf(x)];
+  if (detect_negative) return [np.isneginf(x)];
+  if (detect_positive) return [np.isposinf(x)];
+  return [np.fullLike(x, false, { dtype: np.bool })];
+}
+
+export const And = wrapFn(
+  np.logicalAnd,
+  (a, b) => Number(Boolean(a) && Boolean(b)),
+  np.bool,
+);
+export const Or = wrapFn(
+  np.logicalOr,
+  (a, b) => Number(Boolean(a) || Boolean(b)),
+  np.bool,
+);
+export const Xor = wrapFn(
+  np.logicalXor,
+  (a, b) => Number(Boolean(a) !== Boolean(b)),
+  np.bool,
+);
+
 export function Not([x]: Operand[]): Operand[] {
   return [np.notEqual(operandToJax(x), true)];
+}
+
+export const BitwiseAnd = wrapBitwiseFn(np.bitwiseAnd);
+export const BitwiseOr = wrapBitwiseFn(np.bitwiseOr);
+export const BitwiseXor = wrapBitwiseFn(np.bitwiseXor);
+export const BitwiseNot = wrapBitwiseFn(np.bitwiseNot);
+
+export function BitShift(
+  inputs: Operand[],
+  { direction }: { direction: "LEFT" | "RIGHT" },
+): Operand[] {
+  if (!inputs.every((op) => op.dtype === np.uint32)) {
+    throw new Error("ONNX BitShift only supports unsigned integer tensors");
+  }
+  const [x, y] = inputs.map(operandToJax);
+  if (direction === "LEFT") return [np.leftShift(x, y)];
+  if (direction === "RIGHT") return [np.rightShift(x, y)];
+  throw new Error(`Unsupported BitShift direction: ${direction}`);
 }
 
 export const Sin = wrapFn(np.sin);
@@ -121,6 +195,57 @@ export const Celu = wrapFn(nn.celu);
 export const Softplus = wrapFn(nn.softplus);
 export const Softsign = wrapFn(nn.softSign);
 export const Mish = wrapFn(nn.mish);
+export const HardSwish = wrapFn(nn.hardSwish);
+
+export function HardSigmoid(
+  [xOp]: Operand[],
+  { alpha = 0.2, beta = 0.5 }: { alpha?: number; beta?: number },
+): Operand[] {
+  const x = operandToJax(xOp);
+  return [np.clip(x.mul(alpha).add(beta), 0, 1)];
+}
+
+export function Selu(
+  [xOp]: Operand[],
+  {
+    alpha = 1.67326319217681884765625,
+    gamma = 1.05070102214813232421875,
+  }: { alpha?: number; gamma?: number },
+): Operand[] {
+  const x = operandToJax(xOp);
+  return [
+    np.where(x.ref.lessEqual(0), np.expm1(x.ref).mul(alpha), x).mul(gamma),
+  ];
+}
+
+export function PRelu([xOp, slopeOp]: Operand[]): Operand[] {
+  const x = operandToJax(xOp);
+  const slope = operandToJax(slopeOp);
+  return [np.where(x.ref.less(0), x.ref.mul(slope), x)];
+}
+
+export function ThresholdedRelu(
+  [xOp]: Operand[],
+  { alpha = 1.0 }: { alpha?: number },
+): Operand[] {
+  const x = operandToJax(xOp);
+  return [np.where(x.ref.greater(alpha), x, np.zerosLike(x.ref))];
+}
+
+export function Shrink(
+  [xOp]: Operand[],
+  { bias = 0.0, lambd = 0.5 }: { bias?: number; lambd?: number },
+): Operand[] {
+  const x = operandToJax(xOp);
+  const negative = x.ref.less(-lambd);
+  const positive = x.ref.greater(lambd);
+  const positiveOrZero = np.where(
+    positive,
+    x.ref.sub(bias),
+    np.zerosLike(x.ref),
+  );
+  return [np.where(negative, x.add(bias), positiveOrZero)];
+}
 
 export function Gelu(
   inputs: Operand[],

--- a/packages/onnx/src/ops/linalg.ts
+++ b/packages/onnx/src/ops/linalg.ts
@@ -1,0 +1,84 @@
+// Linear algebra routines.
+
+import { numpy as np } from "@jax-js/jax";
+
+import {
+  onnxDtypeToJax,
+  type Operand,
+  operandToJax,
+  operandToJs,
+} from "../tensor";
+
+export function Det([xOp]: Operand[]): Operand[] {
+  const x = operandToJax(xOp);
+  return [np.linalg.det(x)];
+}
+
+export function EyeLike(
+  [inputOp]: Operand[],
+  { dtype, k = 0 }: { dtype?: number; k?: number } = {},
+): Operand[] {
+  const input = operandToJax(inputOp);
+  if (input.ndim !== 2) {
+    const ndim = input.ndim;
+    input.dispose();
+    throw new Error(`EyeLike: input must be 2D, got ${ndim}D`);
+  }
+  const [rows, cols] = input.shape;
+  const outDtype = dtype === undefined ? input.dtype : onnxDtypeToJax(dtype);
+  const device = input.device;
+  input.dispose();
+
+  if (k > 0) {
+    if (k >= cols) return [np.zeros([rows, cols], { dtype: outDtype, device })];
+    return [
+      np.pad(np.eye(rows, cols - k, { dtype: outDtype, device }), [
+        [0, 0],
+        [k, 0],
+      ]),
+    ];
+  } else if (k < 0) {
+    if (-k >= rows)
+      return [np.zeros([rows, cols], { dtype: outDtype, device })];
+    return [
+      np.pad(np.eye(rows + k, cols, { dtype: outDtype, device }), [
+        [-k, 0],
+        [0, 0],
+      ]),
+    ];
+  }
+  return [np.eye(rows, cols, { dtype: outDtype, device })];
+}
+
+export function LpNormalization(
+  [xOp]: Operand[],
+  { axis = -1, p = 2 }: { axis?: number; p?: number } = {},
+): Operand[] {
+  if (p !== 1 && p !== 2) {
+    throw new Error(`LpNormalization: p must be 1 or 2, got ${p}`);
+  }
+
+  const x = operandToJax(xOp);
+  const norm = np.linalg.vectorNorm(x.ref, { ord: p, axis, keepdims: true });
+  const safeNorm = np.where(norm.ref.equal(0), np.onesLike(norm.ref), norm);
+  return [x.div(safeNorm)];
+}
+
+export function Trilu(
+  [xOp, kOp]: Operand[],
+  { upper = 1 }: { upper?: number } = {},
+): Operand[] {
+  const x = operandToJax(xOp);
+  let k = 0;
+  if (kOp) {
+    const kValue = operandToJs(kOp);
+    if (typeof kValue !== "number" || !Number.isInteger(kValue)) {
+      x.dispose();
+      throw new Error(
+        `Trilu: k must be an integer, got ${JSON.stringify(kValue)}`,
+      );
+    }
+    k = kValue;
+  }
+  return [upper ? np.triu(x, k) : np.tril(x, k)];
+}

--- a/packages/onnx/src/ops/reduction.ts
+++ b/packages/onnx/src/ops/reduction.ts
@@ -53,6 +53,23 @@ export const ReduceProd = wrapReduction(np.prod);
 export const ReduceSum = wrapReduction(np.sum);
 export const ReduceSumSquare = wrapReduction(np.sum, { prelude: np.square });
 
+export function MeanVarianceNormalization(
+  [xOp]: Operand[],
+  { axes = [0, 2, 3] }: { axes?: number[] },
+): Operand[] {
+  const x = operandToJax(xOp);
+  const mean = np.mean(x.ref, axes, { keepdims: true });
+  const centered = x.sub(mean);
+  const std = np
+    .sqrt(
+      np.mean(np.square(centered.ref), axes, {
+        keepdims: true,
+      }),
+    )
+    .add(1e-9);
+  return [centered.div(std)];
+}
+
 export function CumSum(
   [x, axisOnnx]: Operand[],
   { exclusive = 0, reverse = 0 }: { exclusive?: number; reverse?: number },

--- a/packages/onnx/src/ops/utility.ts
+++ b/packages/onnx/src/ops/utility.ts
@@ -8,6 +8,7 @@ import { numpy as np } from "@jax-js/jax";
 import { TensorProto } from "onnx-buf";
 
 import {
+  onnxDtypeToJax,
   type Operand,
   operandToJax,
   operandToJs,
@@ -77,4 +78,9 @@ export function ConstantOfShape(
   } else {
     return [np.zeros(shape)];
   }
+}
+
+export function BitCast([input]: Operand[], { to }: { to: number }): Operand[] {
+  const x = operandToJax(input);
+  return [x.view(onnxDtypeToJax(to))];
 }


### PR DESCRIPTION
New ONNX ops added:

- linalg: Det, EyeLike, LpNormalization, Trilu

- elementwise: And, Or, Xor, BitShift, BitwiseAnd, BitwiseOr, BitwiseXor, BitwiseNot, HardSigmoid, HardSwish, IsInf, Max, Min, PRelu, Round, Selu, Shrink, ThresholdedRelu

- reduction: MeanVarianceNormalization

- utility: BitCast

Also adds model tests for the new handlers and spec edge cases.