### PR TITLE
Backprop for gather/sort via `scatter`

### DIFF
--- a/src/backend/backend.test.ts
+++ b/src/backend/backend.test.ts
@@ -10,7 +10,7 @@ import {
   Reduction,
 } from "../alu";
 import { devices, getBackend, init } from "../backend";
-import { Routine, Routines } from "../routine";
+import { Routine, Routines, ScatterOp } from "../routine";
 import { ShapeTracker, unravelAlu } from "../shape";
 import { range } from "../utils";
 
@@ -111,6 +111,77 @@ suite.each(devices)("device:%s", (device) => {
         expect(result).toEqual(new Float32Array([2, 0, 1, Math.sqrt(2)]));
       } finally {
         backend.decRef(input);
+        backend.decRef(output);
+      }
+    });
+
+    test("scatter clears an existing output slot", async () => {
+      const backend = getBackend(device);
+      const bytes = (values: Float32Array | Int32Array) =>
+        new Uint8Array(values.buffer);
+      const updates = backend.malloc(4, bytes(new Float32Array([7])));
+      const firstIndex = backend.malloc(4, bytes(new Int32Array([1])));
+      const secondIndex = backend.malloc(4, bytes(new Int32Array([2])));
+      const emptyUpdates = backend.malloc(0);
+      const emptyIndex = backend.malloc(0);
+      const output = backend.malloc(
+        4 * 4,
+        bytes(new Float32Array([9, 9, 9, 9])),
+      );
+
+      try {
+        const routine = new Routine(
+          Routines.Scatter,
+          {
+            inputShapes: [[1], [1]],
+            inputDtypes: [DType.Float32, DType.Int32],
+            outputShapes: [[4]],
+            outputDtypes: [DType.Float32],
+          },
+          {
+            op: ScatterOp.Update,
+            shape: [4],
+            axis: [0],
+            outDim: 0,
+            uniqueIndices: true,
+          },
+        );
+        const exe = await backend.prepareRoutine(routine);
+
+        backend.dispatch(exe, [updates, firstIndex], [output]);
+        let result = new Float32Array((await backend.read(output)).buffer);
+        expect(result).toEqual(new Float32Array([0, 7, 0, 0]));
+
+        backend.dispatch(exe, [updates, secondIndex], [output]);
+        result = new Float32Array((await backend.read(output)).buffer);
+        expect(result).toEqual(new Float32Array([0, 0, 7, 0]));
+
+        const emptyRoutine = new Routine(
+          Routines.Scatter,
+          {
+            inputShapes: [[0], [0]],
+            inputDtypes: [DType.Float32, DType.Int32],
+            outputShapes: [[4]],
+            outputDtypes: [DType.Float32],
+          },
+          {
+            op: ScatterOp.Update,
+            shape: [4],
+            axis: [0],
+            outDim: 0,
+            uniqueIndices: true,
+          },
+        );
+        const emptyExe = await backend.prepareRoutine(emptyRoutine);
+        backend.dispatch(emptyExe, [emptyUpdates, emptyIndex], [output]);
+        result = new Float32Array((await backend.read(output)).buffer);
+        expect(result).toEqual(new Float32Array([0, 0, 0, 0]));
+      } finally {
+        backend.decRef(updates);
+        backend.decRef(firstIndex);
+        backend.decRef(secondIndex);
+        backend.decRef(emptyUpdates);
+        backend.decRef(emptyIndex);
         backend.decRef(output);
       }
     });

--- a/src/backend/webgpu.ts
+++ b/src/backend/webgpu.ts
@@ -547,6 +547,10 @@ function pipelineSubmit(
       );
     }
 
+    if (shader.clearOutputs) {
+      for (const output of outputs) commandEncoder.clearBuffer(output);
+    }
+
     const filteredPasses = shader.passes.filter(({ grid }) => prod(grid) > 0);
     if (filteredPasses.length === 0) continue; // No work to do.
 

