### PR TITLE
Much faster FFT (50-300x faster), any base

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -473,31 +473,31 @@ Most operations behave the same way as they do in JAX.
 
 ## [`jax.numpy.fft` module](https://docs.jax.dev/en/latest/jax.numpy.html#module-jax.numpy.fft)
 
-Basic FFT is supported, but there is no `complex64` data type in the library.
+FFT is fully supported, but there is no `complex64` data type in the library.
 
 Complex FFT routines take in pairs of real and imaginary parts. Real and Hermitian FFT use real
 arrays where appropriate.
 
-| API         | Support | Notes                     |
-| ----------- | ------- | ------------------------- |
-| `fft`       | 🟡      | only powers of 2          |
-| `fft2`      | 🟡      | only powers of 2          |
-| `fftfreq`   | 🟢      |                           |
-| `fftn`      | 🟡      | only powers of 2          |
-| `fftshift`  | 🟢      |                           |
-| `hfft`      | 🟡      | only powers of 2 (output) |
-| `ifft`      | 🟡      | only powers of 2          |
-| `ifft2`     | 🟡      | only powers of 2          |
-| `ifftn`     | 🟡      | only powers of 2          |
-| `ifftshift` | 🟢      |                           |
-| `ihfft`     | 🟡      | only powers of 2          |
-| `irfft`     | 🟡      | only powers of 2 (output) |
-| `irfft2`    | 🟡      | only powers of 2 (output) |
-| `irfftn`    | 🟡      | only powers of 2 (output) |
-| `rfft`      | 🟡      | only powers of 2          |
-| `rfft2`     | 🟡      | only powers of 2          |
-| `rfftfreq`  | 🟢      |                           |
-| `rfftn`     | 🟡      | only powers of 2          |
+| API         | Support | Notes                   |
+| ----------- | ------- | ----------------------- |
+| `fft`       | 🟢      | O(n^2) for large primes |
+| `fft2`      | 🟢      |                         |
+| `fftfreq`   | 🟢      |                         |
+| `fftn`      | 🟢      |                         |
+| `fftshift`  | 🟢      |                         |
+| `hfft`      | 🟢      |                         |
+| `ifft`      | 🟢      |                         |
+| `ifft2`     | 🟢      |                         |
+| `ifftn`     | 🟢      |                         |
+| `ifftshift` | 🟢      |                         |
+| `ihfft`     | 🟢      |                         |
+| `irfft`     | 🟢      |                         |
+| `irfft2`    | 🟢      |                         |
+| `irfftn`    | 🟢      |                         |
+| `rfft`      | 🟢      |                         |
+| `rfft2`     | 🟢      |                         |
+| `rfftfreq`  | 🟢      |                         |
+| `rfftn`     | 🟢      |                         |
 
 ## [`jax.numpy.linalg` module](https://docs.jax.dev/en/latest/jax.numpy.html#module-jax.numpy.linalg)
 

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -16,9 +16,9 @@ Other features just aren't implemented yet. But those can probably be added easi
 
 In the tables below, we use a color legend to refer to functions in JAX:
 
-- 🟢 = supported **(~60%)**
-- 🟡 = supported, with API limitations **(~5%)**
-- 🟠 = not supported, easy to add (<1 day) **(~24%)**
+- 🟢 = supported **(~63%)**
+- 🟡 = supported, with API limitations **(~3%)**
+- 🟠 = not supported, easy to add (<1 day) **(~23%)**
 - 🔴 = not supported **(~11%)**
 - ⚪️ = not applicable, will not be supported (see notes)
 

--- a/bench/fft.bench.ts
+++ b/bench/fft.bench.ts
@@ -1,0 +1,58 @@
+import { blockUntilReady, defaultDevice, init, numpy as np } from "@jax-js/jax";
+import { afterAll, bench, suite } from "vitest";
+
+const devices = await init("wasm", "webgpu");
+
+const cases = [
+  { name: "256", shape: [256], phase: 0.0 },
+  { name: "1024", shape: [1024], phase: 0.01 },
+  { name: "1000", shape: [1000], phase: 0.02 },
+  { name: "64x256", shape: [64, 256], phase: 0.03 },
+  { name: "100k", shape: [100_000], phase: 0.04 },
+  { name: "1m", shape: [1_000_000], phase: 0.05 },
+] as const;
+
+function prod(shape: readonly number[]) {
+  return shape.reduce((a, b) => a * b, 1);
+}
+
+function makeData(shape: readonly number[], phase: number) {
+  const data = new Float32Array(prod(shape));
+  for (let i = 0; i < data.length; i++) {
+    data[i] =
+      Math.sin((i + 1) * (0.013 + phase)) +
+      0.25 * Math.cos((i + 3) * (0.037 + phase));
+  }
+  return data;
+}
+
+for (const device of ["wasm", "webgpu"] as const) {
+  suite.skipIf(!devices.includes(device))(`${device} fft`, async () => {
+    defaultDevice(device);
+
+    const inputs = cases.map(({ shape, phase }) => ({
+      real: np.array(makeData(shape, phase), { shape: [...shape] }),
+      imag: np.array(makeData(shape, phase + 0.01), { shape: [...shape] }),
+    }));
+    await blockUntilReady(inputs.flatMap(({ real, imag }) => [real, imag]));
+
+    afterAll(() => {
+      for (const { real, imag } of inputs) {
+        real.dispose();
+        imag.dispose();
+      }
+    });
+
+    for (let i = 0; i < cases.length; i++) {
+      bench(`fft ${cases[i].name}`, async () => {
+        const y = np.fft.fft({
+          real: inputs[i].real.ref,
+          imag: inputs[i].imag.ref,
+        });
+        await blockUntilReady([y.real, y.imag]);
+        y.real.dispose();
+        y.imag.dispose();
+      });
+    }
+  });
+}

--- a/src/backend/webgpu/routines.ts
+++ b/src/backend/webgpu/routines.ts
@@ -743,6 +743,173 @@ fn main(
   ];
 }
 
