### PR TITLE
Add `eigh` and `eigvalsh` routines via Jacobi iteration

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -515,9 +515,9 @@ eigenvalues ([issue](https://github.com/ekzhang/jax-js/issues/51)).
 | `det`              | 🟢      |                                         |
 | `diagonal`         | 🟢      |                                         |
 | `eig`              | 🔴      |                                         |
-| `eigh`             | 🟡      | real matrices only, fixed sweeps        |
+| `eigh`             | 🟡      | real matrices only                      |
 | `eigvals`          | 🔴      |                                         |
-| `eigvalsh`         | 🟡      | real matrices only, fixed sweeps        |
+| `eigvalsh`         | 🟡      | real matrices only                      |
 | `inv`              | 🟢      |                                         |
 | `lstsq`            | 🟡      | Cholesky-based, less stable than QR/SVD |
 | `matmul`           | 🟢      |                                         |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -515,9 +515,9 @@ eigenvalues ([issue](https://github.com/ekzhang/jax-js/issues/51)).
 | `det`              | 🟢      |                                         |
 | `diagonal`         | 🟢      |                                         |
 | `eig`              | 🔴      |                                         |
-| `eigh`             | 🔴      |                                         |
+| `eigh`             | 🟡      | real matrices only, fixed sweeps        |
 | `eigvals`          | 🔴      |                                         |
-| `eigvalsh`         | 🔴      |                                         |
+| `eigvalsh`         | 🟡      | real matrices only, fixed sweeps        |
 | `inv`              | 🟢      |                                         |
 | `lstsq`            | 🟡      | Cholesky-based, less stable than QR/SVD |
 | `matmul`           | 🟢      |                                         |

--- a/src/backend/webgpu/routines.ts
+++ b/src/backend/webgpu/routines.ts
@@ -588,6 +588,160 @@ fn main(
   ];
 }
 
+function createJacobiEigh(
+  device: GPUDevice,
+  type: RoutineType,
+  params: { maxSweeps: number; tolerance: number },
+): ShaderInfo[] {
+  const dtype = type.inputDtypes[0];
+  const shape = type.inputShapes[0];
+  const n = shape[shape.length - 1];
+  const batches = prod(shape.slice(0, -2));
+
+  const needsF16 = dtype === DType.Float16;
+  const ty = dtypeToWgsl(dtype, true);
+  const tolerance = `${ty}(${params.tolerance})`;
+  const workgroupSize = findPow2(
+    Math.max(n, 1),
+    device.limits.maxComputeWorkgroupSizeX,
+  );
+
+  const code = `
+${needsF16 ? "enable f16;" : ""}
+${headerWgsl}
+
+@group(0) @binding(0) var<storage, read> input: array<${ty}>;
+@group(0) @binding(1) var<storage, read_write> diagonalized: array<${ty}>;
+@group(0) @binding(2) var<storage, read_write> vectors: array<${ty}>;
+
+var<workgroup> done: u32;
+var<workgroup> rot_active: u32;
+var<workgroup> rot_c: ${ty};
+var<workgroup> rot_s: ${ty};
+var<workgroup> rot_app: ${ty};
+var<workgroup> rot_aqq: ${ty};
+var<workgroup> rot_apq: ${ty};
+
+fn mat_idx(base: u32, row: u32, col: u32) -> u32 {
+  return base + row * ${n}u + col;
+}
+
+@compute @workgroup_size(${workgroupSize})
+fn main(
+  @builtin(workgroup_id) wg_id: vec3<u32>,
+  @builtin(local_invocation_id) local_id: vec3<u32>,
+) {
+  let batch = wg_id.x + wg_id.y * ${gridOffsetY}u;
+  if (batch >= ${batches}u) {
+    return;
+  }
+
+  let base = batch * ${n * n}u;
+  let tid = local_id.x;
+
+  for (var idx = tid; idx < ${n * n}u; idx += ${workgroupSize}u) {
+    let row = idx / ${n}u;
+    let col = idx % ${n}u;
+    diagonalized[base + idx] = input[base + idx];
+    vectors[base + idx] = select(${ty}(0), ${ty}(1), row == col);
+  }
+  storageBarrier();
+
+  for (var sweep = 0u; sweep < ${params.maxSweeps}u; sweep++) {
+    if (tid == 0u) {
+      var max_abs = ${ty}(1);
+      var max_offdiag = ${ty}(0);
+      for (var idx = 0u; idx < ${n * n}u; idx++) {
+        let row = idx / ${n}u;
+        let col = idx % ${n}u;
+        let value = abs(diagonalized[base + idx]);
+        max_abs = max(max_abs, value);
+        if (row != col) {
+          max_offdiag = max(max_offdiag, value);
+        }
+      }
+      done = select(0u, 1u, max_offdiag <= ${tolerance} * max_abs);
+    }
+    let done_uniform = workgroupUniformLoad(&done);
+    if (done_uniform != 0u) {
+      break;
+    }
+
+    for (var p = 0u; p + 1u < ${n}u; p++) {
+      for (var q = p + 1u; q < ${n}u; q++) {
+        if (tid == 0u) {
+          rot_app = diagonalized[mat_idx(base, p, p)];
+          rot_aqq = diagonalized[mat_idx(base, q, q)];
+          rot_apq = diagonalized[mat_idx(base, p, q)];
+          if (rot_apq == ${ty}(0)) {
+            rot_active = 0u;
+            rot_c = ${ty}(1);
+            rot_s = ${ty}(0);
+          } else {
+            let tau = (rot_aqq - rot_app) / (${ty}(2) * rot_apq);
+            let tau_sign = select(${ty}(-1), ${ty}(1), tau >= ${ty}(0));
+            let t = tau_sign / (abs(tau) + sqrt(tau * tau + ${ty}(1)));
+            rot_c = inverseSqrt(t * t + ${ty}(1));
+            rot_s = t * rot_c;
+            rot_active = 1u;
+          }
+        }
+        workgroupBarrier();
+
+        if (rot_active != 0u) {
+          for (var k = tid; k < ${n}u; k += ${workgroupSize}u) {
+            if (k != p && k != q) {
+              let kp = mat_idx(base, k, p);
+              let kq = mat_idx(base, k, q);
+              let pk = mat_idx(base, p, k);
+              let qk = mat_idx(base, q, k);
+              let akp = diagonalized[kp];
+              let akq = diagonalized[kq];
+              let next_kp = rot_c * akp - rot_s * akq;
+              let next_kq = rot_s * akp + rot_c * akq;
+              diagonalized[kp] = next_kp;
+              diagonalized[pk] = next_kp;
+              diagonalized[kq] = next_kq;
+              diagonalized[qk] = next_kq;
+            }
+
+            let vp = mat_idx(base, k, p);
+            let vq = mat_idx(base, k, q);
+            let vkp = vectors[vp];
+            let vkq = vectors[vq];
+            vectors[vp] = rot_c * vkp - rot_s * vkq;
+            vectors[vq] = rot_s * vkp + rot_c * vkq;
+          }
+        }
+        storageBarrier();
+
+        if (tid == 0u && rot_active != 0u) {
+          diagonalized[mat_idx(base, p, p)] =
+            rot_c * rot_c * rot_app - ${ty}(2) * rot_s * rot_c * rot_apq + rot_s * rot_s * rot_aqq;
+          diagonalized[mat_idx(base, q, q)] =
+            rot_s * rot_s * rot_app + ${ty}(2) * rot_s * rot_c * rot_apq + rot_c * rot_c * rot_aqq;
+          diagonalized[mat_idx(base, p, q)] = ${ty}(0);
+          diagonalized[mat_idx(base, q, p)] = ${ty}(0);
+        }
+        storageBarrier();
+      }
+    }
+  }
+}
+`.trim();
+
+  const grid = calculateGrid(batches);
+  return [
+    {
+      code,
+      numInputs: 1,
+      numOutputs: 2,
+      hasUniform: false,
+      passes: [{ grid }],
+    },
+  ];
+}
+
 export function createRoutineShader(
   device: GPUDevice,
   routine: Routine,
@@ -603,6 +757,8 @@ export function createRoutineShader(
       return createCholesky(device, routine.type);
     case Routines.LU:
       return createLU(device, routine.type);
+    case Routines.JacobiEigh:
+      return createJacobiEigh(device, routine.type, routine.params);
     default:
       throw new UnsupportedRoutineError(routine.name, "webgpu");
   }

--- a/src/backend/webgpu/routines.ts
+++ b/src/backend/webgpu/routines.ts
@@ -626,6 +626,10 @@ fn mat_idx(base: u32, row: u32, col: u32) -> u32 {
   return base + row * ${n}u + col;
 }
 
+fn sym_idx(base: u32, row: u32, col: u32) -> u32 {
+  return mat_idx(base, max(row, col), min(row, col));
+}
+
 @compute @workgroup_size(${workgroupSize})
 fn main(
   @builtin(workgroup_id) wg_id: vec3<u32>,
@@ -642,7 +646,11 @@ fn main(
   for (var idx = tid; idx < ${n * n}u; idx += ${workgroupSize}u) {
     let row = idx / ${n}u;
     let col = idx % ${n}u;
-    diagonalized[base + idx] = input[base + idx];
+    diagonalized[base + idx] = select(
+      ${ty}(0),
+      input[base + idx],
+      row >= col,
+    );
     vectors[base + idx] = select(${ty}(0), ${ty}(1), row == col);
   }
   storageBarrier();
@@ -656,7 +664,7 @@ fn main(
         let col = idx % ${n}u;
         let value = abs(diagonalized[base + idx]);
         max_abs = max(max_abs, value);
-        if (row != col) {
+        if (row > col) {
           max_offdiag = max(max_offdiag, value);
         }
       }
@@ -672,7 +680,7 @@ fn main(
         if (tid == 0u) {
           rot_app = diagonalized[mat_idx(base, p, p)];
           rot_aqq = diagonalized[mat_idx(base, q, q)];
-          rot_apq = diagonalized[mat_idx(base, p, q)];
+          rot_apq = diagonalized[sym_idx(base, p, q)];
           if (rot_apq == ${ty}(0)) {
             rot_active = 0u;
             rot_c = ${ty}(1);
@@ -691,18 +699,21 @@ fn main(
         if (rot_active != 0u) {
           for (var k = tid; k < ${n}u; k += ${workgroupSize}u) {
             if (k != p && k != q) {
-              let kp = mat_idx(base, k, p);
-              let kq = mat_idx(base, k, q);
-              let pk = mat_idx(base, p, k);
-              let qk = mat_idx(base, q, k);
+              let kp = sym_idx(base, k, p);
+              let kq = sym_idx(base, k, q);
               let akp = diagonalized[kp];
               let akq = diagonalized[kq];
               let next_kp = rot_c * akp - rot_s * akq;
               let next_kq = rot_s * akp + rot_c * akq;
               diagonalized[kp] = next_kp;
-              diagonalized[pk] = next_kp;
               diagonalized[kq] = next_kq;
-              diagonalized[qk] = next_kq;
+            } else if (k == p) {
+              diagonalized[mat_idx(base, p, p)] =
+                rot_c * rot_c * rot_app - ${ty}(2) * rot_s * rot_c * rot_apq + rot_s * rot_s * rot_aqq;
+              diagonalized[sym_idx(base, p, q)] = ${ty}(0);
+            } else {
+              diagonalized[mat_idx(base, q, q)] =
+                rot_s * rot_s * rot_app + ${ty}(2) * rot_s * rot_c * rot_apq + rot_c * rot_c * rot_aqq;
             }
 
             let vp = mat_idx(base, k, p);
@@ -712,16 +723,6 @@ fn main(
             vectors[vp] = rot_c * vkp - rot_s * vkq;
             vectors[vq] = rot_s * vkp + rot_c * vkq;
           }
-        }
-        storageBarrier();
-
-        if (tid == 0u && rot_active != 0u) {
-          diagonalized[mat_idx(base, p, p)] =
-            rot_c * rot_c * rot_app - ${ty}(2) * rot_s * rot_c * rot_apq + rot_s * rot_s * rot_aqq;
-          diagonalized[mat_idx(base, q, q)] =
-            rot_s * rot_s * rot_app + ${ty}(2) * rot_s * rot_c * rot_apq + rot_c * rot_c * rot_aqq;
-          diagonalized[mat_idx(base, p, q)] = ${ty}(0);
-          diagonalized[mat_idx(base, q, p)] = ${ty}(0);
         }
         storageBarrier();
       }

--- a/src/frontend/array.ts
+++ b/src/frontend/array.ts
@@ -1177,6 +1177,7 @@ export class Array extends Tracer {
       [Primitive.TriangularSolve]: Array.#routine(Primitive.TriangularSolve),
       [Primitive.Cholesky]: Array.#routine(Primitive.Cholesky),
       [Primitive.LU]: Array.#routine(Primitive.LU),
+      [Primitive.JacobiEigh]: Array.#routine(Primitive.JacobiEigh),
       [Primitive.Jit](args, { jaxpr }) {
         if (jaxpr.inBinders.length !== args.length) {
           throw new Error(

--- a/src/frontend/core.ts
+++ b/src/frontend/core.ts
@@ -93,6 +93,7 @@ export enum Primitive {
   TriangularSolve = "triangular_solve", // A is upper triangular, A @ X.T = B.T
   Cholesky = "cholesky", // A is positive-definite, A = L @ L^T
   LU = "lu", // LU decomposition with partial pivoting
+  JacobiEigh = "jacobi_eigh", // Symmetric eigendecomposition via Jacobi rotations
 
   // JIT compilation
   Jit = "jit",
@@ -123,6 +124,7 @@ interface PrimitiveParamsImpl extends Record<Primitive, Record<string, any>> {
   [Primitive.Shrink]: { slice: Pair[] };
   [Primitive.Pad]: { width: Pair[] };
   [Primitive.TriangularSolve]: { unitDiagonal: boolean };
+  [Primitive.JacobiEigh]: { maxSweeps: number; tolerance: number };
   [Primitive.Jit]: { name: string; jaxpr: Jaxpr; numConsts: number };
 }
 
@@ -147,6 +149,7 @@ export const routinePrimitives = new Map([
   [Primitive.TriangularSolve, Routines.TriangularSolve],
   [Primitive.Cholesky, Routines.Cholesky],
   [Primitive.LU, Routines.LU],
+  [Primitive.JacobiEigh, Routines.JacobiEigh],
 ]);
 
 export function add(x: TracerValue, y: TracerValue) {
@@ -534,6 +537,22 @@ export function lu(x: TracerValue) {
   if (aval.ndim < 2)
     throw new Error(`lu: expected batch of matrices, got ${aval}`);
   return bind(Primitive.LU, [x]);
+}
+
+export function jacobiEigh(
+  x: TracerValue,
+  { maxSweeps, tolerance }: { maxSweeps: number; tolerance: number },
+) {
+  const aval = ShapedArray.fromAval(getAval(x));
+  if (aval.ndim < 2 || aval.shape[aval.ndim - 1] !== aval.shape[aval.ndim - 2])
+    throw new Error(
+      `jacobi_eigh: expected batch of square matrices, got ${aval}`,
+    );
+  if (!isFloatDtype(aval.dtype))
+    throw new TypeError(
+      `jacobi_eigh: expected floating-point input, got ${aval}`,
+    );
+  return bind(Primitive.JacobiEigh, [x], { maxSweeps, tolerance });
 }
 
 export function sort(x: TracerValue) {

--- a/src/frontend/jaxpr.ts
+++ b/src/frontend/jaxpr.ts
@@ -1012,6 +1012,17 @@ export const abstractEvalRules: { [P in Primitive]: AbstractEvalRule<P> } = {
       new ShapedArray([...batch, m], DType.Int32, false),
     ];
   },
+  [Primitive.JacobiEigh]([a]) {
+    if (a.ndim < 2)
+      throw new TypeError(`jacobi_eigh: requires at least 2D input, got ${a}`);
+    if (a.shape[a.ndim - 2] !== a.shape[a.ndim - 1])
+      throw new TypeError(`jacobi_eigh: must be square, got ${a}`);
+    if (!isFloatDtype(a.dtype))
+      throw new TypeError(
+        `jacobi_eigh: requires floating-point input, got ${a}`,
+      );
+    return [ShapedArray.fromAval(a), ShapedArray.fromAval(a)];
+  },
   [Primitive.Jit](args, { jaxpr }) {
     const { inTypes, outTypes } = typecheckJaxpr(jaxpr);
     if (args.length !== inTypes.length) {

--- a/src/frontend/jit.ts
+++ b/src/frontend/jit.ts
@@ -778,6 +778,7 @@ const jitRules: { [P in Primitive]: JitRule<P> } = {
   [Primitive.TriangularSolve]: routineNoJit(),
   [Primitive.Cholesky]: routineNoJit(),
   [Primitive.LU]: routineNoJit(),
+  [Primitive.JacobiEigh]: routineNoJit(),
   [Primitive.Jit]() {
     throw new Error(
       "internal: Jit should have been flattened before JIT compilation",

--- a/src/frontend/jvp.ts
+++ b/src/frontend/jvp.ts
@@ -394,6 +394,9 @@ const jvpRules: { [P in Primitive]: JvpRule<P> } = {
       [lDot.add(uDot), zerosLike(pivots.ref), zerosLike(permutation.ref)],
     ];
   },
+  [Primitive.JacobiEigh]() {
+    throw new Error("JVP rule not implemented for jacobi_eigh");
+  },
   [Primitive.Jit](primals, tangents, { name, jaxpr }) {
     const newJaxpr = jvpJaxpr(jaxpr);
     const outs = bind(

--- a/src/frontend/vmap.ts
+++ b/src/frontend/vmap.ts
@@ -402,6 +402,7 @@ const vmapRules: Partial<{ [P in Primitive]: VmapRule<P> }> = {
   },
   [Primitive.Cholesky]: lastDimsBatcher(Primitive.Cholesky, 2),
   [Primitive.LU]: lastDimsBatcher(Primitive.LU, 2, 3),
+  [Primitive.JacobiEigh]: lastDimsBatcher(Primitive.JacobiEigh, 2, 2),
   [Primitive.Jit](axisSize, args, dims, { name, jaxpr }) {
     const newJaxpr = vmapJaxpr(jaxpr, axisSize, dims);
     const outs = bind(

--- a/src/library/lax-linalg.ts
+++ b/src/library/lax-linalg.ts
@@ -76,12 +76,8 @@ export function eigh(
   }
   if (symmetrizeInput) {
     x = x.ref.add(np.matrixTranspose(x)).mul(0.5);
-  } else if (lower) {
-    const lowerTriangle = np.tril(x.ref);
-    x = lowerTriangle.ref.add(np.matrixTranspose(np.tril(x, -1)));
-  } else {
-    const upperTriangle = np.triu(x.ref);
-    x = upperTriangle.ref.add(np.matrixTranspose(np.triu(x, 1)));
+  } else if (!lower) {
+    x = np.matrixTranspose(x);
   }
 
   const batchShape = x.shape.slice(0, -2);

--- a/src/library/lax-linalg.ts
+++ b/src/library/lax-linalg.ts
@@ -4,163 +4,15 @@ import * as np from "./numpy";
 import { DType, isFloatDtype } from "../alu";
 import { Array, type ArrayLike, fudgeArray } from "../frontend/array";
 import * as core from "../frontend/core";
-import { jit } from "../frontend/jaxpr";
 import { checkSquare } from "../utils";
 
-const JsArray = globalThis.Array;
-
-type JacobiRoundPlan = {
-  p: number[];
-  q: number[];
-  active: boolean[];
-  mate: number[];
-  pairId: number[];
-  sign: number[];
-};
-
-function jacobiRoundPlans(n: number): JacobiRoundPlan[] {
-  if (n < 2) return [];
-
-  const participants = JsArray.from({ length: n }, (_, i) => i);
-  if (n % 2 === 1) participants.push(-1);
-
-  const rounds: JacobiRoundPlan[] = [];
-  const m = participants.length;
-  const half = m / 2;
-  const rotating = participants.slice();
-
-  for (let round = 0; round < m - 1; round++) {
-    const mate = JsArray.from({ length: n }, (_, i) => i);
-    const pairId = JsArray(n);
-    const sign = JsArray(n);
-    const p: number[] = [];
-    const q: number[] = [];
-    const active: boolean[] = [];
-
-    for (let k = 0; k < half; k++) {
-      let a = rotating[k];
-      let b = rotating[m - 1 - k];
-      if (a === -1 || b === -1) {
-        const i = a === -1 ? b : a;
-        p.push(i);
-        q.push(i);
-        active.push(false);
-        pairId[i] = k;
-        sign[i] = 0;
-      } else {
-        if (a > b) [a, b] = [b, a];
-        p.push(a);
-        q.push(b);
-        active.push(true);
-        mate[a] = b;
-        mate[b] = a;
-        pairId[a] = k;
-        pairId[b] = k;
-        sign[a] = -1;
-        sign[b] = 1;
-      }
-    }
-
-    rounds.push({ p, q, active, mate, pairId, sign });
-
-    const tail = rotating.pop()!;
-    rotating.splice(1, 0, tail);
-  }
-
-  return rounds;
+function defaultJacobiMaxSweeps(n: number): number {
+  return Math.max(8, 2 * n);
 }
 
-function jacobiSweepPlanRows(n: number): number[][] {
-  return jacobiRoundPlans(n).map(({ p, q, active, pairId, mate, sign }) => [
-    ...p,
-    ...q,
-    ...active.map(Number),
-    ...pairId,
-    ...mate,
-    ...sign,
-  ]);
+function jacobiTolerance(dtype: DType): number {
+  return dtype === DType.Float64 ? 1e-12 : 1e-6;
 }
-
-function applyJacobiRound(
-  a: Array,
-  v: Array,
-  p: Array,
-  q: Array,
-  pairId: Array,
-  mate: Array,
-  sign: Array,
-  pairActive: Array,
-): [Array, Array] {
-  const n = a.shape[a.ndim - 1];
-  const batchShape = a.shape.slice(0, -2);
-  const batchRank = a.ndim - 2;
-  const batchIndex = JsArray.from({ length: batchRank }, () => [] as []);
-  const app = a.ref.slice(...batchIndex, p.ref, p.ref);
-  const aqq = a.ref.slice(...batchIndex, q.ref, q.ref);
-  const apq = a.ref.slice(...batchIndex, p, q);
-
-  const active = np.logicalAnd(pairActive, np.abs(apq.ref).greater(0));
-  const safeApq = np.where(active.ref, apq, 1);
-  const tau = aqq.sub(app).div(safeApq.mul(2));
-  const tauSign = np.where(tau.ref.greaterEqual(0), 1, -1);
-  const t = tauSign.div(np.abs(tau.ref).add(np.sqrt(tau.ref.mul(tau).add(1))));
-  const cRaw = np.reciprocal(np.sqrt(t.ref.mul(t.ref).add(1)));
-  const sRaw = t.mul(cRaw.ref);
-  const cPair = np.where(active.ref, cRaw, 1);
-  const sPair = np.where(active, sRaw, 0);
-
-  const cIdx = np.take(cPair, pairId.ref, -1);
-  const sIdx = np.take(sPair, pairId, -1).mul(sign);
-  const cRow = cIdx.ref.reshape([...batchShape, n, 1]);
-  const cCol = cIdx.reshape([...batchShape, 1, n]);
-  const sRow = sIdx.ref.reshape([...batchShape, n, 1]);
-  const sCol = sIdx.reshape([...batchShape, 1, n]);
-
-  const term1 = cRow.ref.mul(cCol.ref).mul(a.ref);
-  const term2 = cRow.mul(sCol.ref).mul(np.take(a.ref, mate.ref, -1));
-  const term3 = sRow.ref.mul(cCol.ref).mul(np.take(a.ref, mate.ref, -2));
-  const term4 = sRow
-    .mul(sCol.ref)
-    .mul(np.take(np.take(a, mate.ref, -2), mate.ref, -1));
-  const nextA = term1.add(term2).add(term3).add(term4);
-  const nextV = v.ref.mul(cCol).add(np.take(v, mate, -1).mul(sCol));
-
-  return [nextA, nextV];
-}
-
-const applyJacobiSweepJit = jit(function applyJacobiSweepJit(
-  a: Array,
-  v: Array,
-  plan: Array,
-): [Array, Array] {
-  const n = a.shape[a.ndim - 1];
-  const half = Math.ceil(n / 2);
-  const splitPoints = [
-    half,
-    2 * half,
-    3 * half,
-    3 * half + n,
-    3 * half + 2 * n,
-  ];
-  for (let round = 0; round < plan.shape[0]; round++) {
-    const [p, q, active, pairId, mate, sign] = np.split(
-      plan.ref.slice(round),
-      splitPoints,
-      -1,
-    );
-    [a, v] = applyJacobiRound(
-      a,
-      v,
-      p,
-      q,
-      pairId,
-      mate,
-      sign.astype(a.dtype),
-      active.astype(np.bool),
-    );
-  }
-  return [a, v];
-});
 
 /**
  * Compute the Cholesky decomposition of a symmetric positive-definite matrix.
@@ -199,8 +51,9 @@ export function cholesky(
 /**
  * Eigendecomposition of real symmetric matrices.
  *
- * This uses a fixed-sweep cyclic Jacobi method. It does not stop early based on
- * convergence, which avoids synchronizing GPU-computed residuals back to JS.
+ * This uses a cyclic Jacobi routine with an internal convergence check and a
+ * fixed maximum number of sweeps.
+ *
  * Eigenvectors are returned as columns in the first result, and eigenvalues are
  * returned in ascending order in the second result.
  */
@@ -208,9 +61,11 @@ export function eigh(
   x: ArrayLike,
   {
     lower = true,
+    sortEigenvalues = true,
     symmetrizeInput = true,
   }: {
     lower?: boolean;
+    sortEigenvalues?: boolean;
     symmetrizeInput?: boolean;
   } = {},
 ): [Array, Array] {
@@ -230,21 +85,15 @@ export function eigh(
   }
 
   const batchShape = x.shape.slice(0, -2);
-  let v = np.broadcastTo(
-    np.eye(n, undefined, { dtype: x.dtype, device: x.device }),
-    x.shape,
-  );
-  const plan = np.array(jacobiSweepPlanRows(n), {
-    dtype: np.int32,
-    device: x.device,
-  });
-  const sweeps = Math.max(8, 2 * n);
-  for (let sweep = 0; sweep < sweeps; sweep++) {
-    [x, v] = applyJacobiSweepJit(x, v, plan.ref);
-  }
-  plan.dispose();
+  let v: Array;
+  [x, v] = core.jacobiEigh(x, {
+    maxSweeps: defaultJacobiMaxSweeps(n),
+    tolerance: jacobiTolerance(x.dtype),
+  }) as [Array, Array];
 
   const valuesUnsorted = np.diagonal(x, 0, -2, -1);
+  if (!sortEigenvalues) return [v, valuesUnsorted];
+
   const order = np.argsort(valuesUnsorted.ref);
   const values = np.takeAlongAxis(valuesUnsorted, order.ref, -1);
   const vectors = np.takeAlongAxis(v, order.reshape([...batchShape, 1, n]), -1);

--- a/src/library/lax-linalg.ts
+++ b/src/library/lax-linalg.ts
@@ -1,8 +1,166 @@
 // Linear algebra functions, mirroring `jax.lax.linalg`.
 
-import { moveaxis } from "./numpy";
+import * as np from "./numpy";
+import { DType, isFloatDtype } from "../alu";
 import { Array, type ArrayLike, fudgeArray } from "../frontend/array";
 import * as core from "../frontend/core";
+import { jit } from "../frontend/jaxpr";
+import { checkSquare } from "../utils";
+
+const JsArray = globalThis.Array;
+
+type JacobiRoundPlan = {
+  p: number[];
+  q: number[];
+  active: boolean[];
+  mate: number[];
+  pairId: number[];
+  sign: number[];
+};
+
+function jacobiRoundPlans(n: number): JacobiRoundPlan[] {
+  if (n < 2) return [];
+
+  const participants = JsArray.from({ length: n }, (_, i) => i);
+  if (n % 2 === 1) participants.push(-1);
+
+  const rounds: JacobiRoundPlan[] = [];
+  const m = participants.length;
+  const half = m / 2;
+  const rotating = participants.slice();
+
+  for (let round = 0; round < m - 1; round++) {
+    const mate = JsArray.from({ length: n }, (_, i) => i);
+    const pairId = JsArray(n);
+    const sign = JsArray(n);
+    const p: number[] = [];
+    const q: number[] = [];
+    const active: boolean[] = [];
+
+    for (let k = 0; k < half; k++) {
+      let a = rotating[k];
+      let b = rotating[m - 1 - k];
+      if (a === -1 || b === -1) {
+        const i = a === -1 ? b : a;
+        p.push(i);
+        q.push(i);
+        active.push(false);
+        pairId[i] = k;
+        sign[i] = 0;
+      } else {
+        if (a > b) [a, b] = [b, a];
+        p.push(a);
+        q.push(b);
+        active.push(true);
+        mate[a] = b;
+        mate[b] = a;
+        pairId[a] = k;
+        pairId[b] = k;
+        sign[a] = -1;
+        sign[b] = 1;
+      }
+    }
+
+    rounds.push({ p, q, active, mate, pairId, sign });
+
+    const tail = rotating.pop()!;
+    rotating.splice(1, 0, tail);
+  }
+
+  return rounds;
+}
+
+function jacobiSweepPlanRows(n: number): number[][] {
+  return jacobiRoundPlans(n).map(({ p, q, active, pairId, mate, sign }) => [
+    ...p,
+    ...q,
+    ...active.map(Number),
+    ...pairId,
+    ...mate,
+    ...sign,
+  ]);
+}
+
+function applyJacobiRound(
+  a: Array,
+  v: Array,
+  p: Array,
+  q: Array,
+  pairId: Array,
+  mate: Array,
+  sign: Array,
+  pairActive: Array,
+): [Array, Array] {
+  const n = a.shape[a.ndim - 1];
+  const batchShape = a.shape.slice(0, -2);
+  const batchRank = a.ndim - 2;
+  const batchIndex = JsArray.from({ length: batchRank }, () => [] as []);
+  const app = a.ref.slice(...batchIndex, p.ref, p.ref);
+  const aqq = a.ref.slice(...batchIndex, q.ref, q.ref);
+  const apq = a.ref.slice(...batchIndex, p, q);
+
+  const active = np.logicalAnd(pairActive, np.abs(apq.ref).greater(0));
+  const safeApq = np.where(active.ref, apq, 1);
+  const tau = aqq.sub(app).div(safeApq.mul(2));
+  const tauSign = np.where(tau.ref.greaterEqual(0), 1, -1);
+  const t = tauSign.div(np.abs(tau.ref).add(np.sqrt(tau.ref.mul(tau).add(1))));
+  const cRaw = np.reciprocal(np.sqrt(t.ref.mul(t.ref).add(1)));
+  const sRaw = t.mul(cRaw.ref);
+  const cPair = np.where(active.ref, cRaw, 1);
+  const sPair = np.where(active, sRaw, 0);
+
+  const cIdx = np.take(cPair, pairId.ref, -1);
+  const sIdx = np.take(sPair, pairId, -1).mul(sign);
+  const cRow = cIdx.ref.reshape([...batchShape, n, 1]);
+  const cCol = cIdx.reshape([...batchShape, 1, n]);
+  const sRow = sIdx.ref.reshape([...batchShape, n, 1]);
+  const sCol = sIdx.reshape([...batchShape, 1, n]);
+
+  const term1 = cRow.ref.mul(cCol.ref).mul(a.ref);
+  const term2 = cRow.mul(sCol.ref).mul(np.take(a.ref, mate.ref, -1));
+  const term3 = sRow.ref.mul(cCol.ref).mul(np.take(a.ref, mate.ref, -2));
+  const term4 = sRow
+    .mul(sCol.ref)
+    .mul(np.take(np.take(a, mate.ref, -2), mate.ref, -1));
+  const nextA = term1.add(term2).add(term3).add(term4);
+  const nextV = v.ref.mul(cCol).add(np.take(v, mate, -1).mul(sCol));
+
+  return [nextA, nextV];
+}
+
+const applyJacobiSweepJit = jit(function applyJacobiSweepJit(
+  a: Array,
+  v: Array,
+  plan: Array,
+): [Array, Array] {
+  const n = a.shape[a.ndim - 1];
+  const half = Math.ceil(n / 2);
+  const splitPoints = [
+    half,
+    2 * half,
+    3 * half,
+    3 * half + n,
+    3 * half + 2 * n,
+  ];
+  for (let round = 0; round < plan.shape[0]; round++) {
+    const [p, q, active, pairId, mate, sign] = np.split(
+      plan.ref.slice(round),
+      splitPoints,
+      -1,
+    );
+    [a, v] = applyJacobiRound(
+      a,
+      v,
+      p,
+      q,
+      pairId,
+      mate,
+      sign.astype(a.dtype),
+      active.astype(np.bool),
+    );
+  }
+  return [a, v];
+});
 
 /**
  * Compute the Cholesky decomposition of a symmetric positive-definite matrix.
@@ -35,7 +193,62 @@ export function cholesky(
   { upper = false }: { upper?: boolean } = {},
 ): Array {
   const L = core.cholesky(a) as Array;
-  return upper ? moveaxis(L, -2, -1) : L;
+  return upper ? np.moveaxis(L, -2, -1) : L;
+}
+
+/**
+ * Eigendecomposition of real symmetric matrices.
+ *
+ * This uses a fixed-sweep cyclic Jacobi method. It does not stop early based on
+ * convergence, which avoids synchronizing GPU-computed residuals back to JS.
+ * Eigenvectors are returned as columns in the first result, and eigenvalues are
+ * returned in ascending order in the second result.
+ */
+export function eigh(
+  x: ArrayLike,
+  {
+    lower = true,
+    symmetrizeInput = true,
+  }: {
+    lower?: boolean;
+    symmetrizeInput?: boolean;
+  } = {},
+): [Array, Array] {
+  x = fudgeArray(x);
+  const n = checkSquare("eigh", x.shape);
+  if (!isFloatDtype(x.dtype) || x.dtype === DType.Float16) {
+    x = x.astype(np.float32);
+  }
+  if (symmetrizeInput) {
+    x = x.ref.add(np.matrixTranspose(x)).mul(0.5);
+  } else if (lower) {
+    const lowerTriangle = np.tril(x.ref);
+    x = lowerTriangle.ref.add(np.matrixTranspose(np.tril(x, -1)));
+  } else {
+    const upperTriangle = np.triu(x.ref);
+    x = upperTriangle.ref.add(np.matrixTranspose(np.triu(x, 1)));
+  }
+
+  const batchShape = x.shape.slice(0, -2);
+  let v = np.broadcastTo(
+    np.eye(n, undefined, { dtype: x.dtype, device: x.device }),
+    x.shape,
+  );
+  const plan = np.array(jacobiSweepPlanRows(n), {
+    dtype: np.int32,
+    device: x.device,
+  });
+  const sweeps = Math.max(8, 2 * n);
+  for (let sweep = 0; sweep < sweeps; sweep++) {
+    [x, v] = applyJacobiSweepJit(x, v, plan.ref);
+  }
+  plan.dispose();
+
+  const valuesUnsorted = np.diagonal(x, 0, -2, -1);
+  const order = np.argsort(valuesUnsorted.ref);
+  const values = np.takeAlongAxis(valuesUnsorted, order.ref, -1);
+  const vectors = np.takeAlongAxis(v, order.reshape([...batchShape, 1, n]), -1);
+  return [vectors, values];
 }
 
 /**
@@ -108,13 +321,13 @@ export function triangularSolve(
     // b and x (output) values.
     transposeA = !transposeA;
   } else {
-    b = moveaxis(b, -2, -1);
+    b = np.moveaxis(b, -2, -1);
   }
   if (transposeA) {
-    a = moveaxis(a, -2, -1);
+    a = np.moveaxis(a, -2, -1);
     lower = !lower;
   }
   let x = core.triangularSolve(a, b, { lower, unitDiagonal }) as Array;
-  if (leftSide) x = moveaxis(x, -2, -1);
+  if (leftSide) x = np.moveaxis(x, -2, -1);
   return x;
 }

--- a/src/library/numpy-linalg.ts
+++ b/src/library/numpy-linalg.ts
@@ -2,16 +2,7 @@ import * as lax from "./lax";
 import { triangularSolve } from "./lax-linalg";
 import * as np from "./numpy";
 import { Array, ArrayLike, fudgeArray } from "../frontend/array";
-import { checkAxis, generalBroadcast } from "../utils";
-
-function checkSquare(name: string, a: Array) {
-  if (a.ndim < 2 || a.shape[a.ndim - 1] !== a.shape[a.ndim - 2]) {
-    throw new Error(
-      `${name}: input must be at least 2D square matrix, got ${a.aval}`,
-    );
-  }
-  return a.shape[a.ndim - 1];
-}
+import { checkAxis, checkSquare, generalBroadcast } from "../utils";
 
 /**
  * Compute the Cholesky decomposition of a (batched) positive-definite matrix.
@@ -30,7 +21,7 @@ export function cholesky(
   } = {},
 ): Array {
   a = fudgeArray(a);
-  checkSquare("cholesky", a);
+  checkSquare("cholesky", a.shape);
   if (symmetrizeInput) {
     a = a.ref.add(np.matrixTranspose(a)).mul(0.5);
   }
@@ -60,7 +51,7 @@ export function cross(x1: ArrayLike, x2: ArrayLike, axis: number = -1): Array {
 /** Compute the determinant of a square matrix (batched). */
 export function det(a: ArrayLike): Array {
   a = fudgeArray(a);
-  const n = checkSquare("det", a);
+  const n = checkSquare("det", a.shape);
   const [lu, pivots, permutation] = lax.linalg.lu(a);
   permutation.dispose();
 
@@ -72,10 +63,36 @@ export function det(a: ArrayLike): Array {
 
 export { diagonal } from "./numpy";
 
+type EighOpts = {
+  symmetrizeInput?: boolean;
+};
+
+/**
+ * Compute eigenvalues and eigenvectors of real symmetric matrices.
+ *
+ * The returned eigenvalues are sorted in ascending order, and eigenvectors are
+ * returned as columns.
+ */
+export function eigh(a: ArrayLike, opts?: EighOpts): [Array, Array] {
+  const [vectors, values] = lax.linalg.eigh(a, {
+    symmetrizeInput: opts?.symmetrizeInput,
+  });
+  return [values, vectors];
+}
+
+/** Compute eigenvalues of real symmetric matrices. */
+export function eigvalsh(a: ArrayLike, opts?: EighOpts): Array {
+  const [vectors, values] = lax.linalg.eigh(a, {
+    symmetrizeInput: opts?.symmetrizeInput,
+  });
+  vectors.dispose();
+  return values;
+}
+
 /** Compute the inverse of a square matrix (batched). */
 export function inv(a: ArrayLike): Array {
   a = fudgeArray(a);
-  const n = checkSquare("inv", a);
+  const n = checkSquare("inv", a.shape);
   return solve(a, np.eye(n, undefined, { dtype: a.dtype }));
 }
 
@@ -136,7 +153,7 @@ export function matrixPower(a: ArrayLike, n: number): Array {
   if (!Number.isInteger(n))
     throw new Error(`matrixPower: exponent must be an integer, got ${n}`);
   a = fudgeArray(a);
-  const m = checkSquare("matrixPower", a);
+  const m = checkSquare("matrixPower", a.shape);
   if (n === 0) {
     const dtype = a.dtype;
     a.dispose();
@@ -199,7 +216,7 @@ export { outer } from "./numpy";
 /** Return sign and natural logarithm of the determinant of `a`. */
 export function slogdet(a: ArrayLike): [Array, Array] {
   a = fudgeArray(a);
-  const n = checkSquare("slogdet", a);
+  const n = checkSquare("slogdet", a.shape);
   const [lu, pivots, permutation] = lax.linalg.lu(a);
   permutation.dispose();
 
@@ -224,7 +241,7 @@ export function slogdet(a: ArrayLike): [Array, Array] {
 export function solve(a: ArrayLike, b: ArrayLike): Array {
   a = fudgeArray(a);
   b = fudgeArray(b);
-  const n = checkSquare("solve", a);
+  const n = checkSquare("solve", a.shape);
   if (b.ndim === 0) throw new Error(`solve: b cannot be scalar`);
   const bIs1d = b.ndim === 1;
   if (bIs1d) {

--- a/src/routine.ts
+++ b/src/routine.ts
@@ -1,6 +1,6 @@
 // Custom lowering for advanced operations that don't fit into AluExp.
 
-import { DataArray, DType, dtypedArray } from "./alu";
+import { DataArray, DType, dtypedArray, isFloatDtype } from "./alu";
 
 /**
  * Advanced operations that don't fit into the `AluExp` compiler representation.
@@ -74,6 +74,17 @@ export enum Routines {
    *   such that `P = eye(M).slice(Permutation)` -> `P @ A = L @ U`.
    */
   LU = "LU",
+
+  /**
+   * Symmetric eigendecomposition using cyclic Jacobi rotations.
+   *
+   * The input is a batch of real symmetric matrices with shape `[..., N, N]`.
+   * The output is a tuple `Diagonalized, Vectors`, both shape `[..., N, N]`.
+   * `Diagonalized` is approximately diagonal and `Vectors` contains the
+   * accumulated eigenvectors as columns. Sorting eigenpairs is handled by the
+   * frontend wrapper.
+   */
+  JacobiEigh = "JacobiEigh",
 }
 
 export interface RoutineType {
@@ -109,6 +120,8 @@ export function runCpuRoutine(
       return runCholesky(type, inputAr, outputAr);
     case Routines.LU:
       return runLU(type, inputAr, outputAr);
+    case Routines.JacobiEigh:
+      return runJacobiEigh(type, inputAr, outputAr, routine.params);
     default:
       name satisfies never; // Exhaustiveness check
   }
@@ -264,6 +277,114 @@ function runLU(
             out[i * n + col] -= factor * out[j * n + col];
         }
       }
+    }
+  }
+}
+
+function runJacobiEigh(
+  type: RoutineType,
+  [input]: DataArray[],
+  [diagonalized, vectors]: DataArray[],
+  { maxSweeps, tolerance }: { maxSweeps: number; tolerance: number },
+) {
+  const shape = type.inputShapes[0];
+  if (shape.length < 2)
+    throw new Error("jacobi_eigh: input must be at least 2D");
+  const n = shape[shape.length - 1];
+  if (n !== shape[shape.length - 2])
+    throw new Error(`jacobi_eigh: input must be square, got ${shape}`);
+  if (!isFloatDtype(type.inputDtypes[0]))
+    throw new TypeError(`jacobi_eigh: input must be floating-point`);
+
+  function maxAbsMatrix(a: DataArray): number {
+    let maxAbs = 1;
+    for (let i = 0; i < n * n; i++) {
+      maxAbs = Math.max(maxAbs, Math.abs(a[i]));
+    }
+    return maxAbs;
+  }
+
+  function maxAbsOffDiagonal(a: DataArray): number {
+    let maxAbs = 0;
+    for (let i = 0; i < n; i++) {
+      for (let j = 0; j < n; j++) {
+        if (i !== j) maxAbs = Math.max(maxAbs, Math.abs(a[i * n + j]));
+      }
+    }
+    return maxAbs;
+  }
+
+  function applyJacobiRotation(
+    a: DataArray,
+    v: DataArray,
+    p: number,
+    q: number,
+  ) {
+    const pp = p * n + p;
+    const qq = q * n + q;
+    const pq = p * n + q;
+    const app = a[pp];
+    const aqq = a[qq];
+    const apq = a[pq];
+    if (apq === 0) return;
+
+    const tau = (aqq - app) / (2 * apq);
+    const tauSign = tau >= 0 ? 1 : -1;
+    const t = tauSign / (Math.abs(tau) + Math.sqrt(tau * tau + 1));
+    const c = 1 / Math.sqrt(t * t + 1);
+    const s = t * c;
+
+    for (let k = 0; k < n; k++) {
+      if (k === p || k === q) continue;
+      const kp = k * n + p;
+      const kq = k * n + q;
+      const akp = a[kp];
+      const akq = a[kq];
+      const nextKp = c * akp - s * akq;
+      const nextKq = s * akp + c * akq;
+      a[kp] = nextKp;
+      a[p * n + k] = nextKp;
+      a[kq] = nextKq;
+      a[q * n + k] = nextKq;
+    }
+
+    a[pp] = c * c * app - 2 * s * c * apq + s * s * aqq;
+    a[qq] = s * s * app + 2 * s * c * apq + c * c * aqq;
+    a[pq] = 0;
+    a[q * n + p] = 0;
+
+    for (let k = 0; k < n; k++) {
+      const kp = k * n + p;
+      const kq = k * n + q;
+      const vkp = v[kp];
+      const vkq = v[kq];
+      v[kp] = c * vkp - s * vkq;
+      v[kq] = s * vkp + c * vkq;
+    }
+  }
+
+  const matrixSize = n * n;
+  for (let offset = 0; offset < input.length; offset += matrixSize) {
+    const x = input.subarray(offset, offset + matrixSize);
+    const a = diagonalized.subarray(offset, offset + matrixSize);
+    const v = vectors.subarray(offset, offset + matrixSize);
+    a.set(x);
+    v.fill(0);
+    for (let i = 0; i < n; i++) v[i * n + i] = 1;
+
+    const threshold = tolerance * maxAbsMatrix(a);
+    let maxOffDiagonal = maxAbsOffDiagonal(a);
+    for (
+      let sweep = 0;
+      sweep < maxSweeps && maxOffDiagonal > threshold;
+      sweep++
+    ) {
+      for (let p = 0; p < n - 1; p++) {
+        for (let q = p + 1; q < n; q++) {
+          applyJacobiRotation(a, v, p, q);
+        }
+      }
+      maxOffDiagonal = maxAbsOffDiagonal(a);
     }
   }
 }

--- a/src/routine.ts
+++ b/src/routine.ts
@@ -78,11 +78,11 @@ export enum Routines {
   /**
    * Symmetric eigendecomposition using cyclic Jacobi rotations.
    *
-   * The input is a batch of real symmetric matrices with shape `[..., N, N]`.
-   * The output is a tuple `Diagonalized, Vectors`, both shape `[..., N, N]`.
-   * `Diagonalized` is approximately diagonal and `Vectors` contains the
-   * accumulated eigenvectors as columns. Sorting eigenpairs is handled by the
-   * frontend wrapper.
+   * The input is a batch of real symmetric matrices with shape `[..., N, N]`;
+   * only the lower triangle is read. The output is a tuple `Diagonalized,
+   * Vectors`, both shape `[..., N, N]`. `Diagonalized` is approximately
+   * diagonal and `Vectors` contains the accumulated eigenvectors as columns.
+   * Sorting eigenpairs is handled by the frontend wrapper.
    */
   JacobiEigh = "JacobiEigh",
 }
@@ -296,10 +296,16 @@ function runJacobiEigh(
   if (!isFloatDtype(type.inputDtypes[0]))
     throw new TypeError(`jacobi_eigh: input must be floating-point`);
 
+  function symIndex(i: number, j: number): number {
+    return i >= j ? i * n + j : j * n + i;
+  }
+
   function maxAbsMatrix(a: DataArray): number {
     let maxAbs = 1;
-    for (let i = 0; i < n * n; i++) {
-      maxAbs = Math.max(maxAbs, Math.abs(a[i]));
+    for (let i = 0; i < n; i++) {
+      for (let j = 0; j <= i; j++) {
+        maxAbs = Math.max(maxAbs, Math.abs(a[i * n + j]));
+      }
     }
     return maxAbs;
   }
@@ -307,8 +313,8 @@ function runJacobiEigh(
   function maxAbsOffDiagonal(a: DataArray): number {
     let maxAbs = 0;
     for (let i = 0; i < n; i++) {
-      for (let j = 0; j < n; j++) {
-        if (i !== j) maxAbs = Math.max(maxAbs, Math.abs(a[i * n + j]));
+      for (let j = 0; j < i; j++) {
+        maxAbs = Math.max(maxAbs, Math.abs(a[i * n + j]));
       }
     }
     return maxAbs;
@@ -322,7 +328,7 @@ function runJacobiEigh(
   ) {
     const pp = p * n + p;
     const qq = q * n + q;
-    const pq = p * n + q;
+    const pq = symIndex(p, q);
     const app = a[pp];
     const aqq = a[qq];
     const apq = a[pq];
@@ -336,22 +342,19 @@ function runJacobiEigh(
 
     for (let k = 0; k < n; k++) {
       if (k === p || k === q) continue;
-      const kp = k * n + p;
-      const kq = k * n + q;
+      const kp = symIndex(k, p);
+      const kq = symIndex(k, q);
       const akp = a[kp];
       const akq = a[kq];
       const nextKp = c * akp - s * akq;
       const nextKq = s * akp + c * akq;
       a[kp] = nextKp;
-      a[p * n + k] = nextKp;
       a[kq] = nextKq;
-      a[q * n + k] = nextKq;
     }
 
     a[pp] = c * c * app - 2 * s * c * apq + s * s * aqq;
     a[qq] = s * s * app + 2 * s * c * apq + c * c * aqq;
     a[pq] = 0;
-    a[q * n + p] = 0;
 
     for (let k = 0; k < n; k++) {
       const kp = k * n + p;
@@ -368,7 +371,12 @@ function runJacobiEigh(
     const x = input.subarray(offset, offset + matrixSize);
     const a = diagonalized.subarray(offset, offset + matrixSize);
     const v = vectors.subarray(offset, offset + matrixSize);
-    a.set(x);
+    a.fill(0);
+    for (let i = 0; i < n; i++) {
+      for (let j = 0; j <= i; j++) {
+        a[i * n + j] = x[i * n + j];
+      }
+    }
     v.fill(0);
     for (let i = 0; i < n; i++) v[i * n + i] = 1;
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -184,6 +184,16 @@ export function normalizeAxis(
   }
 }
 
+/** Check that a shape ends in square matrix dimensions, and return the size. */
+export function checkSquare(name: string, shape: number[]): number {
+  if (shape.length < 2 || shape[shape.length - 1] !== shape[shape.length - 2]) {
+    throw new Error(
+      `${name}: input must be at least 2D square matrix, got shape ${JSON.stringify(shape)}`,
+    );
+  }
+  return shape[shape.length - 1];
+}
+
 /** Check for an array of integers with no duplicates. */
 export function checkInts(indices: number | number[]) {
   if (typeof indices === "number") {

--- a/test/lax-linalg.test.ts
+++ b/test/lax-linalg.test.ts
@@ -116,6 +116,100 @@ suite.each(devicesWithLinalg)("device:%s", (device) => {
     });
   });
 
+  suite("jax.lax.linalg.eigh()", () => {
+    test("returns eigenvectors then sorted eigenvalues", () => {
+      const x = np.array([
+        [3.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0],
+        [0.0, 0.0, 2.0],
+      ]);
+      const [vectors, values] = lax.linalg.eigh(x);
+
+      expect(values).toBeAllclose([1.0, 2.0, 3.0]);
+      expect(vectors).toBeAllclose([
+        [0.0, 0.0, 1.0],
+        [1.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0],
+      ]);
+    });
+
+    test("reconstructs a symmetric matrix", () => {
+      const x = np.array([
+        [4.0, 1.0, 2.0],
+        [1.0, 3.0, 0.5],
+        [2.0, 0.5, 5.0],
+      ]);
+      const [vectors, values] = lax.linalg.eigh(x.ref);
+      const reconstructed = np.matmul(
+        vectors.ref.mul(values.reshape([1, -1])),
+        vectors.ref.transpose(),
+      );
+      const orthogonal = np.matmul(vectors.ref.transpose(), vectors);
+
+      expect(reconstructed).toBeAllclose(x, { rtol: 1e-3, atol: 1e-3 });
+      expect(orthogonal).toBeAllclose(np.eye(3), { rtol: 1e-3, atol: 1e-3 });
+    });
+
+    test("supports batched matrices", () => {
+      const x = np.array([
+        [
+          [2.0, 1.0],
+          [1.0, 2.0],
+        ],
+        [
+          [3.0, 1.0],
+          [1.0, 3.0],
+        ],
+      ]);
+      const [vectors, values] = lax.linalg.eigh(x.ref);
+
+      expect(values.ref).toBeAllclose([
+        [1.0, 3.0],
+        [2.0, 4.0],
+      ]);
+
+      const reconstructed = np.matmul(
+        vectors.ref.mul(values.reshape([2, 1, 2])),
+        np.matrixTranspose(vectors.ref),
+      );
+      const orthogonal = np.matmul(np.matrixTranspose(vectors.ref), vectors);
+
+      expect(reconstructed).toBeAllclose(x, { rtol: 1e-4, atol: 1e-4 });
+      expect(orthogonal).toBeAllclose(np.broadcastTo(np.eye(2), [2, 2, 2]), {
+        rtol: 1e-4,
+        atol: 1e-4,
+      });
+    });
+
+    test("uses the selected triangle when not symmetrizing", () => {
+      const lowerInput = np.array([
+        [2.0, 100.0],
+        [1.0, 2.0],
+      ]);
+      const upperInput = np.array([
+        [2.0, 100.0],
+        [1.0, 2.0],
+      ]);
+      const [, lowerValues] = lax.linalg.eigh(lowerInput.ref, {
+        symmetrizeInput: false,
+        lower: true,
+      });
+      const [, upperValues] = lax.linalg.eigh(upperInput, {
+        symmetrizeInput: false,
+        lower: false,
+      });
+
+      expect(lowerValues).toBeAllclose([1.0, 3.0], {
+        rtol: 1e-4,
+        atol: 1e-4,
+      });
+      expect(upperValues).toBeAllclose([-98.0, 102.0], {
+        rtol: 1e-4,
+        atol: 1e-4,
+      });
+    });
+  });
+
   suite("jax.lax.linalg.lu()", () => {
     test("example with partial pivoting", () => {
       const A = np.array([

--- a/test/lax-linalg.test.ts
+++ b/test/lax-linalg.test.ts
@@ -133,6 +133,20 @@ suite.each(devicesWithLinalg)("device:%s", (device) => {
       ]);
     });
 
+    test("can leave eigenvalues unsorted", () => {
+      const x = np.array([
+        [3.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0],
+        [0.0, 0.0, 2.0],
+      ]);
+      const [vectors, values] = lax.linalg.eigh(x, {
+        sortEigenvalues: false,
+      });
+
+      expect(values).toBeAllclose([3.0, 1.0, 2.0]);
+      expect(vectors).toBeAllclose(np.eye(3));
+    });
+
     test("reconstructs a symmetric matrix", () => {
       const x = np.array([
         [4.0, 1.0, 2.0],

--- a/test/numpy-linalg.test.ts
+++ b/test/numpy-linalg.test.ts
@@ -33,6 +33,91 @@ suite.each(devicesWithLinalg)("device:%s", (device) => {
     });
   });
 
+  suite("numpy.linalg.eigh()", () => {
+    test("sorts diagonal eigenvalues and eigenvectors", () => {
+      const a = np.array([
+        [3.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0],
+        [0.0, 0.0, 2.0],
+      ]);
+      const [values, vectors] = np.linalg.eigh(a);
+
+      expect(values.ref).toBeAllclose([1.0, 2.0, 3.0]);
+      expect(vectors).toBeAllclose([
+        [0.0, 0.0, 1.0],
+        [1.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0],
+      ]);
+      values.dispose();
+    });
+
+    test("reconstructs a symmetric matrix", () => {
+      const a = np.array([
+        [4.0, 1.0, 2.0],
+        [1.0, 3.0, 0.5],
+        [2.0, 0.5, 5.0],
+      ]);
+      const [values, vectors] = np.linalg.eigh(a.ref);
+      const reconstructed = np.matmul(
+        vectors.ref.mul(values.reshape([1, -1])),
+        vectors.ref.transpose(),
+      );
+      const orthogonal = np.matmul(vectors.ref.transpose(), vectors);
+
+      expect(reconstructed).toBeAllclose(a, { rtol: 1e-3, atol: 1e-3 });
+      expect(orthogonal).toBeAllclose(np.eye(3), { rtol: 1e-3, atol: 1e-3 });
+    });
+  });
+
+  suite("numpy.linalg.eigvalsh()", () => {
+    test("returns eigenvalues only", () => {
+      const a = np.array([
+        [2.0, 1.0],
+        [1.0, 2.0],
+      ]);
+      expect(np.linalg.eigvalsh(a)).toBeAllclose([1.0, 3.0], {
+        rtol: 1e-4,
+        atol: 1e-4,
+      });
+    });
+
+    test("supports batched matrices", () => {
+      const a = np.array([
+        [
+          [2.0, 1.0],
+          [1.0, 2.0],
+        ],
+        [
+          [3.0, 1.0],
+          [1.0, 3.0],
+        ],
+      ]);
+      expect(np.linalg.eigvalsh(a)).toBeAllclose(
+        [
+          [1.0, 3.0],
+          [2.0, 4.0],
+        ],
+        { rtol: 1e-4, atol: 1e-4 },
+      );
+    });
+
+    test("only forwards symmetrizeInput option", () => {
+      const a = np.array([
+        [2.0, 100.0],
+        [1.0, 2.0],
+      ]);
+      expect(
+        np.linalg.eigvalsh(a, {
+          symmetrizeInput: false,
+          lower: false,
+        } as { symmetrizeInput: boolean }),
+      ).toBeAllclose([1.0, 3.0], {
+        rtol: 1e-4,
+        atol: 1e-4,
+      });
+    });
+  });
+
   suite("numpy.linalg.det()", () => {
     test("computes determinant of simple matrix", () => {
       const a = np.array([


### PR DESCRIPTION
These need to be implemented as routines, otherwise the overhead is too large.

Anyway, Jacobi iteration is simple to implement and fast enough for our purposes. JAX also uses Jacobi iteration backend for GPU devices. :)