--- a/src/backend/webgpu/codegen.ts
+++ b/src/backend/webgpu/codegen.ts
@@ -10,6 +10,7 @@ export interface ShaderInfo {
   numInputs: number;
   numOutputs: number;
   hasUniform: boolean;
+  clearOutputs?: boolean; // Zero-fill output buffers before the first pass.
   passes: {
     grid: [number, number]; // Grid size (number of workgroups) in x and y.
     uniform?: Uint8Array<ArrayBuffer>; // Optional uniform value.

--- a/src/backend/webgpu/routines.ts
+++ b/src/backend/webgpu/routines.ts
@@ -10,8 +10,15 @@ import {
 } from "./codegen";
 import { DType, isFloatDtype } from "../../alu";
 import { UnsupportedRoutineError } from "../../backend";
-import { Routine, Routines, RoutineType } from "../../routine";
-import { findPow2, prod } from "../../utils";
+import {
+  Routine,
+  Routines,
+  RoutineType,
+  ScatterOp,
+  type ScatterParams,
+} from "../../routine";
+import { View } from "../../shape";
+import { findPow2, prod, range } from "../../utils";
 
 type BitonicSortPass = {
   kind: "sort" | "merge"; // sort = full sort (stages 0..k), merge is only merge steps
@@ -267,6 +274,231 @@ function createArgsort(device: GPUDevice, type: RoutineType): ShaderInfo[] {
   const n = shape[shape.length - 1];
   const batches = prod(shape.slice(0, -1));
   return bitonicSortShader(device, dtype, n, batches, true);
+}
+
+function wgslCoordinate(linearIndex: string, view: View, axis: number): string {
+  if (view.shape[axis] <= 1) return "0u";
+  const stride = view.strides[axis];
+  const divided = stride === 1 ? linearIndex : `(${linearIndex} / ${stride}u)`;
+  return `(${divided} % ${view.shape[axis]}u)`;
+}
+
+function wgslBroadcastIndex(
+  linearIndex: string,
+  updateView: View,
+  indexView: View,
+  outDim: number,
+  indexRank: number,
+): string {
+  const firstUpdateDim = outDim + indexRank - indexView.ndim;
+  const terms: string[] = [];
+  for (let i = 0; i < indexView.ndim; i++) {
+    const stride = indexView.strides[i];
+    if (stride === 0) continue;
+    const coord = wgslCoordinate(linearIndex, updateView, firstUpdateDim + i);
+    terms.push(stride === 1 ? coord : `(${coord} * ${stride}u)`);
+  }
+  return terms.length === 0 ? "0u" : terms.join(" + ");
+}
+
+type ScatterUpdateSource = {
+  statement: string;
+  helpers: string;
+};
+
+/**
+ * Generate the update statement for scatter-add.
+ *
+ * WGSL only has native integer atomics. Float32 uses a compare-exchange loop,
+ * while float16 updates one lane of a packed u32 with the same technique.
+ */
+function scatterAddWgsl(dtype: DType): ScatterUpdateSource {
+  switch (dtype) {
+    case DType.Float32:
+      return {
+        statement: "atomic_add_f32(&output[output_index], updates[global]);",
+        helpers: `
+fn atomic_add_f32(address: ptr<storage, atomic<u32>, read_write>, value: f32) {
+  var old_bits = atomicLoad(address);
+  loop {
+    let new_bits = bitcast<u32>(bitcast<f32>(old_bits) + value);
+    let result = atomicCompareExchangeWeak(address, old_bits, new_bits);
+    if (result.exchanged) {
+      break;
+    }
+    old_bits = result.old_value;
+  }
+}`,
+      };
+    case DType.Float16:
+      return {
+        statement: `
+  atomic_add_f16(
+    &output[output_index / 2u],
+    output_index % 2u != 0u,
+    updates[global],
+  );`.trim(),
+        helpers: `
+fn atomic_add_f16(
+  address: ptr<storage, atomic<u32>, read_write>,
+  high: bool,
+  value: f16,
+) {
+  var old_bits = atomicLoad(address);
+  loop {
+    var pair = unpack2x16float(old_bits);
+    if (high) {
+      pair.y += f32(value);
+    } else {
+      pair.x += f32(value);
+    }
+    let new_bits = pack2x16float(pair);
+    let result = atomicCompareExchangeWeak(address, old_bits, new_bits);
+    if (result.exchanged) {
+      break;
+    }
+    old_bits = result.old_value;
+  }
+}`,
+      };
+    case DType.Uint32:
+    case DType.Int32:
+      return {
+        statement: "atomicAdd(&output[output_index], updates[global]);",
+        helpers: "",
+      };
+    case DType.Bool:
+      return {
+        statement: "atomicOr(&output[output_index], updates[global]);",
+        helpers: "",
+      };
+    default:
+      throw new Error(`Unsupported atomic Scatter dtype for WebGPU: ${dtype}`);
+  }
+}
+
+function createScatter(
+  device: GPUDevice,
+  type: RoutineType,
+  {
+    op,
+    shape: outputShape,
+    axis: indexedAxes,
+    outDim,
+    uniqueIndices,
+  }: ScatterParams,
+): ShaderInfo[] {
+  const dtype = type.inputDtypes[0];
+  const updateView = View.create(type.inputShapes[0]);
+  const indexViews = type.inputShapes
+    .slice(1)
+    .map((shape) => View.create(shape));
+  const indexRank = Math.max(...indexViews.map((view) => view.ndim));
+  const updateCount = updateView.size;
+  const elementType = dtypeToWgsl(dtype, true);
+  const needsF16 = dtype === DType.Float16;
+  if (needsF16 && !device.features.has("shader-f16")) {
+    throw new Error("WebGPU device does not support shader-f16 feature");
+  }
+
+  // Updates have the free output dimensions, with the broadcasted index
+  // dimensions inserted at outDim.
+  const freeUpdateDims = [
+    ...range(outDim),
+    ...range(outDim + indexRank, updateView.ndim),
+  ];
+
+  // Each index input is right-aligned within the broadcasted index dimensions.
+  const indexLoads = indexViews.map((indexView, i) => {
+    const indexOffset = wgslBroadcastIndex(
+      "global",
+      updateView,
+      indexView,
+      outDim,
+      indexRank,
+    );
+    return `  let scatter_index_${i} = i32(index_${i}[${indexOffset}]);`;
+  });
+  const bounds = indexedAxes.map(
+    (outputAxis, i) =>
+      `scatter_index_${i} < 0 || scatter_index_${i} >= ${outputShape[outputAxis]}`,
+  );
+
+  const outputView = View.create(outputShape);
+  // Indexed output axes come from index buffers; all others come directly from
+  // the corresponding update coordinate.
+  let freeDim = 0;
+  const outputTerms = range(outputShape.length).map((outputAxis) => {
+    const indexInput = indexedAxes.indexOf(outputAxis);
+    let coord: string;
+    if (indexInput === -1) {
+      coord = wgslCoordinate("global", updateView, freeUpdateDims[freeDim++]);
+    } else {
+      coord = `u32(scatter_index_${indexInput})`;
+    }
+    return outputView.strides[outputAxis] === 1
+      ? coord
+      : `(${coord} * ${outputView.strides[outputAxis]}u)`;
+  });
+  const outputIndex = outputTerms.join(" + ");
+
+  const atomicAdd = op === ScatterOp.Add && !uniqueIndices;
+  const usesSignedAtomics = dtype === DType.Int32 || dtype === DType.Bool;
+  const outputStorageType = atomicAdd
+    ? `atomic<${usesSignedAtomics ? "i32" : "u32"}>`
+    : elementType;
+  const updateSource = atomicAdd
+    ? scatterAddWgsl(dtype)
+    : {
+        statement: "output[output_index] = updates[global];",
+        helpers: "",
+      };
+
+  const maxThreads = device.limits.maxComputeWorkgroupSizeX;
+  const dispatchSize = Math.max(updateCount, 1);
+  const workgroupSize = findPow2(
+    Math.min(dispatchSize, maxThreads),
+    maxThreads,
+  );
+  const code = `
+${needsF16 ? "enable f16;" : ""}
+${headerWgsl}
+${updateSource.helpers}
+
+@group(0) @binding(0) var<storage, read> updates: array<${elementType}>;
+${indexViews
+  .map(
+    (_, i) =>
+      `@group(0) @binding(${i + 1}) var<storage, read> index_${i}: array<${dtypeToWgsl(type.inputDtypes[i + 1], true)}>;`,
+  )
+  .join("\n")}
+@group(0) @binding(${type.inputShapes.length}) var<storage, read_write> output: array<${outputStorageType}>;
+
+@compute @workgroup_size(${workgroupSize})
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
+  let global = global_id.x + global_id.y * ${gridOffsetY * workgroupSize}u;
+  if (global >= ${updateCount}u) {
+    return;
+  }
+${indexLoads.join("\n")}
+  if (${bounds.join(" || ")}) {
+    return;
+  }
+  let output_index = ${outputIndex};
+  ${updateSource.statement}
+}
+`.trim();
+
+  return [
+    {
+      code,
+      numInputs: type.inputShapes.length,
+      numOutputs: 1,
+      hasUniform: false,
+      clearOutputs: true,
+      passes: [{ grid: calculateGrid(Math.ceil(updateCount / workgroupSize)) }],
+    },
+  ];
 }
 
 /**
@@ -1128,6 +1360,8 @@ export function createRoutineShader(
       return createSort(device, routine.type);
     case Routines.Argsort:
       return createArgsort(device, routine.type);
+    case Routines.Scatter:
+      return createScatter(device, routine.type, routine.params);
     case Routines.TriangularSolve:
       return createTriangularSolve(device, routine.type, routine.params);
     case Routines.Cholesky:

--- a/src/frontend/array.test.ts
+++ b/src/frontend/array.test.ts
@@ -1,9 +1,11 @@
 import { beforeEach, expect, suite, test } from "vitest";
 
-import { defaultDevice, devices, init } from "../backend";
-import { arange, array, eye, ones, zeros } from "./array";
 import { hasStrictNumerics } from "../../test/setup";
 import { DType } from "../alu";
+import { defaultDevice, devices, init } from "../backend";
+import { ScatterOp } from "../routine";
+import { arange, array, eye, Array as JaxArray, ones, zeros } from "./array";
+import { scatter } from "./core";
 
 const devicesAvailable = await init();
 
@@ -45,6 +47,132 @@ suite.each(devices)("device:%s", (device) => {
     expect(ar3.dtype).toEqual("float32");
     expect(await ar3.data()).toEqual(new Float32Array([2, 2, 2, 2]));
   });
+
+  if (device !== "webgl") {
+    test("scatter maps multiple indexed axes", () => {
+      const result = scatter(
+        array([
+          [10, 20],
+          [30, 40],
+          [50, 60],
+        ]),
+        [
+          array([1, 3], { dtype: DType.Int32 }),
+          array([0, 1], { dtype: DType.Int32 }),
+        ],
+        {
+          op: ScatterOp.Update,
+          shape: [2, 3, 4],
+          axis: [2, 0],
+          outDim: 1,
+          uniqueIndices: true,
+        },
+      ) as JaxArray;
+      expect(result.js()).toEqual([
+        [
+          [0, 10, 0, 0],
+          [0, 30, 0, 0],
+          [0, 50, 0, 0],
+        ],
+        [
+          [0, 0, 0, 20],
+          [0, 0, 0, 40],
+          [0, 0, 0, 60],
+        ],
+      ]);
+    });
+
+    test("scatterAdd sums repeated indices", async () => {
+      const result = scatter(
+        array([1, 2, 3]),
+        [array([1, 1, 3], { dtype: DType.Int32 })],
+        {
+          op: ScatterOp.Add,
+          shape: [4],
+          axis: [0],
+          outDim: 0,
+          uniqueIndices: false,
+        },
+      ) as JaxArray;
+      expect(Array.from(await result.data())).toEqual([0, 3, 0, 3]);
+    });
+
+    if (device === "cpu" || device === "webgpu") {
+      test("scatterAdd preserves adjacent float16 destinations", () => {
+        const result = scatter(
+          array([1, 2, 3, 4], { dtype: DType.Float16 }),
+          [array([0, 1, 0, 1], { dtype: DType.Int32 })],
+          {
+            op: ScatterOp.Add,
+            shape: [2],
+            axis: [0],
+            outDim: 0,
+            uniqueIndices: false,
+          },
+        ) as JaxArray;
+        expect(result.js()).toEqual([4, 6]);
+      });
+    }
+
+    test.each([
+      [DType.Int32, [1, 2, 3], [0, 3, 0, 3]],
+      [DType.Uint32, [1, 2, 3], [0, 3, 0, 3]],
+      [DType.Bool, [false, true, true], [false, true, false, true]],
+    ])("scatterAdd supports %s", (dtype, updates, expected) => {
+      const result = scatter(
+        array(updates, { dtype }),
+        [array([1, 1, 3], { dtype: DType.Int32 })],
+        {
+          op: ScatterOp.Add,
+          shape: [4],
+          axis: [0],
+          outDim: 0,
+          uniqueIndices: false,
+        },
+      ) as JaxArray;
+      expect(result.js()).toEqual(expected);
+    });
+
+    test("scatterAdd accepts a unique-index promise", () => {
+      const result = scatter(
+        array([10, 20, 30]),
+        [array([3, 0, 2], { dtype: DType.Int32 })],
+        {
+          op: ScatterOp.Add,
+          shape: [4],
+          axis: [0],
+          outDim: 0,
+          uniqueIndices: true,
+        },
+      ) as JaxArray;
+      expect(result.js()).toEqual([20, 0, 30, 10]);
+    });
+
+    test("scatterAdd broadcasts index arrays", () => {
+      const result = scatter(
+        array([
+          [1, 2, 3],
+          [4, 5, 6],
+        ]),
+        [
+          array([[0], [2]], { dtype: DType.Int32 }),
+          array([[0, 1, 1]], { dtype: DType.Int32 }),
+        ],
+        {
+          op: ScatterOp.Add,
+          shape: [3, 4],
+          axis: [0, 1],
+          outDim: 0,
+          uniqueIndices: false,
+        },
+      ) as JaxArray;
+      expect(result.js()).toEqual([
+        [1, 5, 0, 0],
+        [0, 0, 0, 0],
+        [4, 11, 0, 0],
+      ]);
+    });
+  }
 
   test("can construct arrays from data", () => {
     const a = array([1, 2, 3, 4]);

--- a/src/frontend/array.ts
+++ b/src/frontend/array.ts
@@ -1174,6 +1174,7 @@ export class Array extends Tracer {
       },
       [Primitive.Sort]: Array.#routine(Primitive.Sort),
       [Primitive.Argsort]: Array.#routine(Primitive.Argsort),
+      [Primitive.Scatter]: Array.#routine(Primitive.Scatter),
       [Primitive.TriangularSolve]: Array.#routine(Primitive.TriangularSolve),
       [Primitive.Cholesky]: Array.#routine(Primitive.Cholesky),
       [Primitive.LU]: Array.#routine(Primitive.LU),

--- a/src/frontend/core.ts
+++ b/src/frontend/core.ts
@@ -1,7 +1,7 @@
 /** @file Core library internals and interpreter stack, based on Autodidax. */
 
 import { AluGroup, AluOp, DType, isFloatDtype, promoteTypes } from "../alu";
-import { Routines } from "../routine";
+import { Routines, type ScatterParams } from "../routine";
 import { type Pair } from "../shape";
 import {
   JsTreeDef,
@@ -90,6 +90,7 @@ export enum Primitive {
   // Routines (custom lowering)
   Sort = "sort", // sort(x, axis=-1), unstable
   Argsort = "argsort", // argsort(x, axis=-1), stable
+  Scatter = "scatter",
   TriangularSolve = "triangular_solve", // A is upper triangular, A @ X.T = B.T
   Cholesky = "cholesky", // A is positive-definite, A = L @ L^T
   LU = "lu", // LU decomposition with partial pivoting
@@ -117,13 +118,18 @@ interface PrimitiveParamsImpl extends Record<Primitive, Record<string, any>> {
   [Primitive.Concatenate]: { axis: number };
   [Primitive.Split]: { axis: number; sizes: number[] };
   [Primitive.RandomBits]: { shape: number[]; mode: "xor" | 0 | 1 };
-  [Primitive.Gather]: { axis: number[]; outDim: number };
+  [Primitive.Gather]: {
+    axis: number[];
+    outDim: number;
+    uniqueIndices: boolean;
+  };
   [Primitive.Transpose]: { perm: number[] };
   [Primitive.Broadcast]: { shape: number[]; axis: number[] };
   [Primitive.Reshape]: { shape: number[] };
   [Primitive.Flip]: { axis: number[] };
   [Primitive.Shrink]: { slice: Pair[] };
   [Primitive.Pad]: { width: Pair[] };
+  [Primitive.Scatter]: ScatterParams;
   [Primitive.TriangularSolve]: { unitDiagonal: boolean };
   [Primitive.JacobiEigh]: { maxSweeps: number; tolerance: number };
   [Primitive.Fft]: { factors: number[]; inverse: boolean };
@@ -148,6 +154,7 @@ export enum CompareOp {
 export const routinePrimitives = new Map([
   [Primitive.Sort, Routines.Sort],
   [Primitive.Argsort, Routines.Argsort],
+  [Primitive.Scatter, Routines.Scatter],
   [Primitive.TriangularSolve, Routines.TriangularSolve],
   [Primitive.Cholesky, Routines.Cholesky],
   [Primitive.LU, Routines.LU],
@@ -381,30 +388,49 @@ export function randomBits(
   return bind1(Primitive.RandomBits, [k0, k1], { shape, mode });
 }
 
-export function gather(
-  x: TracerValue,
-  indices: TracerValue[],
-  axis: number[], // one for each index
+function normalizeGatherIndexing(
+  operandNdim: number,
+  indexCount: number,
+  axis: number[],
   outDim: number,
-) {
-  // Evaluate advanced indexing x[:, ...indices, :], with the index dimensions
-  // starting at axis `outDim` in the output.
-  if (indices.length === 0) {
+): [number[], number] {
+  if (indexCount === 0) {
     throw new Error("gather() requires at least one index");
   }
-  if (!Array.isArray(axis) || axis.length !== indices.length) {
+  if (!Array.isArray(axis) || axis.length !== indexCount) {
     throw new Error(
-      `Invalid gather() axis: expected ${indices.length} axes, got ${JSON.stringify(axis)}`,
+      `Invalid gather() axis: expected ${indexCount} axes, got ${JSON.stringify(axis)}`,
     );
   }
-  axis = axis.map((a) => checkAxis(a, ndim(x)));
+  axis = axis.map((a) => checkAxis(a, operandNdim));
   if (new Set(axis).size !== axis.length) {
     throw new Error(
       `Invalid gather() axis: duplicate axes ${JSON.stringify(axis)}`,
     );
   }
-  outDim = checkAxis(outDim, ndim(x) - axis.length + 1);
-  return bind1(Primitive.Gather, [x, ...indices], { axis, outDim });
+  return [axis, checkAxis(outDim, operandNdim - axis.length + 1)];
+}
+
+export function gather(
+  x: TracerValue,
+  indices: TracerValue[],
+  axis: number[], // one for each index
+  outDim: number,
+  uniqueIndices: boolean = false,
+) {
+  // Evaluate advanced indexing x[:, ...indices, :], with the index dimensions
+  // starting at axis `outDim` in the output.
+  [axis, outDim] = normalizeGatherIndexing(
+    ndim(x),
+    indices.length,
+    axis,
+    outDim,
+  );
+  return bind1(Primitive.Gather, [x, ...indices], {
+    axis,
+    outDim,
+    uniqueIndices,
+  });
 }
 
 export function transpose(x: TracerValue, perm?: number[]) {
@@ -576,6 +602,14 @@ export function argsort(x: TracerValue) {
   const nd = ndim(x);
   if (nd === 0) throw new Error("argsort: requires at least 1D input");
   return bind(Primitive.Argsort, [x]);
+}
+
+export function scatter(
+  updates: TracerValue,
+  indices: TracerValue[],
+  params: ScatterParams,
+) {
+  return bind1(Primitive.Scatter, [updates, ...indices], params);
 }
 
 export function bind1<P extends Primitive>(

--- a/src/frontend/jaxpr.ts
+++ b/src/frontend/jaxpr.ts
@@ -770,6 +770,35 @@ function vectorizedUnopAbstractEval([x]: ShapedArray[]) {
   return [ShapedArray.fromAval(x)];
 }
 
+/** Shape for the output of a gather operation. */
+function gatherShape(
+  operandShape: number[],
+  indices: ShapedArray[],
+  { axis, outDim }: { axis: number[]; outDim: number },
+) {
+  for (const a of indices) {
+    if (a.dtype !== DType.Int32 && a.dtype !== DType.Uint32) {
+      throw new TypeError(`indices must be Int32 or Uint32, got ${a.dtype}`);
+    }
+  }
+  if (axis.length !== indices.length)
+    throw new TypeError(`got ${axis} axes but ${indices.length} indices`);
+  if (indices.length === 0) throw new TypeError(`must have at least one index`);
+  if (axis.some((a) => a < 0 || a >= operandShape.length))
+    throw new TypeError(`axis out of bounds`);
+  if (outDim < 0 || outDim > operandShape.length - axis.length)
+    throw new TypeError(`outDim out of bounds`);
+  const axisSet = new Set(axis);
+  if (axisSet.size !== axis.length) throw new TypeError(`axes are not unique`);
+  const indexShape = indices.reduce<number[]>(
+    (result, a) => generalBroadcast(result, a.shape),
+    [],
+  );
+  const result = operandShape.filter((_, i) => !axisSet.has(i));
+  result.splice(outDim, 0, ...indexShape);
+  return result;
+}
+
 export const abstractEvalRules: { [P in Primitive]: AbstractEvalRule<P> } = {
   [Primitive.Add]: binopAbstractEval,
   [Primitive.Mul]: binopAbstractEval,
@@ -915,29 +944,8 @@ export const abstractEvalRules: { [P in Primitive]: AbstractEvalRule<P> } = {
     return [new ShapedArray(shape, DType.Uint32, false)];
   },
   [Primitive.Gather]([x, ...indices], { axis, outDim }) {
-    for (const a of indices)
-      if (a.dtype !== DType.Int32 && a.dtype !== DType.Uint32)
-        throw new TypeError(
-          `Gather indices must be Int32 or Uint32, got ${a.dtype}`,
-        );
-    if (axis.length !== indices.length)
-      throw new TypeError(`Gather: ${axis} axes but ${indices.length} indices`);
-    if (indices.length === 0)
-      throw new TypeError("Gather must have 1+ indices with same shape");
-    if (axis.some((a) => a < 0 || a >= x.shape.length))
-      throw new TypeError("Gather axis out of bounds");
-    if (outDim < 0 || outDim > x.shape.length - axis.length)
-      throw new TypeError("Gather outDim out of bounds");
-    const axisSet = new Set(axis);
-    if (axisSet.size !== axis.length)
-      throw new TypeError("Gather axes are not unique");
-    const gatherShape = indices.reduce<number[]>(
-      (shape, a) => generalBroadcast(shape, a.shape),
-      [],
-    );
-    const newShape = x.shape.filter((_, i) => !axisSet.has(i));
-    newShape.splice(outDim, 0, ...gatherShape);
-    return [new ShapedArray(newShape, x.dtype, x.weakType)];
+    const shape = gatherShape(x.shape, indices, { axis, outDim });
+    return [new ShapedArray(shape, x.dtype, x.weakType)];
   },
   [Primitive.Transpose]([x], { perm }) {
     return [
@@ -976,6 +984,15 @@ export const abstractEvalRules: { [P in Primitive]: AbstractEvalRule<P> } = {
       ShapedArray.fromAval(x),
       new ShapedArray(x.shape, DType.Int32, false),
     ];
+  },
+  [Primitive.Scatter]([updates, ...indices], { shape, axis, outDim }) {
+    const expectedUpdatesShape = gatherShape(shape, indices, { axis, outDim });
+    if (!deepEqual(updates.shape, expectedUpdatesShape)) {
+      throw new TypeError(
+        `Scatter updates shape ${updates.shape} does not match expected shape ${expectedUpdatesShape}`,
+      );
+    }
+    return [new ShapedArray(shape, updates.dtype, updates.weakType)];
   },
   [Primitive.TriangularSolve]([a, b]) {
     if (a.ndim < 2)

--- a/src/frontend/jit.ts
+++ b/src/frontend/jit.ts
@@ -775,6 +775,7 @@ const jitRules: { [P in Primitive]: JitRule<P> } = {
   [Primitive.Pad]: reshapeJit((st, { width }) => st.pad(width)),
   [Primitive.Sort]: routineNoJit(),
   [Primitive.Argsort]: routineNoJit(),
+  [Primitive.Scatter]: routineNoJit(),
   [Primitive.TriangularSolve]: routineNoJit(),
   [Primitive.Cholesky]: routineNoJit(),
   [Primitive.LU]: routineNoJit(),

--- a/src/frontend/jvp.ts
+++ b/src/frontend/jvp.ts
@@ -44,6 +44,7 @@ import {
   PrimitiveParams,
   reciprocal,
   reduce,
+  scatter,
   sin,
   sqrt,
   Trace,
@@ -155,7 +156,7 @@ function takeAlongLastAxis(x: Tracer, indices: Tracer): Tracer {
     coords.push(arange(x.shape[axis]).reshape(shape));
   }
   coords.push(indices);
-  return gather(x, coords, range(x.ndim), 0);
+  return gather(x, coords, range(x.ndim), 0, true);
 }
 
 /** Compute `a @ b.T`, batched to last two axes. */
@@ -310,13 +311,14 @@ const jvpRules: { [P in Primitive]: JvpRule<P> } = {
   [Primitive.Concatenate]: linearTangentsJvp(Primitive.Concatenate),
   [Primitive.Split]: linearTangentsJvp(Primitive.Split),
   [Primitive.RandomBits]: zeroTangentsJvp(Primitive.RandomBits),
-  [Primitive.Gather]([x, ...indices], [dx, ..._], { axis, outDim }) {
+  [Primitive.Gather]([x, ...indices], [dx, ...dindices], params) {
     // d(gather(x, indices)) = gather(dx, indices).
     // Note: We ignore the tangents for indices, since they are not differentiable.
-    const indicesRef = indices.map((t) => t.ref);
+    dindices.forEach((index) => index.dispose());
+    const tangentIndices = indices.map((index) => index.ref);
     return [
-      [gather(x, indices, axis, outDim)],
-      [gather(dx, indicesRef, axis, outDim)],
+      bind(Primitive.Gather, [x, ...indices], params),
+      bind(Primitive.Gather, [dx, ...tangentIndices], params),
     ];
   },
   [Primitive.Transpose]: linearTangentsJvp(Primitive.Transpose),
@@ -335,6 +337,14 @@ const jvpRules: { [P in Primitive]: JvpRule<P> } = {
     return [
       [y, idx.ref],
       [takeAlongLastAxis(dx, idx.ref), zerosLike(idx)],
+    ];
+  },
+  [Primitive.Scatter]([updates, ...indices], [dupdates, ...dindices], params) {
+    dindices.forEach((index) => index.dispose());
+    const tangentIndices = indices.map((index) => index.ref);
+    return [
+      [scatter(updates, indices, params)],
+      [scatter(dupdates, tangentIndices, params)],
     ];
   },
   [Primitive.TriangularSolve]([a, b], [da, db], { unitDiagonal }) {

--- a/src/frontend/linearize.ts
+++ b/src/frontend/linearize.ts
@@ -1,6 +1,7 @@
 /** @file Implementations of vjp() and partial evaluation. */
 
 import { AluOp, isFloatDtype } from "../alu";
+import { ScatterOp } from "../routine";
 import {
   dispose as treeDispose,
   flatten as treeFlatten,
@@ -32,6 +33,7 @@ import {
   flattenFunWithAux,
   flip,
   fullRaise,
+  gather,
   mul,
   ndim,
   neg,
@@ -41,6 +43,7 @@ import {
   PrimitiveParams,
   reduce,
   reshape,
+  scatter,
   ShapedArray,
   shrink,
   split,
@@ -864,14 +867,20 @@ const transposeRules: Partial<{ [P in Primitive]: TransposeRule<P> }> = {
     if (!(x instanceof UndefPrimal)) throw new NonlinearError(Primitive.Split);
     return [concatenate(cts, axis)];
   },
-  [Primitive.Gather]([ct], [x, ...indices], { axis, outDim }) {
+  [Primitive.Gather]([ct], [x, ...indices], { axis, outDim, uniqueIndices }) {
     if (!(x instanceof UndefPrimal)) throw new NonlinearError(Primitive.Gather);
     if (indices.some((i) => i instanceof UndefPrimal))
       throw new NonlinearError(Primitive.Gather);
-    void [ct, axis, outDim];
-    throw new Error(
-      "Gather transpose rule is not yet implemented, requires complex Scatter sum operation",
-    );
+    return [
+      scatter(ct, indices as Tracer[], {
+        op: ScatterOp.Add,
+        shape: x.aval.shape,
+        axis,
+        outDim,
+        uniqueIndices,
+      }),
+      ...indices.map(() => null),
+    ];
   },
   [Primitive.Transpose]([ct], [x], { perm }) {
     if (!(x instanceof UndefPrimal))
@@ -905,6 +914,20 @@ const transposeRules: Partial<{ [P in Primitive]: TransposeRule<P> }> = {
       ([s, _e], i) => [s, s + x.aval.shape[i]] as [number, number],
     );
     return [shrink(ct, slice)];
+  },
+  [Primitive.Scatter](
+    [ct],
+    [updates, ...indices],
+    { axis, outDim, uniqueIndices },
+  ) {
+    if (!(updates instanceof UndefPrimal))
+      throw new NonlinearError(Primitive.Scatter);
+    if (indices.some((i) => i instanceof UndefPrimal))
+      throw new NonlinearError(Primitive.Scatter);
+    return [
+      gather(ct, indices as Tracer[], axis, outDim, uniqueIndices),
+      ...indices.map(() => null),
+    ];
   },
   [Primitive.TriangularSolve]([ct], [a, b], { unitDiagonal }) {
     if (a instanceof UndefPrimal || !(b instanceof UndefPrimal))

--- a/src/frontend/vmap.ts
+++ b/src/frontend/vmap.ts
@@ -20,6 +20,7 @@ import {
   randomBits,
   reduce,
   reshape,
+  scatter,
   ShapedArray,
   shrink,
   split,
@@ -236,6 +237,32 @@ function lastDimsBatcher<P extends Primitive>(
   };
 }
 
+function batchIndexArrays(
+  axisSize: number,
+  indices: Tracer[],
+  batchDims: (number | null)[],
+): [Tracer[], number] {
+  const rank = Math.max(
+    ...indices.map((index, i) => index.ndim + (batchDims[i] === null ? 1 : 0)),
+  );
+  return [
+    indices.map((index, i) => {
+      const batchDim = batchDims[i];
+      if (batchDim === null) return index;
+      index = moveBatchAxis(axisSize, batchDim, 0, index);
+      if (index.ndim < rank) {
+        index = index.reshape([
+          index.shape[0],
+          ...rep(rank - index.ndim, 1),
+          ...index.shape.slice(1),
+        ]);
+      }
+      return index;
+    }),
+    rank,
+  ];
+}
+
 const vmapRules: Partial<{ [P in Primitive]: VmapRule<P> }> = {
   [Primitive.Add]: broadcastBatcher(Primitive.Add),
   [Primitive.Mul]: broadcastBatcher(Primitive.Mul),
@@ -305,7 +332,7 @@ const vmapRules: Partial<{ [P in Primitive]: VmapRule<P> }> = {
     axisSize,
     [x, ...indices],
     [xBdim, ...indicesBdim],
-    { axis, outDim },
+    { axis, outDim, uniqueIndices },
   ) {
     if (indicesBdim.every((d) => d === null)) {
       // If none of the indices are mapped, this is an ordinary Gather on larger
@@ -316,34 +343,33 @@ const vmapRules: Partial<{ [P in Primitive]: VmapRule<P> }> = {
       let newOutDim = outDim;
       if (newOutDim < newBdim) newBdim += axis.length;
       else newOutDim += 1;
-      return [[gather(x, indices, newAxis, newOutDim)], [newBdim]];
+      return [
+        [gather(x, indices, newAxis, newOutDim, uniqueIndices)],
+        [newBdim],
+      ];
     }
     // If indices are mapped, move those mapped axes to front.
-    const nd = Math.max(
-      ...indices.map((m, i) => ndim(m) + (indicesBdim[i] === null ? 1 : 0)),
+    const [batchedIndices, indexRank] = batchIndexArrays(
+      axisSize,
+      indices,
+      indicesBdim,
     );
-    indices = indices.map((m, i) => {
-      if (indicesBdim[i] === null) return m;
-      m = moveBatchAxis(axisSize, indicesBdim[i], 0, m);
-      if (m.ndim < nd)
-        m = m.reshape([
-          m.shape[0],
-          ...rep(nd - m.ndim, 1),
-          ...m.shape.slice(1),
-        ]);
-      return m;
-    });
+    indices = batchedIndices;
     // Now there are two cases. If x is not mapped, dispatch directly.
     if (xBdim === null) {
-      return [[gather(x, indices, axis, outDim)], [outDim]];
+      // Indices may overlap between vmap lanes even if each lane is unique.
+      return [[gather(x, indices, axis, outDim, false)], [outDim]];
     } else {
       // Otherwise, we need a new `arange(axisSize)` index.
       // For simplicity, let's also move x's batch axis to the front.
       x = moveBatchAxis(axisSize, xBdim, 0, x);
       const newAxis = [0, ...axis.map((ax) => ax + 1)];
-      const extraBatchIndex = arange(axisSize).reshape([-1, ...rep(nd - 1, 1)]);
+      const extraBatchIndex = arange(axisSize).reshape([
+        -1,
+        ...rep(indexRank - 1, 1),
+      ]);
       indices.splice(0, 0, extraBatchIndex);
-      return [[gather(x, indices, newAxis, outDim)], [outDim]];
+      return [[gather(x, indices, newAxis, outDim, uniqueIndices)], [outDim]];
     }
   },
   [Primitive.Transpose](axisSize, [x], [xBdim], { perm }) {
@@ -380,6 +406,36 @@ const vmapRules: Partial<{ [P in Primitive]: VmapRule<P> }> = {
   },
   [Primitive.Sort]: lastDimsBatcher(Primitive.Sort, 1),
   [Primitive.Argsort]: lastDimsBatcher(Primitive.Argsort, 1, 2),
+  [Primitive.Scatter]: (
+    axisSize,
+    [updates, ...indices],
+    [updatesBdim, ...indicesBdim],
+    { op, shape, axis, outDim, uniqueIndices },
+  ) => {
+    // Put mapped index dimensions first and align their remaining dimensions
+    // so ordinary broadcasting produces one index set per vmap lane.
+    const [batchedIndices, indexRank] = batchIndexArrays(
+      axisSize,
+      indices,
+      indicesBdim,
+    );
+    indices = batchedIndices;
+    // Represent the vmap lane as another indexed destination axis. Unmapped
+    // indices broadcast across it, while mapped indices select per-lane values.
+    updates = moveBatchAxis(axisSize, updatesBdim, outDim, updates);
+    const batchIndex = arange(axisSize).reshape([
+      axisSize,
+      ...rep(indexRank - 1, 1),
+    ]);
+    const result = scatter(updates, [batchIndex, ...indices], {
+      op,
+      shape: [axisSize, ...shape],
+      axis: [0, ...axis.map((a) => a + 1)],
+      outDim,
+      uniqueIndices,
+    });
+    return [[result], [0]];
+  },
   [Primitive.TriangularSolve](
     axisSize,
     [a, b],

--- a/src/routine.ts
+++ b/src/routine.ts
@@ -42,6 +42,12 @@ export enum Routines {
   Argsort = "Argsort",
 
   /**
+   * Scatter updates into a zero-filled output, either replacing or adding at
+   * each destination according to `ScatterOp`.
+   */
+  Scatter = "Scatter",
+
+  /**
    * Solve a triangular system of equations.
    *
    * The first batch of inputs `A` should be of shape `[..., N, N]` and upper
@@ -95,6 +101,20 @@ export enum Routines {
   Fft = "Fft",
 }
 
+/** Operation applied when scattering an update into its destination. */
+export enum ScatterOp {
+  Update = "update",
+  Add = "add",
+}
+
+export interface ScatterParams {
+  op: ScatterOp;
+  shape: number[];
+  axis: number[];
+  outDim: number;
+  uniqueIndices: boolean;
+}
+
 export interface RoutineType {
   inputShapes: number[][];
   inputDtypes: DType[];
@@ -122,6 +142,8 @@ export function runCpuRoutine(
       return runSort(type, inputAr, outputAr);
     case Routines.Argsort:
       return runArgsort(type, inputAr, outputAr);
+    case Routines.Scatter:
+      return runScatter(type, inputAr, outputAr, routine.params);
     case Routines.TriangularSolve:
       return runTriangularSolve(type, inputAr, outputAr, routine.params);
     case Routines.Cholesky:
@@ -145,9 +167,12 @@ const Routines = ${JSON.stringify(Routines)};
 const ${byteWidth.name} = ${byteWidth.toString()};
 const ${isFloatDtype.name} = ${isFloatDtype.toString()};
 const ${dtypedArray.name} = ${dtypedArray.toString()};
+const ScatterOp = ${JSON.stringify(ScatterOp)};
 ${runCpuRoutine.toString()}
 ${runSort.toString()}
 ${runArgsort.toString()}
+${shapeStrides.toString()}
+${runScatter.toString()}
 ${runTriangularSolve.toString()}
 ${runCholesky.toString()}
 ${runLU.toString()}
@@ -185,6 +210,88 @@ function runArgsort(type: RoutineType, [x]: DataArray[], [y, yi]: DataArray[]) {
       return x === y ? 0 : x < y ? -1 : 1;
     });
     for (let i = 0; i < n; i++) out[i] = ar[outi[i]];
+  }
+}
+
+function shapeStrides(shape: number[]): number[] {
+  const strides = new Array(shape.length);
+  let stride = 1;
+  for (let i = shape.length - 1; i >= 0; i--) {
+    strides[i] = stride;
+    stride *= shape[i];
+  }
+  return strides;
+}
+
+function runScatter(
+  type: RoutineType,
+  [updates, ...indices]: DataArray[],
+  [output]: DataArray[],
+  {
+    op,
+    shape: outputShape,
+    axis: indexedAxes,
+    outDim,
+    uniqueIndices,
+  }: ScatterParams,
+) {
+  output.fill(0);
+  const accumulate = op !== ScatterOp.Update && !uniqueIndices;
+
+  // Updates have the non-indexed output dimensions, with the broadcasted
+  // index dimensions inserted at outDim.
+  const updateShape = type.inputShapes[0];
+  const indexShapes = type.inputShapes.slice(1);
+  const indexRank = Math.max(...indexShapes.map((s) => s.length));
+
+  const updateStrides = shapeStrides(updateShape);
+  const outputStrides = shapeStrides(outputShape);
+  const indexStrides = indexShapes.map(shapeStrides);
+  const outputAxisToIndex = outputShape.map((_, d) => indexedAxes.indexOf(d));
+  const freeUpdateDims = updateShape
+    .map((_, i) => i)
+    .filter((i) => i < outDim || i >= outDim + indexRank);
+
+  // Translate every update coordinate into its destination output coordinate.
+  for (let i = 0; i < updates.length; i++) {
+    let outputIndex = 0;
+    let valid = true;
+    let freeDim = 0;
+    for (let outputAxis = 0; outputAxis < outputShape.length; outputAxis++) {
+      const indexInput = outputAxisToIndex[outputAxis];
+      let coord: number;
+      if (indexInput === -1) {
+        const updateDim = freeUpdateDims[freeDim++];
+        coord =
+          Math.floor(i / updateStrides[updateDim]) % updateShape[updateDim];
+      } else {
+        const indexShape = indexShapes[indexInput];
+        const firstUpdateDim = outDim + indexRank - indexShape.length;
+        let indexOffset = 0;
+        for (let j = 0; j < indexShape.length; j++) {
+          if (indexShape[j] === 1) continue;
+          const updateDim = firstUpdateDim + j;
+          const updateCoord =
+            Math.floor(i / updateStrides[updateDim]) % updateShape[updateDim];
+          indexOffset += updateCoord * indexStrides[indexInput][j];
+        }
+        coord = indices[indexInput][indexOffset];
+      }
+      if (coord < 0 || coord >= outputShape[outputAxis]) {
+        valid = false;
+        break;
+      }
+      outputIndex += coord * outputStrides[outputAxis];
+    }
+    if (!valid) continue;
+
+    if (accumulate && type.inputDtypes[0] === DType.Bool) {
+      output[outputIndex] |= updates[i];
+    } else if (accumulate) {
+      output[outputIndex] += updates[i];
+    } else {
+      output[outputIndex] = updates[i];
+    }
   }
 }
 

--- a/test/numpy.test.ts
+++ b/test/numpy.test.ts
@@ -2767,12 +2767,28 @@ suite.each(devices)("device:%s", (device) => {
         ]);
       });
 
-      // Won't work until scatter is implemented.
-      test.fails("works with grad", () => {
+      test("works with grad", () => {
         const x = np.array([3, 1, 4, 2]);
         const f = (x: np.Array) => np.sort(x).slice([0, 2]).sum();
         const dx = grad(f)(x);
         expect(dx.js()).toEqual([0, 1, 0, 1]);
+      });
+
+      test("works with grad for batched inputs", () => {
+        const weights = np.array([
+          [10, 20, 30],
+          [40, 50, 60],
+        ]);
+        const dx = grad((x: np.Array) => np.sort(x, 1).mul(weights).sum())(
+          np.array([
+            [3, 1, 2],
+            [4, 6, 5],
+          ]),
+        );
+        expect(dx.js()).toEqual([
+          [30, 10, 20],
+          [40, 60, 50],
+        ]);
       });
 
       test("works inside a jit function", () => {
@@ -2894,6 +2910,87 @@ suite.each(devices)("device:%s", (device) => {
         [90, 70],
       ]);
     });
+
+    if (device !== "webgl") {
+      test("works with grad and repeated indices", () => {
+        const x = np.arange(10).astype(np.float32).reshape([5, 2]);
+        const indices = np.array([3, 0, 3, 1], { dtype: np.int32 });
+        const dx = grad((x: np.Array) => np.take(x, indices, 0).sum())(x);
+        expect(dx).toBeAllclose([
+          [1, 1],
+          [1, 1],
+          [0, 0],
+          [2, 2],
+          [0, 0],
+        ]);
+      });
+
+      test("works with grad inside jit", () => {
+        const f = jit(
+          grad((x: np.Array) =>
+            np
+              .take(x, np.array([3, 1, 3], { dtype: np.int32 }), 0)
+              .mul(2)
+              .sum(),
+          ),
+        );
+        const dx = f(np.zeros([5, 2]));
+        expect(dx).toBeAllclose([
+          [0, 0],
+          [2, 2],
+          [0, 0],
+          [4, 4],
+          [0, 0],
+        ]);
+      });
+
+      test("vmaps gradients with mapped indices", () => {
+        const f = vmap(
+          grad((x: np.Array, indices: np.Array) => np.take(x, indices).sum()),
+          [0, 0],
+        );
+        const dx = f(
+          np.ones([2, 5]),
+          np.array(
+            [
+              [0, 0, 2],
+              [1, 3, 3],
+            ],
+            { dtype: np.int32 },
+          ),
+        );
+        expect(dx).toBeAllclose([
+          [2, 0, 1, 0, 0],
+          [0, 1, 0, 2, 0],
+        ]);
+      });
+
+      test("vmaps gradients with shared indices", () => {
+        const indices = np.array([0, 0, 2], { dtype: np.int32 });
+        const f = vmap(
+          grad((x: np.Array) => np.take(x, indices).sum()),
+          0,
+        );
+        const dx = f(np.ones([2, 5]));
+        expect(dx).toBeAllclose([
+          [2, 0, 1, 0, 0],
+          [2, 0, 1, 0, 0],
+        ]);
+      });
+
+      if (device === "cpu" || device === "webgpu") {
+        test("supports float16 gradients", () => {
+          const indices = np.array([1, 1, 3], { dtype: np.int32 });
+          const dx = grad((x: np.Array) =>
+            np
+              .take(x, indices)
+              .mul(np.array([0.5, 1.25, 2], { dtype: np.float16 }))
+              .sum(),
+          )(np.zeros([4], { dtype: np.float16 }));
+          expect(dx).toBeAllclose([0, 1.75, 0, 2]);
+        });
+      }
+    }
   });
 
   suite("jax.numpy.append()", () => {
@@ -2987,6 +3084,25 @@ suite.each(devices)("device:%s", (device) => {
       const y = np.takeAlongAxis(x, indices);
       expect(y.js()).toEqual([[20], [40]]);
     });
+
+    if (device !== "webgl") {
+      test("works with grad and repeated indices", () => {
+        const indices = np.array(
+          [
+            [2, 0],
+            [1, 1],
+          ],
+          { dtype: np.int32 },
+        );
+        const dx = grad((x: np.Array) => np.takeAlongAxis(x, indices, 1).sum())(
+          np.zeros([2, 3]),
+        );
+        expect(dx).toBeAllclose([
+          [1, 0, 1],
+          [0, 2, 0],
+        ]);
+      });
+    }
 
     test("rejects rank mismatches", () => {
       expect(() => np.takeAlongAxis(np.ones([2, 3]), np.ones([2]), 1)).toThrow(


### PR DESCRIPTION
We don't implement the full `jax.lax.scatter()` API yet as it's complicated with dimension numbers, but this is enough to implement grad / backward rules for all gather operations.

Resolves #79 