### PR TITLE
Fix unsoundness in negative truncated residuals

### DIFF
--- a/src/alu.test.ts
+++ b/src/alu.test.ts
@@ -219,6 +219,38 @@ test("AluOp.Idiv", () => {
   expect(e2.max).toBe(-2);
 });
 
+test("AluOp.Idiv simplification preserves negative residuals", () => {
+  const i = AluExp.special(DType.Int32, "i", 3);
+  const e = AluExp.idiv(
+    AluExp.add(AluExp.mul(i, AluExp.i32(2)), AluExp.i32(-1)),
+    AluExp.i32(2),
+  );
+  const values = [0, 1, 2].map((i) => e.evaluate({ i }));
+  const simplified = e.simplify();
+  const normalize = (x: number) => (Object.is(x, -0) ? 0 : x);
+
+  expect(values.map(normalize)).toEqual([0, 0, 1]);
+  expect(
+    [0, 1, 2].map((i) => simplified.evaluate({ i })).map(normalize),
+  ).toEqual(values.map(normalize));
+});
+
+test("AluOp.Idiv simplification preserves negative denominators", () => {
+  const i = AluExp.special(DType.Int32, "i", 3);
+  const e = AluExp.idiv(
+    AluExp.add(AluExp.mul(i, AluExp.i32(-2)), AluExp.i32(1)),
+    AluExp.i32(-2),
+  );
+  const values = [0, 1, 2].map((i) => e.evaluate({ i }));
+  const simplified = e.simplify();
+  const normalize = (x: number) => (Object.is(x, -0) ? 0 : x);
+
+  expect(values.map(normalize)).toEqual([0, 0, 1]);
+  expect(
+    [0, 1, 2].map((i) => simplified.evaluate({ i })).map(normalize),
+  ).toEqual(values.map(normalize));
+});
+
 test("AluOp.Mod", () => {
   // Make sure that mod uses the sign of the numerator.
   const e = AluExp.mod(AluExp.i32(7), AluExp.i32(3));

--- a/src/alu.ts
+++ b/src/alu.ts
@@ -806,7 +806,7 @@ export class AluExp implements FpHashable {
             return ret.simplify(cache);
           }
         }
-        // (x * A + C) / B => x * (A / B) + trunc(C / B)
+        // (x * A + y) / B => x * (A / B) + trunc(y / B)
         for (let j = 0; j < 2; j++) {
           if (
             numer.op === AluOp.Add &&
@@ -818,11 +818,23 @@ export class AluExp implements FpHashable {
               let ret = numer.src[j].src[1 - i]; // x
               if (A / B !== 1)
                 ret = AluExp.mul(ret, AluExp.const(ret.dtype, A / B));
-              ret = AluExp.add(
-                ret,
-                AluExp.idiv(numer.src[1 - j], AluExp.const(ret.dtype, B)),
-              );
-              return ret.simplify(cache);
+              const y = numer.src[1 - j];
+              const yOverB = y.divides(B);
+              if (yOverB !== null) {
+                return AluExp.add(ret, yOverB).simplify(cache);
+              } else if (
+                B > 0 &&
+                ((ret.min >= 0 && y.min >= 0) || (ret.max <= 0 && y.max <= 0))
+              ) {
+                // For trunc-toward-zero division, `trunc(q + y/B)` is not always
+                // `q + trunc(y/B)`. Counterexample: q=1, y=-1, B=2.
+                // Only split non-exact y terms when the quotient and fractional part
+                // cannot point in opposite directions.
+                return AluExp.add(
+                  ret,
+                  AluExp.idiv(y, AluExp.const(ret.dtype, B)),
+                ).simplify(cache);
+              }
             }
           }
         }

--- a/test/numpy.test.ts
+++ b/test/numpy.test.ts
@@ -1851,6 +1851,17 @@ suite.each(devices)("device:%s", (device) => {
       expect(b.js()).toEqual([0, 3, 4, 5, 0]);
     });
 
+    test("slices a padded lazy nested stack", () => {
+      const row = (a: number, b: number) =>
+        np.stack([np.array(a), np.array(b)]);
+      const x = np.stack([row(1, 2), row(3, 4), row(5, 6)]);
+      const y = np.pad(x.slice([0, 2]), [
+        [1, 0],
+        [0, 0],
+      ]);
+      expect(y.slice([], [1, 2]).js()).toEqual([[0], [2], [4]]);
+    });
+
     test("pad with explicit indices", () => {
       const x = np.zeros([2, 3, 4, 5]);
       const y = np.pad(x, { 1: [0, 2], [-1]: [3, 0] });
@@ -2053,6 +2064,18 @@ suite.each(devices)("device:%s", (device) => {
       const x = np.array([1, 2, 3, 4, 5]);
       const y = np.roll(x, 20);
       expect(y.js()).toEqual([1, 2, 3, 4, 5]);
+    });
+
+    test("rolls a 3x3 lazy nested stack over two axes", () => {
+      const row = (a: number, b: number, c: number) =>
+        np.stack([np.array(a), np.array(b), np.array(c)]);
+      const x = np.stack([row(1, 2, 3), row(4, 5, 6), row(7, 8, 9)]);
+      const y = np.roll(np.roll(x, 1, 0), 1, 1);
+      expect(y.js()).toEqual([
+        [9, 7, 8],
+        [3, 1, 2],
+        [6, 4, 5],
+      ]);
     });
   });
 

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -23,6 +23,10 @@ const opts: UserConfig = {
     // https://github.com/rolldown/tsdown/issues/396
     newContext: true,
   },
+  checks: {
+    // Hide warnings about dts generation taking a long time.
+    pluginTimings: false,
+  },
 };
 
 export default defineConfig([


### PR DESCRIPTION
Fixes #146. The issue was that in the symbolic expression grammar, we had a truncation rule like:

`(x * A + y) / B => x * (A / B) + trunc(y / B)`

However, this is not sound when `y` has a different sign from `x * (A / B)`, as then truncation doesn't work the same direction.

Added extra guards around this rule for soundness.

(This is a place where formal verification might really help!)