### PR TITLE
Initial implementation of the np.linalg.matrix_norm methods.

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -521,7 +521,7 @@ eigenvalues ([issue](https://github.com/ekzhang/jax-js/issues/51)).
 | `inv`              | 🟢      |                                         |
 | `lstsq`            | 🟡      | Cholesky-based, less stable than QR/SVD |
 | `matmul`           | 🟢      |                                         |
-| `matrix_norm`      | 🟠      |                                         |
+| `matrix_norm`      | 🟡      | nuc, -2/2 not supported (need SVD)      |
 | `matrix_power`     | 🟢      |                                         |
 | `matrix_rank`      | 🔴      |                                         |
 | `matrix_transpose` | 🟢      |                                         |

--- a/src/library/numpy-linalg.ts
+++ b/src/library/numpy-linalg.ts
@@ -302,3 +302,48 @@ export function vectorNorm(
     return np.power(np.power(np.abs(x), ord).sum(ax, { keepdims }), 1 / ord);
   }
 }
+
+/**
+ * Calculates the matrix norm of a matrix or a stack of matrices.
+ * @param x - Input Array (..., M, N)
+ * @param ord - Order of the norm (default "fro").
+ * @param keepdims - Whether to keep reduced dimensions as size 1 or collapse axes.
+ * @returns Matrix norm of input array. If `keepdims` is `true`, the result has shape (..., 1, 1). Otherwise, it has shape (...,).
+ */
+export function matrixNorm(
+  x: ArrayLike,
+  {
+    ord = "fro",
+    keepdims = false,
+  }: { ord?: number | "fro" | "nuc"; keepdims?: boolean } = {},
+): Array {
+  x = fudgeArray(x);
+  if (x.ndim < 2) {
+    throw new Error(
+      `Input must be at least 2-dimensional. Recieved ${x.ndim}-dimensional array`,
+    );
+  }
+  if (ord === "fro") {
+    return np.sqrt(np.sum(np.square(x), [-2, -1], { keepdims }));
+  } else if (ord === "nuc") {
+    throw new Error("Order nuc is not supported");
+  } else if (ord === -1) {
+    return np.min(np.sum(np.abs(x), [-2], { keepdims }), [-1], { keepdims });
+  } else if (ord === 1) {
+    return np.max(np.sum(np.abs(x), [-2], { keepdims }), [-1], { keepdims });
+  } else if (ord === -2) {
+    throw new Error("Order -2 is not supported");
+  } else if (ord === 2) {
+    throw new Error("Order 2 is not supported");
+  } else if (ord === -Infinity) {
+    return np.min(np.sum(np.abs(x), [-1], { keepdims }), [keepdims ? -2 : -1], {
+      keepdims,
+    });
+  } else if (ord === Infinity) {
+    return np.max(np.sum(np.abs(x), [-1], { keepdims }), [keepdims ? -2 : -1], {
+      keepdims,
+    });
+  } else {
+    throw new Error(`Order ${ord} is not supported`);
+  }
+}

--- a/test/numpy-linalg.test.ts
+++ b/test/numpy-linalg.test.ts
@@ -402,4 +402,122 @@ suite.each(devicesWithLinalg)("device:%s", (device) => {
       expect(norms).toBeAllclose([[5.0], [13.0]]);
     });
   });
