### PR TITLE
Make allocation contents unspecified

### DIFF
--- a/src/backend.ts
+++ b/src/backend.ts
@@ -162,7 +162,11 @@ export interface Backend {
   /** Maximum number of arguments per dispatched kernel. */
   readonly maxArgs: number;
 
-  /** Allocate a new slot with reference count 1. */
+  /**
+   * Allocate a new slot with reference count 1.
+   *
+   * Contents are unspecified unless initialData is provided.
+   */
   malloc(size: number, initialData?: Uint8Array): Slot;
 
   /** Increment the reference count of the slot. */

--- a/src/backend/backend.test.ts
+++ b/src/backend/backend.test.ts
@@ -10,6 +10,7 @@ import {
   Reduction,
 } from "../alu";
 import { devices, getBackend, init } from "../backend";
+import { Routine, Routines } from "../routine";
 import { ShapeTracker, unravelAlu } from "../shape";
 import { range } from "../utils";
 
@@ -82,6 +83,38 @@ suite.each(devices)("device:%s", (device) => {
       backend.decRef(c);
     }
   });
+
+  if (device !== "webgl") {
+    test("routines initialize partially written outputs", async () => {
+      const backend = getBackend(device);
+      const bytes = (values: Float32Array) => new Uint8Array(values.buffer);
+      const input = backend.malloc(
+        4 * 4,
+        bytes(new Float32Array([4, 2, 2, 3])),
+      );
+      const output = backend.malloc(
+        4 * 4,
+        bytes(new Float32Array([9, 9, 9, 9])),
+      );
+
+      try {
+        const routine = new Routine(Routines.Cholesky, {
+          inputShapes: [[2, 2]],
+          inputDtypes: [DType.Float32],
+          outputShapes: [[2, 2]],
+          outputDtypes: [DType.Float32],
+        });
+        const exe = await backend.prepareRoutine(routine);
+        backend.dispatch(exe, [input], [output]);
+
+        const result = new Float32Array((await backend.read(output)).buffer);
+        expect(result).toEqual(new Float32Array([2, 0, 1, Math.sqrt(2)]));
+      } finally {
+        backend.decRef(input);
+        backend.decRef(output);
+      }
+    });
+  }
 
   test("can create array from index", async () => {
     const backend = getBackend(device);

--- a/src/backend/wasm/allocator.ts
+++ b/src/backend/wasm/allocator.ts
@@ -21,7 +21,6 @@ export class WasmAllocator {
     let ptr: number;
     if (freeList && freeList.length > 0) {
       ptr = freeList.pop()!;
-      new Uint8Array(this.#memory.buffer, ptr, sizeClass).fill(0);
     } else {
       ptr = this.#bumpAlloc(sizeClass);
     }

--- a/src/routine.ts
+++ b/src/routine.ts
@@ -236,6 +236,7 @@ function runCholesky(type: RoutineType, [x]: DataArray[], [y]: DataArray[]) {
   if (n !== m)
     throw new Error(`cholesky: input must be square, got [${n}, ${m}]`);
 
+  y.fill(0);
   for (let offset = 0; offset < y.length; offset += n * n) {
     const ar = x.subarray(offset, offset + n * n);
     const out = y.subarray(offset, offset + n * n);


### PR DESCRIPTION
## Summary

- document that backend allocations have unspecified contents unless initialized
- stop clearing reused Wasm allocation blocks
- make the Cholesky reference routine explicitly zero its unwritten triangle
- test Cholesky against a deliberately dirty output buffer across supported backends

## Why

Operations should fully define their outputs rather than depending on allocator initialization. This avoids an unconditional clear on every reused Wasm allocation while preserving Cholesky's zero-filled upper triangle.

## Validation

- `pnpm build`
- `pnpm check`
- `pnpm lint`
- `pnpm format:check`
- `pnpm test` (2,329 passed; 7 expected failures)
