### PR TITLE
Add append and fix vjp of concatenate

### DIFF
--- a/src/frontend/linearize.ts
+++ b/src/frontend/linearize.ts
@@ -825,10 +825,13 @@ const transposeRules: Partial<{ [P in Primitive]: TransposeRule<P> }> = {
   },
   [Primitive.Concatenate]([ct], inputs, { axis }) {
     // The backprop of concatenate is split.
-    if (inputs.some((x) => !(x instanceof UndefPrimal)))
-      throw new NonlinearError(Primitive.Concatenate);
     const sizes = inputs.map((x) => x.aval.shape[axis]);
-    return split(ct, axis, sizes);
+    const cts = split(ct, axis, sizes);
+    return inputs.map((x, i) => {
+      if (x instanceof UndefPrimal) return cts[i];
+      (x.dispose(), cts[i].dispose());
+      return null;
+    });
   },
   [Primitive.Split](cts, [x], { axis }) {
     if (!(x instanceof UndefPrimal)) throw new NonlinearError(Primitive.Split);

--- a/src/library/numpy.ts
+++ b/src/library/numpy.ts
@@ -1112,6 +1112,24 @@ export function argsort(a: ArrayLike, axis: number = -1): Array {
 }
 
 /**
+ * Append values to the end of an array.
+ *
+ * If `axis` is `null`, both inputs are flattened before concatenation.
+ */
+export function append(
+  arr: ArrayLike,
+  values: ArrayLike,
+  axis: number | null = null,
+): Array {
+  if (axis === null) {
+    return concatenate([ravel(arr), ravel(values)], 0);
+  }
+  const a = fudgeArray(arr);
+  axis = checkAxis(axis, a.ndim);
+  return concatenate([a, fudgeArray(values)], axis);
+}
+
+/**
  * Take elements from an array along an axis.
  *
  * This is equivalent to advanced indexing with integer indices over that

--- a/test/numpy.test.ts
+++ b/test/numpy.test.ts
@@ -2853,6 +2853,43 @@ suite.each(devices)("device:%s", (device) => {
     });
   });
 
+  suite("jax.numpy.append()", () => {
+    test("flattens inputs when axis is omitted", () => {
+      const x = np.array([
+        [1, 2],
+        [3, 4],
+      ]);
+      const y = np.append(x, np.array([[5, 6]]));
+      expect(y.shape).toEqual([6]);
+      expect(y.js()).toEqual([1, 2, 3, 4, 5, 6]);
+    });
+
+    test("appends along an axis", () => {
+      const x = np.array([
+        [1, 2],
+        [3, 4],
+      ]);
+      const y0 = np.append(x.ref, np.array([[5, 6]]), 0);
+      expect(y0.js()).toEqual([
+        [1, 2],
+        [3, 4],
+        [5, 6],
+      ]);
+
+      const y1 = np.append(x, np.array([[5], [6]]), 1);
+      expect(y1.js()).toEqual([
+        [1, 2, 5],
+        [3, 4, 6],
+      ]);
+    });
+
+    test("works with grad", () => {
+      const x = np.array([1, 2, 3]);
+      const dx = grad((x: np.Array) => np.append(x, np.array([4, 5])).sum())(x);
+      expect(dx.js()).toEqual([1, 1, 1]);
+    });
+  });
+
   suite("jax.numpy.takeAlongAxis()", () => {
     test("takes values along columns", () => {
       const x = np.array([


### PR DESCRIPTION
Add `jax.numpy.append()` API and fix a minor bug in the vjp rule for concatenate.