### PR TITLE
Fix async routine bug in Wasm

### DIFF
--- a/src/backend/wasm.ts
+++ b/src/backend/wasm.ts
@@ -150,7 +150,10 @@ export class WasmBackend implements Backend {
   async prepareRoutine(
     routine: Routine,
   ): Promise<Executable<WasmExecutableData>> {
-    return this.prepareRoutineSync(routine);
+    return new Executable(routine, {
+      program: undefined!,
+      sync: false,
+    });
   }
 
   prepareRoutineSync(routine: Routine): Executable<WasmExecutableData> {
@@ -170,14 +173,55 @@ export class WasmBackend implements Backend {
     const tracing = isTracing();
     const start = tracing ? performance.now() : 0;
 
+    const { sync } = exe.data;
     if (exe.source instanceof Routine) {
-      runCpuRoutine(
-        exe.source,
-        inputs.map((slot) => this.#getBuffer(slot)),
-        outputs.map((slot) => this.#getBuffer(slot)),
-      );
+      if (this.#workerPool && !sync) {
+        const routine = {
+          name: exe.source.name,
+          type: exe.source.type,
+          params: exe.source.params,
+        };
+        const retainedSlots = [...inputs, ...outputs];
+        for (const slot of retainedSlots) this.incRef(slot);
+        const epoch = this.#workerPool.dispatchRoutine(
+          routine,
+          inputs.map((slot) => {
+            const { ptr, size } = this.#buffers.get(slot)!;
+            return { ptr, size };
+          }),
+          outputs.map((slot) => {
+            const { ptr, size } = this.#buffers.get(slot)!;
+            return { ptr, size };
+          }),
+        );
+        for (const slot of outputs) this.#pendingWork.set(slot, epoch);
+        this.#workerPool.waitForEpoch(epoch).then(() => {
+          for (const slot of outputs) {
+            if (this.#pendingWork.get(slot) === epoch) {
+              this.#pendingWork.delete(slot);
+            }
+          }
+          for (const slot of retainedSlots) this.decRef(slot);
+        });
+      } else {
+        if (
+          inputs.some((slot) => {
+            const epoch = this.#pendingWork.get(slot);
+            return epoch && this.#workerPool!.epoch < epoch;
+          })
+        ) {
+          throw new Error(
+            "cannot dispatch wasm routine synchronously with pending async work",
+          );
+        }
+        runCpuRoutine(
+          exe.source,
+          inputs.map((slot) => this.#getBuffer(slot)),
+          outputs.map((slot) => this.#getBuffer(slot)),
+        );
+      }
     } else {
-      const { program, sync } = exe.data;
+      const { program } = exe.data;
       const ptrs = [...inputs, ...outputs].map(
         (slot) => this.#buffers.get(slot)!.ptr,
       );

--- a/src/backend/wasm/parallel.ts
+++ b/src/backend/wasm/parallel.ts
@@ -8,6 +8,8 @@
 // Cross-Origin-Embedder-Policy: require-corp
 // ```
 
+import { cpuRoutineJSForWorkers, type Routine } from "../../routine";
+
 /** Check if SharedArrayBuffer is available. */
 export function hasSharedArrayBuffer(): boolean {
   // Node.js has SharedArrayBuffer but not Worker, so check both.
@@ -19,6 +21,8 @@ export function hasSharedArrayBuffer(): boolean {
 const MIN_ELEMS_PER_THREAD = 256;
 
 const WORKER_SOURCE = `
+${cpuRoutineJSForWorkers()}
+
 let memory = null;
 let cachedModule = null;
 let cachedFunc = null;
@@ -31,19 +35,38 @@ self.onmessage = (e) => {
     return;
   }
   try {
-    const { module, ptrs, begin, end } = msg;
-    if (module !== cachedModule) {
-      cachedModule = module;
-      const instance = new WebAssembly.Instance(module, { env: { memory } });
-      cachedFunc = instance.exports.kernel;
+    if (msg.type === "kernel") {
+      const { module, ptrs, begin, end } = msg;
+      if (module !== cachedModule) {
+        cachedModule = module;
+        const instance = new WebAssembly.Instance(module, { env: { memory } });
+        cachedFunc = instance.exports.kernel;
+      }
+      cachedFunc(...ptrs, begin, end);
+    } else if (msg.type === "routine") {
+      const inputs = msg.inputs.map(({ ptr, size }) =>
+        new Uint8Array(memory.buffer, ptr, size)
+      );
+      const outputs = msg.outputs.map(({ ptr, size }) =>
+        new Uint8Array(memory.buffer, ptr, size)
+      );
+      runCpuRoutine(msg.routine, inputs, outputs);
+    } else {
+      throw new Error("Unknown wasm worker message: " + msg.type);
     }
-    cachedFunc(...ptrs, begin, end);
     postMessage({ type: "done", ok: true });
   } catch (err) {
     postMessage({ type: "done", ok: false, error: String(err) });
   }
 };
 `;
+
+interface RoutineBuffer {
+  ptr: number;
+  size: number;
+}
+
+type RoutinePayload = Pick<Routine, "name" | "type" | "params">;
 
 /** Pool of Web Workers for parallel WASM kernel dispatch. */
 export class WasmWorkerPool {
@@ -117,11 +140,31 @@ export class WasmWorkerPool {
     chunkAlignment: number = 16,
     minWorkPerWorker: number = MIN_ELEMS_PER_THREAD,
   ): bigint {
-    this.#ensureInit();
-    this.#epochEnd++;
-    const result = this.#queue.then(() =>
+    return this.#enqueue(() =>
       this.#dispatchNow(module, ptrs, size, chunkAlignment, minWorkPerWorker),
     );
+  }
+
+  /**
+   * Dispatch a CPU fallback routine on a worker.
+   *
+   * This uses the same serial queue as generated wasm kernels so routine reads
+   * observe prior async writes and later kernels observe routine outputs.
+   */
+  dispatchRoutine(
+    routine: RoutinePayload,
+    inputs: RoutineBuffer[],
+    outputs: RoutineBuffer[],
+  ): bigint {
+    return this.#enqueue(() =>
+      this.#dispatchRoutineNow(routine, inputs, outputs),
+    );
+  }
+
+  #enqueue(job: () => Promise<void>): bigint {
+    this.#ensureInit();
+    this.#epochEnd++;
+    const result = this.#queue.then(job);
     this.#queue = result
       .then(
         () => {},
@@ -163,11 +206,26 @@ export class WasmWorkerPool {
             if (e.data.ok) resolve();
             else reject(new Error(`Worker error: ${e.data.error}`));
           };
-          worker.postMessage({ module, ptrs, begin, end });
+          worker.postMessage({ type: "kernel", module, ptrs, begin, end });
         }),
       );
     }
     await Promise.all(promises);
+  }
+
+  async #dispatchRoutineNow(
+    routine: RoutinePayload,
+    inputs: RoutineBuffer[],
+    outputs: RoutineBuffer[],
+  ): Promise<void> {
+    const worker = this.#workers[0];
+    await new Promise<void>((resolve, reject) => {
+      worker.onmessage = (e) => {
+        if (e.data.ok) resolve();
+        else reject(new Error(`Worker error: ${e.data.error}`));
+      };
+      worker.postMessage({ type: "routine", routine, inputs, outputs });
+    });
   }
 }
 

