### PR TITLE
Fix batched sort and argsort JVP rules

### DIFF
--- a/src/frontend/jvp.ts
+++ b/src/frontend/jvp.ts
@@ -6,7 +6,7 @@ import {
   map as treeMap,
   unflatten as treeUnflatten,
 } from "../tree";
-import { checkAxis, unzip2, zip } from "../utils";
+import { checkAxis, range, rep, unzip2, zip } from "../utils";
 import { arange, eye, pureArray, tril, triu, zerosLike } from "./array";
 import {
   AbstractValue,
@@ -144,6 +144,18 @@ function zeroTangentsJvp<P extends Primitive>(primitive: P): JvpRule<P> {
     const ys = bind(primitive, primals, params);
     return [ys, ys.map((y) => zerosLike(y.ref))];
   };
+}
+
+/** Gather values along the final axis while preserving leading coordinates. */
+function takeAlongLastAxis(x: Tracer, indices: Tracer): Tracer {
+  const coords: Tracer[] = [];
+  for (let axis = 0; axis < x.ndim - 1; axis++) {
+    const shape = rep(x.ndim, 1);
+    shape[axis] = x.shape[axis];
+    coords.push(arange(x.shape[axis]).reshape(shape));
+  }
+  coords.push(indices);
+  return gather(x, coords, range(x.ndim), 0);
 }
 
 /** Compute `a @ b.T`, batched to last two axes. */
@@ -316,13 +328,13 @@ const jvpRules: { [P in Primitive]: JvpRule<P> } = {
   [Primitive.Sort]([x], [dx]) {
     // Propagate both primals and derivatives along the sorted order.
     const [y, idx] = argsort(x);
-    return [[y], [gather(dx, [idx], [-1], -1)]];
+    return [[y], [takeAlongLastAxis(dx, idx)]];
   },
   [Primitive.Argsort]([x], [dx]) {
     const [y, idx] = argsort(x);
     return [
       [y, idx.ref],
-      [gather(dx, [idx.ref], [-1], -1), zerosLike(idx)],
+      [takeAlongLastAxis(dx, idx.ref), zerosLike(idx)],
     ];
   },
   [Primitive.TriangularSolve]([a, b], [da, db], { unitDiagonal }) {

--- a/test/numpy.test.ts
+++ b/test/numpy.test.ts
@@ -2747,6 +2747,26 @@ suite.each(devices)("device:%s", (device) => {
         expect(dy.js()).toEqual([20, 30, 10]);
       });
 
+      test("works with jvp for batched inputs", () => {
+        const x = np.array([
+          [3, 1, 2],
+          [4, 6, 5],
+        ]);
+        const dx = np.array([
+          [10, 20, 30],
+          [40, 60, 50],
+        ]);
+        const [y, dy] = jvp((x) => np.sort(x, 1), [x], [dx]);
+        expect(y.js()).toEqual([
+          [1, 2, 3],
+          [4, 5, 6],
+        ]);
+        expect(dy.js()).toEqual([
+          [20, 30, 10],
+          [40, 50, 60],
+        ]);
+      });
+
       // Won't work until scatter is implemented.
       test.fails("works with grad", () => {
         const x = np.array([3, 1, 4, 2]);


### PR DESCRIPTION
## Summary

- gather sort tangents with leading batch coordinates instead of treating batch dimensions as advanced-index dimensions
- share the take-along-last-axis logic between Sort and Argsort JVP rules
- add batched sort JVP coverage

## Root cause

The existing JVP rules gathered with only the final-axis permutation array. For inputs with leading dimensions, Gather interpreted the permutation's leading dimensions as additional output index dimensions and produced an incorrectly expanded tangent.

## Validation

The regression failed on CPU, Wasm, and WebGPU before the fix.

- `pnpm build`
- `pnpm check`
- `pnpm lint`
- `pnpm format:check`
- `pnpm test` (2,329 passed; 7 expected failures)