+function fftUniform(
+  phase: number,
+  radix: number,
+  prev: number,
+  normalize: boolean,
+): Uint8Array<ArrayBuffer> {
+  return new Uint8Array(
+    new Uint32Array([phase, radix, prev, normalize ? 1 : 0]).buffer,
+  );
+}
+
+function createFft(
+  device: GPUDevice,
+  type: RoutineType,
+  params: { factors: number[]; inverse: boolean },
+): ShaderInfo[] {
+  const dtype = type.inputDtypes[0];
+  const shape = type.inputShapes[0];
+  const n = shape[shape.length - 1];
+  const batches = prod(shape.slice(0, -1));
+  if (prod(params.factors) !== n) {
+    throw new Error(
+      `fft: factorization ${params.factors} does not match size ${n}`,
+    );
+  }
+
+  const needsF16 = dtype === DType.Float16;
+  const ty = dtypeToWgsl(dtype, true);
+  const workgroupSize = Math.min(
+    256,
+    findPow2(0, device.limits.maxComputeWorkgroupSizeX),
+  );
+  const maxFactor = Math.max(1, ...params.factors);
+  const angleScale = params.inverse
+    ? "6.283185307179586"
+    : "-6.283185307179586";
+  const digitReversal = params.factors
+    .map(
+      (factor) => `
+  digit = remaining % ${factor}u;
+  remaining = remaining / ${factor}u;
+  stride = stride * ${factor}u;
+  reversed = reversed + digit * (${n}u / stride);`,
+    )
+    .join("");
+
+  const code = `
+${needsF16 ? "enable f16;" : ""}
+${headerWgsl}
+
+@group(0) @binding(0) var<storage, read> input_real: array<${ty}>;
+@group(0) @binding(1) var<storage, read> input_imag: array<${ty}>;
+@group(0) @binding(2) var<storage, read_write> output_real: array<${ty}>;
+@group(0) @binding(3) var<storage, read_write> output_imag: array<${ty}>;
+
+struct FftParams {
+  phase: u32,
+  radix: u32,
+  prev: u32,
+  normalize: u32,
+}
+
+@group(1) @binding(0) var<uniform> fft_params: FftParams;
+
+fn digit_reversed_index(index: u32) -> u32 {
+  var remaining = index;
+  var stride = 1u;
+  var reversed = 0u;
+  var digit = 0u;
+${digitReversal}
+  return reversed;
+}
+
+@compute @workgroup_size(${workgroupSize})
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
+  let global = global_id.x + global_id.y * ${gridOffsetY * workgroupSize}u;
+
+  if (fft_params.phase == 0u) {
+    if (global >= ${batches * n}u) {
+      return;
+    }
+    let batch = global / ${n}u;
+    let out_idx = global % ${n}u;
+    let source = batch * ${n}u + digit_reversed_index(out_idx);
+    output_real[global] = input_real[source];
+    output_imag[global] = input_imag[source];
+    return;
+  }
+
+  let butterflies_per_batch = ${n}u / fft_params.radix;
+  if (global >= ${batches}u * butterflies_per_batch) {
+    return;
+  }
+
+  let batch = global / butterflies_per_batch;
+  let local = global % butterflies_per_batch;
+  let j = local % fft_params.prev;
+  let group = local / fft_params.prev;
+  let span = fft_params.prev * fft_params.radix;
+  let start = batch * ${n}u + group * span + j;
+  let scale = select(1.0, 1.0 / f32(${n}u), fft_params.normalize != 0u);
+
+  var scratch_real: array<f32, ${maxFactor}>;
+  var scratch_imag: array<f32, ${maxFactor}>;
+
+  for (var q = 0u; q < fft_params.radix; q++) {
+    let idx = start + q * fft_params.prev;
+    let angle = ${angleScale} * f32(q * j) / f32(span);
+    let c = cos(angle);
+    let s = sin(angle);
+    let xr = f32(output_real[idx]);
+    let xi = f32(output_imag[idx]);
+    scratch_real[q] = xr * c - xi * s;
+    scratch_imag[q] = xr * s + xi * c;
+  }
+
+  for (var p = 0u; p < fft_params.radix; p++) {
+    var sum_real = 0.0;
+    var sum_imag = 0.0;
+    for (var q = 0u; q < fft_params.radix; q++) {
+      let angle = ${angleScale} * f32(q * p) / f32(fft_params.radix);
+      let c = cos(angle);
+      let s = sin(angle);
+      let xr = scratch_real[q];
+      let xi = scratch_imag[q];
+      sum_real += xr * c - xi * s;
+      sum_imag += xr * s + xi * c;
+    }
+    let idx = start + p * fft_params.prev;
+    output_real[idx] = ${ty}(sum_real * scale);
+    output_imag[idx] = ${ty}(sum_imag * scale);
+  }
+}
+`.trim();
+
+  const passes = [
+    {
+      grid: calculateGrid(Math.ceil((batches * n) / workgroupSize)),
+      uniform: fftUniform(0, 1, 1, false),
+    },
+  ];
+  let prev = 1;
+  for (let i = 0; i < params.factors.length; i++) {
+    const radix = params.factors[i];
+    passes.push({
+      grid: calculateGrid(Math.ceil((batches * n) / radix / workgroupSize)),
+      uniform: fftUniform(
+        1,
+        radix,
+        prev,
+        params.inverse && i === params.factors.length - 1,
+      ),
+    });
+    prev *= radix;
+  }
+
+  return [
+    {
+      code,
+      numInputs: 2,
+      numOutputs: 2,
+      hasUniform: true,
+      passes,
+    },
+  ];
+}
+
 export function createRoutineShader(
   device: GPUDevice,
   routine: Routine,
@@ -760,6 +927,8 @@ export function createRoutineShader(
       return createLU(device, routine.type);
     case Routines.JacobiEigh:
       return createJacobiEigh(device, routine.type, routine.params);
+    case Routines.Fft:
+      return createFft(device, routine.type, routine.params);
     default:
       throw new UnsupportedRoutineError(routine.name, "webgpu");
   }

--- a/src/frontend/array.ts
+++ b/src/frontend/array.ts
@@ -1178,6 +1178,7 @@ export class Array extends Tracer {
       [Primitive.Cholesky]: Array.#routine(Primitive.Cholesky),
       [Primitive.LU]: Array.#routine(Primitive.LU),
       [Primitive.JacobiEigh]: Array.#routine(Primitive.JacobiEigh),
+      [Primitive.Fft]: Array.#routine(Primitive.Fft),
       [Primitive.Jit](args, { jaxpr }) {
         if (jaxpr.inBinders.length !== args.length) {
           throw new Error(

--- a/src/frontend/core.ts
+++ b/src/frontend/core.ts
@@ -94,6 +94,7 @@ export enum Primitive {
   Cholesky = "cholesky", // A is positive-definite, A = L @ L^T
   LU = "lu", // LU decomposition with partial pivoting
   JacobiEigh = "jacobi_eigh", // Symmetric eigendecomposition via Jacobi rotations
+  Fft = "fft", // Complex FFT along the final axis
 
   // JIT compilation
   Jit = "jit",
@@ -125,6 +126,7 @@ interface PrimitiveParamsImpl extends Record<Primitive, Record<string, any>> {
   [Primitive.Pad]: { width: Pair[] };
   [Primitive.TriangularSolve]: { unitDiagonal: boolean };
   [Primitive.JacobiEigh]: { maxSweeps: number; tolerance: number };
+  [Primitive.Fft]: { factors: number[]; inverse: boolean };
   [Primitive.Jit]: { name: string; jaxpr: Jaxpr; numConsts: number };
 }
 
@@ -150,6 +152,7 @@ export const routinePrimitives = new Map([
   [Primitive.Cholesky, Routines.Cholesky],
   [Primitive.LU, Routines.LU],
   [Primitive.JacobiEigh, Routines.JacobiEigh],
+  [Primitive.Fft, Routines.Fft],
 ]);
 
 export function add(x: TracerValue, y: TracerValue) {
@@ -553,6 +556,14 @@ export function jacobiEigh(
       `jacobi_eigh: expected floating-point input, got ${aval}`,
     );
   return bind(Primitive.JacobiEigh, [x], { maxSweeps, tolerance });
+}
+
+export function fft(
+  real: TracerValue,
+  imag: TracerValue,
+  params: { factors: number[]; inverse: boolean },
+) {
+  return bind(Primitive.Fft, [real, imag], params);
 }
 
 export function sort(x: TracerValue) {

--- a/src/frontend/jaxpr.ts
+++ b/src/frontend/jaxpr.ts
@@ -12,6 +12,7 @@ import {
   FpHash,
   FpHashable,
   generalBroadcast,
+  prod,
   runWithCache,
   unzip2,
   zip,
@@ -1022,6 +1023,24 @@ export const abstractEvalRules: { [P in Primitive]: AbstractEvalRule<P> } = {
         `jacobi_eigh: requires floating-point input, got ${a}`,
       );
     return [ShapedArray.fromAval(a), ShapedArray.fromAval(a)];
+  },
+  [Primitive.Fft]([real, imag], { factors }) {
+    if (!real.equals(imag)) {
+      throw new TypeError(
+        `fft: real and imag arrays must match, got ${real} and ${imag}`,
+      );
+    }
+    if (real.ndim < 1)
+      throw new TypeError(`fft: requires at least 1D input, got ${real}`);
+    if (!isFloatDtype(real.dtype))
+      throw new TypeError(`fft: requires floating-point input, got ${real}`);
+    const n = real.shape[real.ndim - 1];
+    if (prod(factors) !== n) {
+      throw new TypeError(
+        `fft: factorization ${factors} does not match size ${n}`,
+      );
+    }
+    return [ShapedArray.fromAval(real), ShapedArray.fromAval(real)];
   },
   [Primitive.Jit](args, { jaxpr }) {
     const { inTypes, outTypes } = typecheckJaxpr(jaxpr);

--- a/src/frontend/jit.ts
+++ b/src/frontend/jit.ts
@@ -779,6 +779,7 @@ const jitRules: { [P in Primitive]: JitRule<P> } = {
   [Primitive.Cholesky]: routineNoJit(),
   [Primitive.LU]: routineNoJit(),
   [Primitive.JacobiEigh]: routineNoJit(),
+  [Primitive.Fft]: routineNoJit(),
   [Primitive.Jit]() {
     throw new Error(
       "internal: Jit should have been flattened before JIT compilation",

--- a/src/frontend/jvp.ts
+++ b/src/frontend/jvp.ts
@@ -397,6 +397,7 @@ const jvpRules: { [P in Primitive]: JvpRule<P> } = {
   [Primitive.JacobiEigh]() {
     throw new Error("JVP rule not implemented for jacobi_eigh");
   },
+  [Primitive.Fft]: linearTangentsJvp(Primitive.Fft),
   [Primitive.Jit](primals, tangents, { name, jaxpr }) {
     const newJaxpr = jvpJaxpr(jaxpr);
     const outs = bind(

--- a/src/frontend/linearize.ts
+++ b/src/frontend/linearize.ts
@@ -892,6 +892,23 @@ const transposeRules: Partial<{ [P in Primitive]: TransposeRule<P> }> = {
     });
     return [null, ctB];
   },
+  [Primitive.Fft]([ctReal, ctImag], [real, imag], params) {
+    const aval = ShapedArray.fromAval(real.aval);
+    const n = aval.shape[aval.ndim - 1];
+    const [realAdjoint, imagAdjoint] = bind(Primitive.Fft, [ctReal, ctImag], {
+      factors: params.factors,
+      inverse: !params.inverse,
+    });
+    const scale = params.inverse ? 1 / n : n;
+    const realCt = mul(realAdjoint, scale);
+    const imagCt = mul(imagAdjoint, scale);
+    const cts: (Tracer | null)[] = [null, null];
+    if (real instanceof UndefPrimal) cts[0] = realCt;
+    else realCt.dispose();
+    if (imag instanceof UndefPrimal) cts[1] = imagCt;
+    else imagCt.dispose();
+    return cts;
+  },
   [Primitive.Jit](cts, args, { name, jaxpr }) {
     // We need this one because the jvp() rule for Jit generates a Jit
     // with the transformed Jaxpr. So grad-of-jit will result in a transposed

--- a/src/frontend/vmap.ts
+++ b/src/frontend/vmap.ts
@@ -403,6 +403,11 @@ const vmapRules: Partial<{ [P in Primitive]: VmapRule<P> }> = {
   [Primitive.Cholesky]: lastDimsBatcher(Primitive.Cholesky, 2),
   [Primitive.LU]: lastDimsBatcher(Primitive.LU, 2, 3),
   [Primitive.JacobiEigh]: lastDimsBatcher(Primitive.JacobiEigh, 2, 2),
+  [Primitive.Fft](axisSize, [real, imag], [realBdim, imagBdim], params) {
+    real = moveBatchAxis(axisSize, realBdim, 0, real);
+    imag = moveBatchAxis(axisSize, imagBdim, 0, imag);
+    return [bind(Primitive.Fft, [real, imag], params), [0, 0]];
+  },
   [Primitive.Jit](axisSize, args, dims, { name, jaxpr }) {
     const newJaxpr = vmapJaxpr(jaxpr, axisSize, dims);
     const outs = bind(

--- a/src/library/numpy-fft.ts
+++ b/src/library/numpy-fft.ts
@@ -1,26 +1,22 @@
 // Port of the `jax.numpy.fft` module, Fast Fourier Transform.
 
 import {
-  arange,
   array,
   Array,
   concatenate,
-  cos,
   DType,
   flip,
   roll,
-  sin,
   zerosLike,
 } from "./numpy";
 import { isFloatDtype } from "../alu";
-import { jit } from "../frontend/jaxpr";
+import * as core from "../frontend/core";
 import {
   checkAxis,
   deepEqual,
   invertPermutation,
   normalizeAxis,
   range,
-  rep,
 } from "../utils";
 
 /**
@@ -51,12 +47,22 @@ function checkPairInput(name: string, a: ComplexPair) {
   }
 }
 
-function checkPowerOfTwo(name: string, n: number) {
-  if (!Number.isInteger(n) || n < 1 || 2 ** Math.floor(Math.log2(n)) !== n) {
-    throw new Error(
-      `jax.numpy.fft.${name}: size must be a power of two, got ${n}`,
-    );
+function factorFftSize(n: number): number[] {
+  const factors: number[] = [];
+  for (const radix of [4, 2, 3, 5, 7]) {
+    while (n % radix === 0) {
+      factors.push(radix);
+      n /= radix;
+    }
   }
+  for (let radix = 11; radix * radix <= n; radix += 2) {
+    while (n % radix === 0) {
+      factors.push(radix);
+      n /= radix;
+    }
+  }
+  if (n > 1) factors.push(n);
+  return factors;
 }
 
 function checkRealInput(name: string, a: Array) {
@@ -93,48 +99,37 @@ function sliceAlongAxis(
   return a.slice(...index);
 }
 
-const fftUpdate = jit(
-  function fftUpdate(i: number, { real, imag }: ComplexPair): ComplexPair {
-    const half = 2 ** i;
-
-    real = real.reshape([-1, 2 * half]);
-    imag = imag.reshape([-1, 2 * half]);
-
-    const k = arange(0, half, 1, { dtype: real.dtype });
-    const theta = k.mul(-Math.PI / half);
-    const wr = cos(theta.ref);
-    const wi = sin(theta);
-
-    const ur = real.ref.slice([], [0, half]);
-    const ui = imag.ref.slice([], [0, half]);
-    const vr = real.slice([], [half, 2 * half]);
-    const vi = imag.slice([], [half, 2 * half]);
-
-    // t = w * v
-    const tr = vr.ref.mul(wr.ref).sub(vi.ref.mul(wi.ref));
-    const ti = vr.mul(wi).add(vi.mul(wr));
-
-    // store [u + t, u - t]
-    return {
-      real: concatenate([ur.ref.add(tr.ref), ur.sub(tr)], -1),
-      imag: concatenate([ui.ref.add(ti.ref), ui.sub(ti)], -1),
-    };
-  },
-  { staticArgnums: [0] },
-);
-
 /**
  * Compute a one-dimensional discrete Fourier transform.
- *
- * Currently, the size of the axis must be a power of two.
  */
 export function fft(a: ComplexPair, axis: number = -1): ComplexPair {
-  checkPairInput("fft", a);
+  return fftChecked("fft", a, axis, false);
+}
+
+function fftChecked(
+  name: string,
+  a: ComplexPair,
+  axis: number,
+  inverse: boolean,
+): ComplexPair {
+  checkPairInput(name, a);
+  axis = checkAxis(axis, a.real.ndim);
+  const n = a.real.shape[axis];
+  if (!Number.isInteger(n) || n < 1) {
+    throw new Error(
+      `jax.numpy.fft.${name}: size must be a positive integer, got ${n}`,
+    );
+  }
+  return fftRoutine(a, axis, inverse);
+}
+
+function fftRoutine(
+  a: ComplexPair,
+  axis: number,
+  inverse: boolean,
+): ComplexPair {
   let { real, imag } = a;
-  axis = checkAxis(axis, real.ndim);
   const n = real.shape[axis];
-  checkPowerOfTwo("fft", n);
-  const logN = Math.log2(n);
 
   // If axis is not at the end, move it to the end
   let perm: number[] | null = null;
@@ -146,23 +141,10 @@ export function fft(a: ComplexPair, axis: number = -1): ComplexPair {
     imag = imag.transpose(perm);
   }
 
-  // Cooley-Tukey FFT (radix-2)
-  const originalShape = real.shape;
-  real = real
-    .reshape([-1, ...rep(logN, 2)])
-    .transpose([0, ...range(1, logN + 1).reverse()])
-    .flatten();
-  imag = imag
-    .reshape([-1, ...rep(logN, 2)])
-    .transpose([0, ...range(1, logN + 1).reverse()])
-    .flatten();
-
-  // Hack: If you don't do it, the arrays might be lazy and grow exponentially.
-  for (let i = 0; i < logN; i++) {
-    ({ real, imag } = fftUpdate(i, { real, imag }));
-  }
-  real = real.reshape(originalShape);
-  imag = imag.reshape(originalShape);
+  [real, imag] = core.fft(real, imag, {
+    factors: factorFftSize(n),
+    inverse,
+  }) as [Array, Array];
 
   // If axis was moved, move it back
   if (perm !== null) {
@@ -189,8 +171,6 @@ function transformN(
 
 /**
  * Compute an N-dimensional discrete Fourier transform.
- *
- * Currently, every transformed axis must have a power-of-two size.
  */
 export function fftn(
   a: ComplexPair,
@@ -201,8 +181,6 @@ export function fftn(
 
 /**
  * Compute a two-dimensional discrete Fourier transform.
- *
- * Currently, every transformed axis must have a power-of-two size.
  */
 export function fft2(a: ComplexPair, axes: number[] = [-2, -1]): ComplexPair {
   return fftn(a, axes);
@@ -210,29 +188,13 @@ export function fft2(a: ComplexPair, axes: number[] = [-2, -1]): ComplexPair {
 
 /**
  * Compute a one-dimensional inverse discrete Fourier transform.
- *
- * Currently, the size of the axis must be a power of two.
  */
 export function ifft(a: ComplexPair, axis: number = -1): ComplexPair {
-  checkPairInput("ifft", a);
-  let { real, imag } = a;
-  axis = checkAxis(axis, real.ndim);
-  const n = real.shape[axis];
-  checkPowerOfTwo("ifft", n);
-
-  // ifft(a) = 1/n * conj(fft(conj(a)))
-  imag = imag.mul(-1);
-  const result = fft({ real, imag }, axis);
-  return {
-    real: result.real.div(n),
-    imag: result.imag.mul(-1).div(n),
-  };
+  return fftChecked("ifft", a, axis, true);
 }
 
 /**
  * Compute an N-dimensional inverse discrete Fourier transform.
- *
- * Currently, every transformed axis must have a power-of-two size.
  */
 export function ifftn(
   a: ComplexPair,
@@ -243,8 +205,6 @@ export function ifftn(
 
 /**
  * Compute a two-dimensional inverse discrete Fourier transform.
- *
- * Currently, every transformed axis must have a power-of-two size.
  */
 export function ifft2(a: ComplexPair, axes: number[] = [-2, -1]): ComplexPair {
   return ifftn(a, axes);
@@ -253,14 +213,12 @@ export function ifft2(a: ComplexPair, axes: number[] = [-2, -1]): ComplexPair {
 /**
  * Compute a one-dimensional FFT of real input.
  *
- * The output stores only the non-negative frequency terms. Currently, the size
- * of the axis must be a power of two.
+ * The output stores only the non-negative frequency terms.
  */
 export function rfft(a: Array, axis: number = -1): ComplexPair {
   checkRealInput("rfft", a);
   axis = checkAxis(axis, a.ndim);
   const n = a.shape[axis];
-  checkPowerOfTwo("rfft", n);
 
   const result = fft({ real: a, imag: zerosLike(a.ref) }, axis);
   const stop = Math.floor(n / 2) + 1;
@@ -274,7 +232,7 @@ export function rfft(a: Array, axis: number = -1): ComplexPair {
  * Compute the inverse of `rfft`.
  *
  * The real output length is inferred as `2 * (m - 1)`, where `m` is the packed
- * spectrum length. Currently, the inferred length must be a power of two.
+ * spectrum length.
  */
 export function irfft(a: ComplexPair, axis: number = -1): Array {
   checkPairInput("irfft", a);
@@ -286,9 +244,6 @@ export function irfft(a: ComplexPair, axis: number = -1): Array {
       `jax.numpy.fft.irfft: packed input length must be at least 2, got ${m}`,
     );
   }
-  const n = 2 * (m - 1);
-  checkPowerOfTwo("irfft", n);
-
   const mirroredReal = flip(sliceAlongAxis(real.ref, axis, 1, m - 1), axis);
   const mirroredImag = flip(sliceAlongAxis(imag.ref, axis, 1, m - 1), axis).mul(
     -1,
@@ -308,7 +263,6 @@ export function irfft(a: ComplexPair, axis: number = -1): Array {
  * Compute an N-dimensional FFT of real input.
  *
  * The final transformed axis stores only the non-negative frequency terms.
- * Currently, every transformed axis must have a power-of-two size.
  */
 export function rfftn(a: Array, axes: number[] | null = null): ComplexPair {
   checkRealInput("rfftn", a);
@@ -329,7 +283,6 @@ export function rfftn(a: Array, axes: number[] | null = null): ComplexPair {
  * Compute a two-dimensional FFT of real input.
  *
  * The final transformed axis stores only the non-negative frequency terms.
- * Currently, every transformed axis must have a power-of-two size.
  */
 export function rfft2(a: Array, axes: number[] = [-2, -1]): ComplexPair {
   return rfftn(a, axes);
@@ -339,8 +292,7 @@ export function rfft2(a: Array, axes: number[] = [-2, -1]): ComplexPair {
  * Compute the inverse of `rfftn`.
  *
  * The real output length for the final transformed axis is inferred as
- * `2 * (m - 1)`. Currently, every transformed axis must have a power-of-two
- * size.
+ * `2 * (m - 1)`.
  */
 export function irfftn(a: ComplexPair, axes: number[] | null = null): Array {
   checkPairInput("irfftn", a);
@@ -360,8 +312,6 @@ export function irfftn(a: ComplexPair, axes: number[] | null = null): Array {
 
 /**
  * Compute the inverse of `rfft2`.
- *
- * Currently, every transformed axis must have a power-of-two size.
  */
 export function irfft2(a: ComplexPair, axes: number[] = [-2, -1]): Array {
   return irfftn(a, axes);
@@ -371,26 +321,20 @@ export function irfft2(a: ComplexPair, axes: number[] = [-2, -1]): Array {
  * Compute the FFT of a Hermitian-symmetric signal.
  *
  * The real output length is inferred as `2 * (m - 1)`, where `m` is the packed
- * Hermitian input length. Currently, the inferred length must be a power of two.
+ * Hermitian input length.
  */
 export function hfft(a: ComplexPair, axis: number = -1): Array {
   checkPairInput("hfft", a);
   axis = checkAxis(axis, a.real.ndim);
   const n = 2 * (a.real.shape[axis] - 1);
-  checkPowerOfTwo("hfft", n);
   return irfft({ real: a.real, imag: a.imag.mul(-1) }, axis).mul(n);
 }
 
-/**
- * Compute the inverse of `hfft`.
- *
- * Currently, the size of the axis must be a power of two.
- */
+/** Compute the inverse of `hfft`. */
 export function ihfft(a: Array, axis: number = -1): ComplexPair {
   checkRealInput("ihfft", a);
   axis = checkAxis(axis, a.ndim);
   const n = a.shape[axis];
-  checkPowerOfTwo("ihfft", n);
 
   const result = rfft(a, axis);
   return {

--- a/src/routine.ts
+++ b/src/routine.ts
@@ -85,6 +85,14 @@ export enum Routines {
    * Sorting eigenpairs is handled by the frontend wrapper.
    */
   JacobiEigh = "JacobiEigh",
+
+  /**
+   * Complex FFT along the last axis for real/imaginary array pairs.
+   *
+   * Inputs and outputs have identical shape, and the backend receives a
+   * factorization of the FFT dimension.
+   */
+  Fft = "Fft",
 }
 
 export interface RoutineType {
@@ -122,6 +130,8 @@ export function runCpuRoutine(
       return runLU(type, inputAr, outputAr);
     case Routines.JacobiEigh:
       return runJacobiEigh(type, inputAr, outputAr, routine.params);
+    case Routines.Fft:
+      return runFft(type, inputAr, outputAr, routine.params);
     default:
       name satisfies never; // Exhaustiveness check
   }
@@ -142,6 +152,7 @@ ${runTriangularSolve.toString()}
 ${runCholesky.toString()}
 ${runLU.toString()}
 ${runJacobiEigh.toString()}
+${runFft.toString()}
 const __minify_safe_runCpuRoutine = ${runCpuRoutine.name};
 `;
 }
@@ -412,6 +423,87 @@ function runJacobiEigh(
         }
       }
       maxOffDiagonal = maxAbsOffDiagonal(a);
+    }
+  }
+}
+
+function runFft(
+  type: RoutineType,
+  [real, imag]: DataArray[],
+  [outReal, outImag]: DataArray[],
+  { factors, inverse }: { factors: number[]; inverse: boolean },
+) {
+  const shape = type.inputShapes[0];
+  if (shape.length < 1) throw new Error("fft: input must be at least 1D");
+  const n = shape[shape.length - 1];
+  if (n < 1) throw new Error(`fft: final axis must be non-empty, got ${n}`);
+  if (
+    type.inputDtypes[0] !== type.inputDtypes[1] ||
+    !isFloatDtype(type.inputDtypes[0])
+  ) {
+    throw new Error("fft: expected matching floating-point real/imag arrays");
+  }
+
+  const angleScale = (inverse ? 2 : -2) * Math.PI;
+  const permutation = new Uint32Array(n);
+  for (let index = 0; index < n; index++) {
+    let remaining = index;
+    let stride = 1;
+    let reversed = 0;
+    for (const factor of factors) {
+      const digit = remaining % factor;
+      remaining = Math.floor(remaining / factor);
+      stride *= factor;
+      reversed += digit * (n / stride);
+    }
+    permutation[index] = reversed;
+  }
+  const scratchReal = new Array<number>(Math.max(1, ...factors));
+  const scratchImag = new Array<number>(scratchReal.length);
+
+  for (let offset = 0; offset < real.length; offset += n) {
+    for (let index = 0; index < n; index++) {
+      const source = offset + permutation[index];
+      outReal[offset + index] = real[source];
+      outImag[offset + index] = imag[source];
+    }
+
+    let prev = 1;
+    for (let stage = 0; stage < factors.length; stage++) {
+      const radix = factors[stage];
+      const span = prev * radix;
+      const stageScale = inverse && stage === factors.length - 1 ? 1 / n : 1;
+      for (let group = 0; group < n; group += span) {
+        for (let j = 0; j < prev; j++) {
+          for (let q = 0; q < radix; q++) {
+            const idx = offset + group + j + q * prev;
+            const angle = (angleScale * q * j) / span;
+            const c = Math.cos(angle);
+            const s = Math.sin(angle);
+            const xr = outReal[idx];
+            const xi = outImag[idx];
+            scratchReal[q] = xr * c - xi * s;
+            scratchImag[q] = xr * s + xi * c;
+          }
+          for (let p = 0; p < radix; p++) {
+            let sumReal = 0;
+            let sumImag = 0;
+            for (let q = 0; q < radix; q++) {
+              const angle = (angleScale * q * p) / radix;
+              const c = Math.cos(angle);
+              const s = Math.sin(angle);
+              const xr = scratchReal[q];
+              const xi = scratchImag[q];
+              sumReal += xr * c - xi * s;
+              sumImag += xr * s + xi * c;
+            }
+            const idx = offset + group + j + p * prev;
+            outReal[idx] = sumReal * stageScale;
+            outImag[idx] = sumImag * stageScale;
+          }
+        }
+      }
+      prev = span;
     }
   }
 }

--- a/test/numpy-fft.test.ts
+++ b/test/numpy-fft.test.ts
@@ -2,8 +2,46 @@ import { defaultDevice, devices, init, numpy as np } from "@jax-js/jax";
 import { beforeEach, expect, suite, test } from "vitest";
 
 const devicesAvailable = await init();
+const fftDevices = devices.filter((device) => device !== "webgl");
 
-suite.each(devices)("device:%s", (device) => {
+function dft(
+  real: number[],
+  imag: number[],
+): { real: number[]; imag: number[] } {
+  const n = real.length;
+  const outReal: number[] = [];
+  const outImag: number[] = [];
+  for (let k = 0; k < n; k++) {
+    let sumReal = 0;
+    let sumImag = 0;
+    for (let t = 0; t < n; t++) {
+      const angle = (-2 * Math.PI * t * k) / n;
+      const c = Math.cos(angle);
+      const s = Math.sin(angle);
+      sumReal += real[t] * c - imag[t] * s;
+      sumImag += real[t] * s + imag[t] * c;
+    }
+    outReal.push(sumReal);
+    outImag.push(sumImag);
+  }
+  return { real: outReal, imag: outImag };
+}
+
+const fftCases: [string, number[], number[]][] = [
+  ["simple real input", [0, 1, 2, 3], [0, 0, 0, 0]],
+  ["impulse signal", [1, 0, 0, 0], [0, 0, 0, 0]],
+  ["constant signal", [3, 3, 3, 3], [0, 0, 0, 0]],
+  ["length-one input", [3], [-2]],
+  [
+    "complex input (length 8)",
+    [1, 3, 0, -2, 5, 1, 2, -1],
+    [2, -1, 4, 1, 0, -3, 2, 1],
+  ],
+  ["mixed-radix length 6", [1, 3, 0, -2, 5, 1], [2, -1, 4, 1, 0, -3]],
+  ["prime length 5", [4, -1, 2, 0, 3], [0, 2, -3, 1, 5]],
+];
+
+suite.each(fftDevices)("device:%s", (device) => {
   const skipped = !devicesAvailable.includes(device);
   beforeEach(({ skip }) => {
     if (skipped) skip();
@@ -11,47 +49,18 @@ suite.each(devices)("device:%s", (device) => {
   });
 
   suite("jax.numpy.fft.fft()", () => {
-    test("computes FFT of a simple real input", async () => {
-      const real = np.array([0, 1, 2, 3]);
-      const imag = np.array([0, 0, 0, 0]);
-      const result = np.fft.fft({ real, imag });
-      expect(await result.real.jsAsync()).toBeAllclose([6, -2, -2, -2]);
-      expect(await result.imag.jsAsync()).toBeAllclose([0, 2, 0, -2]);
+    test.each(fftCases)("computes FFT of %s", (_name, real, imag) => {
+      const expected = dft(real, imag);
+      const result = np.fft.fft({
+        real: np.array(real),
+        imag: np.array(imag),
+      });
+
+      expect(result.real).toBeAllclose(expected.real, { atol: 1e-4 });
+      expect(result.imag).toBeAllclose(expected.imag, { atol: 1e-4 });
     });
 
-    test("FFT of an impulse (delta) signal", async () => {
-      // FFT of [1, 0, 0, 0] should be all ones (flat spectrum)
-      const real = np.array([1, 0, 0, 0]);
-      const imag = np.array([0, 0, 0, 0]);
-      const result = np.fft.fft({ real, imag });
-      expect(await result.real.jsAsync()).toBeAllclose([1, 1, 1, 1]);
-      expect(await result.imag.jsAsync()).toBeAllclose([0, 0, 0, 0]);
-    });
-
-    test("FFT of a constant signal", async () => {
-      // FFT of [c, c, c, c] should be [4c, 0, 0, 0]
-      const real = np.array([3, 3, 3, 3]);
-      const imag = np.array([0, 0, 0, 0]);
-      const result = np.fft.fft({ real, imag });
-      expect(await result.real.jsAsync()).toBeAllclose([12, 0, 0, 0]);
-      expect(await result.imag.jsAsync()).toBeAllclose([0, 0, 0, 0]);
-    });
-
-    test("FFT with complex input (length 8)", async () => {
-      const real = np.array([1, 3, 0, -2, 5, 1, 2, -1]);
-      const imag = np.array([2, -1, 4, 1, 0, -3, 2, 1]);
-      const result = np.fft.fft({ real, imag });
-      expect(await result.real.jsAsync()).toBeAllclose(
-        [9, 1.5355339, -2, -6.7071068, 7, -5.5355339, 10, -5.2928932],
-        { atol: 1e-4 },
-      );
-      expect(await result.imag.jsAsync()).toBeAllclose(
-        [6, 4.7071068, -11, -2.1213203, 10, 3.2928932, 3, 2.1213203],
-        { atol: 1e-4 },
-      );
-    });
-
-    test("FFT along a non-default axis", async () => {
+    test("FFT along a non-default axis", () => {
       // 2x4 matrix, FFT along axis=0 (length 2)
       const real = np.array([
         [1, 2, 3, 4],
@@ -62,12 +71,12 @@ suite.each(devices)("device:%s", (device) => {
         [0, 0, 0, 0],
       ]);
       const result = np.fft.fft({ real, imag }, 0);
-      // FFT of length-2 along axis 0: [a+b, a-b]
-      expect(await result.real.jsAsync()).toBeAllclose([
+
+      expect(result.real).toBeAllclose([
         [6, 8, 10, 12],
         [-4, -4, -4, -4],
       ]);
-      expect(await result.imag.jsAsync()).toBeAllclose([
+      expect(result.imag).toBeAllclose([
         [0, 0, 0, 0],
         [0, 0, 0, 0],
       ]);
@@ -75,43 +84,44 @@ suite.each(devices)("device:%s", (device) => {
   });
 
   suite("jax.numpy.fft.ifft()", () => {
-    test("computes IFFT of a simple complex input", async () => {
+    test("computes IFFT of a simple complex input", () => {
       const real = np.array([6, -2, -2, -2]);
       const imag = np.array([0, 2, 0, -2]);
       const result = np.fft.ifft({ real, imag });
-      expect(await result.real.jsAsync()).toBeAllclose([0, 1, 2, 3]);
-      expect(await result.imag.jsAsync()).toBeAllclose([0, 0, 0, 0]);
+
+      expect(result.real).toBeAllclose([0, 1, 2, 3]);
+      expect(result.imag).toBeAllclose([0, 0, 0, 0]);
     });
 
-    test("FFT followed by IFFT returns original input", async () => {
-      const real = np.array([1, 2, 3, 4, 5, 6, 7, 8]);
-      const imag = np.array([-5, 9, 0, 3, -1, 4, 2, 8]);
-      const fftResult = np.fft.fft({ real: real.ref, imag: imag.ref });
-      const ifftResult = np.fft.ifft(fftResult);
-      expect(await ifftResult.real.jsAsync()).toBeAllclose(real, {
-        atol: 1e-5,
-      });
-      expect(await ifftResult.imag.jsAsync()).toBeAllclose(imag, {
-        atol: 1e-5,
-      });
-    });
+    test.each([
+      ["power-of-two", [1, 2, 3, 4, 5, 6, 7, 8], [-5, 9, 0, 3, -1, 4, 2, 8]],
+      ["mixed-radix", [1, 2, 3, 4, 5, 6], [-5, 9, 0, 3, -1, 4]],
+    ])(
+      "FFT followed by IFFT returns original %s input",
+      (_name, realData, imagData) => {
+        const real = np.array(realData);
+        const imag = np.array(imagData);
+        const fftResult = np.fft.fft({ real: real.ref, imag: imag.ref });
+        const result = np.fft.ifft(fftResult);
 
-    test("IFFT followed by FFT returns original input", async () => {
+        expect(result.real).toBeAllclose(real, { atol: 1e-5 });
+        expect(result.imag).toBeAllclose(imag, { atol: 1e-5 });
+      },
+    );
+
+    test("IFFT followed by FFT returns original input", () => {
       const real = np.array([2, -1, 4, 0]);
       const imag = np.array([1, 3, -2, 5]);
       const ifftResult = np.fft.ifft({ real: real.ref, imag: imag.ref });
       const fftResult = np.fft.fft(ifftResult);
-      expect(await fftResult.real.jsAsync()).toBeAllclose(real, {
-        atol: 1e-5,
-      });
-      expect(await fftResult.imag.jsAsync()).toBeAllclose(imag, {
-        atol: 1e-5,
-      });
+
+      expect(fftResult.real).toBeAllclose(real, { atol: 1e-5 });
+      expect(fftResult.imag).toBeAllclose(imag, { atol: 1e-5 });
     });
   });
 
   suite("jax.numpy.fft.fftn()", () => {
-    test("computes FFTN over all axes", async () => {
+    test("computes FFTN over all axes", () => {
       const real = np.array([
         [1, 2],
         [3, 4],
@@ -119,17 +129,17 @@ suite.each(devices)("device:%s", (device) => {
       const imag = np.zeros([2, 2]);
       const result = np.fft.fftn({ real, imag });
 
-      expect(await result.real.jsAsync()).toBeAllclose([
+      expect(result.real).toBeAllclose([
         [10, -2],
         [-4, 0],
       ]);
-      expect(await result.imag.jsAsync()).toBeAllclose([
+      expect(result.imag).toBeAllclose([
         [0, 0],
         [0, 0],
       ]);
     });
 
-    test("FFTN followed by IFFTN returns original input", async () => {
+    test("FFTN followed by IFFTN returns original input", () => {
       const real = np.array([
         [1, 2, 3, 4],
         [5, 6, 7, 8],
@@ -139,53 +149,45 @@ suite.each(devices)("device:%s", (device) => {
         [3, -3, 4, -4],
       ]);
       const fftResult = np.fft.fft2({ real: real.ref, imag: imag.ref });
-      const ifftResult = np.fft.ifft2(fftResult);
+      const result = np.fft.ifft2(fftResult);
 
-      expect(await ifftResult.real.jsAsync()).toBeAllclose(real, {
-        atol: 1e-5,
-      });
-      expect(await ifftResult.imag.jsAsync()).toBeAllclose(imag, {
-        atol: 1e-5,
-      });
+      expect(result.real).toBeAllclose(real, { atol: 1e-5 });
+      expect(result.imag).toBeAllclose(imag, { atol: 1e-5 });
     });
   });
 
   suite("jax.numpy.fft.rfft()", () => {
-    test("computes RFFT of a simple real input", async () => {
+    test("computes RFFT of a simple real input", () => {
       const x = np.array([0, 1, 2, 3]);
       const result = np.fft.rfft(x);
 
-      expect(await result.real.jsAsync()).toBeAllclose([6, -2, -2], {
-        atol: 1e-5,
-      });
-      expect(await result.imag.jsAsync()).toBeAllclose([0, 2, 0], {
-        atol: 1e-5,
-      });
+      expect(result.real).toBeAllclose([6, -2, -2], { atol: 1e-5 });
+      expect(result.imag).toBeAllclose([0, 2, 0], { atol: 1e-5 });
     });
 
-    test("RFFT followed by IRFFT returns original input", async () => {
+    test("RFFT followed by IRFFT returns original input", () => {
       const x = np.array([0, 1, 2, 3, 4, 5, 6, 7]);
       const spectrum = np.fft.rfft(x.ref);
       const result = np.fft.irfft(spectrum);
 
-      expect(await result.jsAsync()).toBeAllclose(x, { atol: 1e-5 });
+      expect(result).toBeAllclose(x, { atol: 1e-5 });
     });
 
-    test("computes RFFT2 with packed final axis", async () => {
+    test("computes RFFT2 with packed final axis", () => {
       const x = np.array([
         [1, 2, 3, 4],
         [5, 6, 7, 8],
       ]);
       const result = np.fft.rfft2(x);
 
-      expect(await result.real.jsAsync()).toBeAllclose(
+      expect(result.real).toBeAllclose(
         [
           [36, -4, -4],
           [-16, 0, 0],
         ],
         { atol: 1e-5 },
       );
-      expect(await result.imag.jsAsync()).toBeAllclose(
+      expect(result.imag).toBeAllclose(
         [
           [0, 4, 0],
           [0, 0, 0],
@@ -194,7 +196,7 @@ suite.each(devices)("device:%s", (device) => {
       );
     });
 
-    test("RFFTN followed by IRFFTN returns original input", async () => {
+    test("RFFTN followed by IRFFTN returns original input", () => {
       const x = np.array([
         [1, 2, 3, 4],
         [5, 6, 7, 8],
@@ -202,42 +204,32 @@ suite.each(devices)("device:%s", (device) => {
       const spectrum = np.fft.rfftn(x.ref);
       const result = np.fft.irfftn(spectrum);
 
-      expect(await result.jsAsync()).toBeAllclose(x, { atol: 1e-5 });
+      expect(result).toBeAllclose(x, { atol: 1e-5 });
     });
 
-    test("computes HFFT and IHFFT", async () => {
+    test("computes HFFT and IHFFT", () => {
       const real = np.array([1, 2, 4]);
       const imag = np.array([0, 3, 0]);
       const hfftResult = np.fft.hfft({ real, imag });
-      expect(await hfftResult.jsAsync()).toBeAllclose([9, 3, 1, -9], {
+      expect(hfftResult).toBeAllclose([9, 3, 1, -9], {
         atol: 1e-5,
       });
-
       const ihfftResult = np.fft.ihfft(np.array([9, 3, 1, -9]));
-      expect(await ihfftResult.real.jsAsync()).toBeAllclose([1, 2, 4], {
-        atol: 1e-5,
-      });
-      expect(await ihfftResult.imag.jsAsync()).toBeAllclose([0, 3, 0], {
-        atol: 1e-5,
-      });
+
+      expect(ihfftResult.real).toBeAllclose([1, 2, 4], { atol: 1e-5 });
+      expect(ihfftResult.imag).toBeAllclose([0, 3, 0], { atol: 1e-5 });
     });
   });
 
   suite("jax.numpy.fftfreq()", () => {
-    test("computes FFT sample frequencies", async () => {
-      expect(await np.fft.fftfreq(4).jsAsync()).toBeAllclose([
-        0, 0.25, -0.5, -0.25,
-      ]);
-      expect(await np.fft.fftfreq(5, 0.5).jsAsync()).toBeAllclose([
-        0, 0.4, 0.8, -0.8, -0.4,
-      ]);
+    test("computes FFT sample frequencies", () => {
+      expect(np.fft.fftfreq(4)).toBeAllclose([0, 0.25, -0.5, -0.25]);
+      expect(np.fft.fftfreq(5, 0.5)).toBeAllclose([0, 0.4, 0.8, -0.8, -0.4]);
     });
 
-    test("computes RFFT sample frequencies", async () => {
-      expect(await np.fft.rfftfreq(4).jsAsync()).toBeAllclose([0, 0.25, 0.5]);
-      expect(await np.fft.rfftfreq(5, 0.5).jsAsync()).toBeAllclose([
-        0, 0.4, 0.8,
-      ]);
+    test("computes RFFT sample frequencies", () => {
+      expect(np.fft.rfftfreq(4)).toBeAllclose([0, 0.25, 0.5]);
+      expect(np.fft.rfftfreq(5, 0.5)).toBeAllclose([0, 0.4, 0.8]);
     });
 
     test("shifts FFT spectra", async () => {


### PR DESCRIPTION
Still uses Cooley-Tukey, we but add a custom routine with GPU and CPU lowering that is much faster. Also generalize that routine to support non-power-of-two bases.

```
device  case       before mean   now mean    speedup
cpu     fft 256      9.271 ms    0.0809 ms   114.6x
cpu     fft 1024    25.822 ms    0.3667 ms    70.4x
cpu     fft 64x256 253.080 ms    3.9886 ms    63.5x

wasm    fft 256      8.487 ms    0.1382 ms    61.4x
wasm    fft 1024    22.948 ms    0.4195 ms    54.7x
wasm    fft 64x256 218.790 ms    4.0447 ms    54.1x

webgpu  fft 256     13.606 ms    0.7716 ms    17.6x
webgpu  fft 1024    26.796 ms    0.8136 ms    32.9x
webgpu  fft 64x256 223.010 ms    0.7939 ms   280.9x
```