--- a/src/routine.ts
+++ b/src/routine.ts
@@ -1,6 +1,6 @@
 // Custom lowering for advanced operations that don't fit into AluExp.
 
-import { DataArray, DType, dtypedArray, isFloatDtype } from "./alu";
+import { byteWidth, DataArray, DType, dtypedArray, isFloatDtype } from "./alu";
 
 /**
  * Advanced operations that don't fit into the `AluExp` compiler representation.
@@ -125,6 +125,24 @@ export function runCpuRoutine(
     default:
       name satisfies never; // Exhaustiveness check
   }
+}
+
+/** JS source for running CPU routines inside a Web Worker. */
+export function cpuRoutineJSForWorkers(): string {
+  return `
+const DType = ${JSON.stringify(DType)};
+const Routines = ${JSON.stringify(Routines)};
+const byteWidth = ${byteWidth.toString()};
+const isFloatDtype = ${isFloatDtype.toString()};
+const dtypedArray = ${dtypedArray.toString()};
+${runCpuRoutine.toString()}
+${runSort.toString()}
+${runArgsort.toString()}
+${runTriangularSolve.toString()}
+${runCholesky.toString()}
+${runLU.toString()}
+${runJacobiEigh.toString()}
+`;
 }
 
 function runSort(type: RoutineType, [x]: DataArray[], [y]: DataArray[]) {

--- a/test/numpy-linalg.test.ts
+++ b/test/numpy-linalg.test.ts
@@ -101,6 +101,13 @@ suite.each(devicesWithLinalg)("device:%s", (device) => {
       );
     });
 
+    test("works with lazy random inputs", async () => {
+      const a = random.normal(random.key(0), [16, 16]);
+      const values = (await np.linalg.eigvalsh(a).jsAsync()) as number[];
+      const sumAbs = values.reduce((sum, x) => sum + Math.abs(x), 0);
+      expect(sumAbs).toBeGreaterThan(1);
+    });
+
     test("only forwards symmetrizeInput option", () => {
       const a = np.array([
         [2.0, 100.0],


### PR DESCRIPTION
This offloads async routines to the worker thread for the Wasm runtime, and fixes a bug where they sometimes wouldn't wait for the async work to finish before starting.