+
+  suite("numpy.linalg.matrixNorm()", () => {
+    const matrix = () =>
+      np.array([
+        [1.0, 2.0],
+        [3.0, 4.0],
+      ]);
+    const batched = () => np.arange(18).astype(np.float32).reshape([2, 3, 3]);
+
+    const expectNorm = (
+      input: np.Array,
+      ord: number | "fro",
+      keepdims: boolean,
+      expected: number | number[] | number[][] | number[][][],
+      shape: number[],
+    ) => {
+      const norm = np.linalg.matrixNorm(input, { ord, keepdims });
+      expect(norm).toBeAllclose(expected);
+      expect(norm.shape).toEqual(shape);
+    };
+
+    test("Throws on array with less than 2 dimensions", () => {
+      const a = np.array([1.0, 2.0, 3.0, 4.0]);
+      expect(() => np.linalg.matrixNorm(a)).toThrow();
+    });
+
+    test("Throws on non-supported norms", () => {
+      expect(() => np.linalg.matrixNorm(matrix(), { ord: -2 })).toThrow();
+      expect(() => np.linalg.matrixNorm(matrix(), { ord: 2 })).toThrow();
+      expect(() => np.linalg.matrixNorm(matrix(), { ord: "nuc" })).toThrow();
+    });
+
+    test("Frobenius norm (default)", () => {
+      expectNorm(matrix(), "fro", false, 5.477225575051661, []);
+    });
+
+    test("Frobenius norm keepdims", () => {
+      expectNorm(matrix(), "fro", true, [[5.477225575051661]], [1, 1]);
+    });
+
+    test("Frobenius norm batched", () => {
+      expectNorm(batched(), "fro", false, [14.28285686, 39.7617907], [2]);
+    });
+
+    test("Frobenius norm batched keepdims", () => {
+      expectNorm(
+        batched(),
+        "fro",
+        true,
+        [[[14.28285686]], [[39.7617907]]],
+        [2, 1, 1],
+      );
+    });
+
+    test("L1 norm", () => {
+      expectNorm(matrix(), 1, false, 6.0, []);
+    });
+
+    test("L1 norm keepdims", () => {
+      expectNorm(matrix(), 1, true, [[6.0]], [1, 1]);
+    });
+
+    test("L1 norm batched", () => {
+      expectNorm(batched(), 1, false, [15.0, 42.0], [2]);
+    });
+
+    test("L1 norm batched keepdims", () => {
+      expectNorm(batched(), 1, true, [[[15.0]], [[42.0]]], [2, 1, 1]);
+    });
+
+    test("L-1 norm", () => {
+      expectNorm(matrix(), -1, false, 4.0, []);
+    });
+
+    test("L-1 norm keepdims", () => {
+      expectNorm(matrix(), -1, true, [[4.0]], [1, 1]);
+    });
+
+    test("L-1 norm batched", () => {
+      expectNorm(batched(), -1, false, [9.0, 36.0], [2]);
+    });
+
+    test("L-1 norm batched keepdims", () => {
+      expectNorm(batched(), -1, true, [[[9.0]], [[36.0]]], [2, 1, 1]);
+    });
+
+    test("L-infinity norm", () => {
+      expectNorm(matrix(), Infinity, false, 7.0, []);
+    });
+
+    test("L-infinity norm keepdims", () => {
+      expectNorm(matrix(), Infinity, true, [[7.0]], [1, 1]);
+    });
+
+    test("L-infinity norm batched", () => {
+      expectNorm(batched(), Infinity, false, [21.0, 48.0], [2]);
+    });
+
+    test("L-infinity norm batched keepdims", () => {
+      expectNorm(batched(), Infinity, true, [[[21.0]], [[48.0]]], [2, 1, 1]);
+    });
+
+    test("L-negative-infinity norm", () => {
+      expectNorm(matrix(), -Infinity, false, 3.0, []);
+    });
+
+    test("L-negative-infinity norm keepdims", () => {
+      expectNorm(matrix(), -Infinity, true, [[3.0]], [1, 1]);
+    });
+
+    test("L-negative-infinity norm batched", () => {
+      expectNorm(batched(), -Infinity, false, [3.0, 30.0], [2]);
+    });
+
+    test("L-negative-infinity norm batched keepdims", () => {
+      expectNorm(batched(), -Infinity, true, [[[3.0]], [[30.0]]], [2, 1, 1]);
+    });
+  });
 });


### PR DESCRIPTION
### Summary 
Adds limited support for `la.matrix_norm` and implemented to follow numpy API [parity ](https://numpy.org/doc/stable/reference/generated/numpy.linalg.matrix_norm.html).  Currently support `fro`, $\pm \infty$, $\pm 1$. Doesn't support $\pm 2$ and `nuc` since SVD isn't implemented yet and raises exceptions for those respective cases. 
### Testing 
- Wrote tests for all supported cases and utilized numpy as a reference for ground truth.