### PR TITLE
Fix eager-mode grad materializing m,n,k array

### DIFF
--- a/src/frontend/linearize.ts
+++ b/src/frontend/linearize.ts
@@ -14,6 +14,7 @@ import {
   generalBroadcast,
   invertPermutation,
   partitionList,
+  prod,
   range,
   toposort,
   unzip2,
@@ -26,6 +27,7 @@ import {
   broadcast,
   concatenate,
   conv,
+  dot,
   flattenFun,
   flattenFunWithAux,
   flip,
@@ -667,6 +669,34 @@ function unbroadcast(x: Tracer, target: UndefPrimal): Tracer {
   return result;
 }
 
+/** Transpose a dot, treating every axis as either batch or contracting. */
+function transposeDot(ct: Tracer, known: Tracer, target: UndefPrimal): Tracer {
+  const broadcastShape = generalBroadcast(target.aval.shape, known.shape);
+  const ndim = broadcastShape.length;
+  const align = (shape: number[]) =>
+    Array(ndim - shape.length)
+      .fill(1)
+      .concat(shape);
+  const targetShape = align(target.aval.shape);
+  const knownShape = align(known.shape);
+  const contractingDims = range(ndim).filter((axis) => targetShape[axis] === 1);
+  const batchDims = range(ndim).filter((axis) => targetShape[axis] !== 1);
+  const perm = [...batchDims, ...contractingDims];
+  const dotShape = (shape: number[]) => [
+    ...batchDims.map((axis) => shape[axis]),
+    prod(contractingDims.map((axis) => shape[axis])),
+  ];
+
+  return dot(
+    // ct -> [...ct, reduceSize] -> [...batch dims, contracting dims (1 in target)]
+    transpose(broadcast(ct, broadcastShape, [-1]), perm).reshape(
+      dotShape(broadcastShape),
+    ),
+    // known -> [...batch dims, contracting dims (1 in target)]
+    transpose(known.reshape(knownShape), perm).reshape(dotShape(knownShape)),
+  ).reshape(target.aval.shape); // any inserted axes are size 1
+}
+
 class NonlinearError extends TypeError {
   constructor(primitive: Primitive) {
     super(`Nonlinear operation in backward pass for ${primitive}`);
@@ -735,12 +765,9 @@ const transposeRules: Partial<{ [P in Primitive]: TransposeRule<P> }> = {
   [Primitive.Dot]([ct], [x, y]) {
     if (x instanceof UndefPrimal === y instanceof UndefPrimal)
       throw new NonlinearError(Primitive.Dot);
-    const axisSize = generalBroadcast(x.aval.shape, y.aval.shape).slice(-1)[0];
-    ct = broadcast(ct, ct.shape.concat(axisSize), [-1]); // Undo the contraction.
-    return [
-      x instanceof UndefPrimal ? unbroadcast(mul(ct, y as Tracer), x) : null,
-      y instanceof UndefPrimal ? unbroadcast(mul(x as Tracer, ct), y) : null,
-    ];
+    return x instanceof UndefPrimal
+      ? [transposeDot(ct, y as Tracer, x), null]
+      : [null, transposeDot(ct, x as Tracer, y as UndefPrimal)];
   },
   [Primitive.Conv]([ct], [lhs, rhs], params) {
     if (lhs instanceof UndefPrimal === rhs instanceof UndefPrimal)

--- a/test/tracing.test.ts
+++ b/test/tracing.test.ts
@@ -72,6 +72,50 @@ suite("jax.makeJaxpr()", () => {
     `);
   });
 
+  // Regression test for https://github.com/ekzhang/jax-js/issues/150
+  //
+  // Backprop should never cause a 'dot' rule to be run as a broadcast,
+  // multiply and reduce[sum], as that may materialize a large [M, N, K]
+  // intermediate array in some cases, causing OOM.
+  test("grad of dot transposes to dots", () => {
+    const x = np.ones([2, 3]);
+    const w = np.ones([3, 4]);
+    const f = (xx: np.Array, ww: np.Array) => np.sum(np.dot(xx, ww));
+    const { jaxpr } = makeJaxpr(grad(f, { argnums: [0, 1] }))(x, w);
+
+    try {
+      expect(jaxpr.consts).toEqual([]);
+      expect(jaxpr.toString()).toMatchInlineSnapshot(`
+        "{ lambda a:float32[2,3], b:float32[3,4] .
+          let c:float32[4,3] = transpose [ perm=1,0 ] b
+              d:float32[2,1,3] = reshape [ shape=2,1,3 ] a
+              e:float32[1,4,3] = reshape [ shape=1,4,3 ] c
+              f:float32[2,4] = broadcast [ shape=2,4
+                                           axis=0,1 ] 1
+              g:float32[2,4,3] = broadcast [ shape=2,4,3
+                                             axis=2 ] f
+              h:float32[2,3,4] = transpose [ perm=0,2,1 ] g
+              i:float32[1,3,4] = transpose [ perm=0,2,1 ] e
+              j:float32[2,3] = dot h i
+              k:float32[2,1,3] = reshape [ shape=2,1,3 ] j
+              l:float32[2,3] = reshape [ shape=2,3 ] k
+              m:float32[2,4,3] = broadcast [ shape=2,4,3
+                                             axis=2 ] f
+              n:float32[4,3,2] = transpose [ perm=1,2,0 ] m
+              o:float32[1,3,2] = transpose [ perm=1,2,0 ] d
+              p:float32[4,3] = dot n o
+              q:float32[1,4,3] = reshape [ shape=1,4,3 ] p
+              r:float32[4,3] = reshape [ shape=4,3 ] q
+              s:float32[3,4] = transpose [ perm=1,0 ] r
+          in ( l, s ) }"
+      `);
+    } finally {
+      jaxpr.dispose();
+      x.dispose();
+      w.dispose();
+    }
+  });
+
   test("can flatten() nested Jaxprs", () => {
     const f = (x: np.Array) => {
       const y = x.ref.add(2);


### PR DESCRIPTION
This happened in some cases. We didn't catch this because the demos primarily wrapped the grad calls in `jit()`. In any case, this should make the codegen cleaner!

Fixes #150 and adds a regression test.