### PR TITLE
Fix Wasm memory allocator capping at 2 GiB

### DIFF
--- a/src/backend/wasm/allocator.test.ts
+++ b/src/backend/wasm/allocator.test.ts
@@ -1,0 +1,83 @@
+import { expect, test } from "vitest";
+
+import { WasmAllocator } from "./allocator";
+
+const WASM_PAGE_SIZE = 65536;
+const MAX_MEMORY32_PAGES = 65536;
+
+function createMockMemory(): {
+  memory: WebAssembly.Memory;
+  growDeltas: number[];
+} {
+  let byteLength = 0;
+  const growDeltas: number[] = [];
+  const memory = {
+    get buffer() {
+      return { byteLength };
+    },
+    grow(delta: number) {
+      if (!Number.isInteger(delta) || delta < 0) {
+        throw new TypeError("Memory growth must be a non-negative integer");
+      }
+
+      const previousPages = byteLength / WASM_PAGE_SIZE;
+      if (previousPages + delta > MAX_MEMORY32_PAGES) {
+        throw new RangeError("Memory growth exceeds the memory32 limit");
+      }
+
+      growDeltas.push(delta);
+      byteLength += delta * WASM_PAGE_SIZE;
+      return previousPages;
+    },
+  } as unknown as WebAssembly.Memory;
+
+  return { memory, growDeltas };
+}
+
+test("grows across the signed 32-bit boundary", () => {
+  const { memory, growDeltas } = createMockMemory();
+  const allocator = new WasmAllocator(memory);
+  const gibibyte = 2 ** 30;
+
+  expect(allocator.malloc(gibibyte)).toBe(64);
+  expect(allocator.malloc(gibibyte)).toBe(gibibyte + 64);
+
+  expect(allocator.getStats().totalAllocated).toBe(2 ** 31 + 64);
+  expect(memory.buffer.byteLength).toBe(2 ** 31 + WASM_PAGE_SIZE);
+  expect(growDeltas.every((delta) => delta > 0)).toBe(true);
+});
+
+test("supports a single allocation of 2 GiB", () => {
+  const { memory } = createMockMemory();
+  const allocator = new WasmAllocator(memory);
+
+  expect(allocator.malloc(2 ** 31)).toBe(64);
+  expect(allocator.getStats().totalAllocated).toBe(2 ** 31 + 64);
+  expect(memory.buffer.byteLength).toBe(2 ** 31 + WASM_PAGE_SIZE);
+});
+
+test("grows memory into the final memory32 page", () => {
+  const { memory, growDeltas } = createMockMemory();
+  const allocator = new WasmAllocator(memory);
+  const gibibyte = 2 ** 30;
+
+  allocator.malloc(gibibyte);
+  allocator.malloc(gibibyte);
+  allocator.malloc(gibibyte);
+  allocator.malloc(gibibyte - WASM_PAGE_SIZE);
+
+  expect(memory.buffer.byteLength).toBe(2 ** 32);
+  expect(growDeltas.at(-1)).toBe(16383);
+  expect(growDeltas.every((delta) => delta > 0)).toBe(true);
+});
+
+test("rejects allocations beyond the memory32 address space", () => {
+  const { memory } = createMockMemory();
+  const allocator = new WasmAllocator(memory);
+
+  expect(() => allocator.malloc(2 ** 32)).toThrow(
+    "Allocation exceeds the 4 GiB memory32 limit",
+  );
+  expect(allocator.getStats().totalAllocated).toBe(64);
+  expect(memory.buffer.byteLength).toBe(0);
+});

--- a/src/backend/wasm/allocator.ts
+++ b/src/backend/wasm/allocator.ts
@@ -1,3 +1,11 @@
+const ALLOCATION_ALIGNMENT = 64;
+const WASM_PAGE_SIZE = 65536;
+const MAX_MEMORY32_BYTES = 2 ** 32;
+
+function alignTo(size: number, alignment: number): number {
+  return Math.ceil(size / alignment) * alignment;
+}
+
 /** Simple tensor memory allocator for WebAssembly linear memory. */
 export class WasmAllocator {
   #memory: WebAssembly.Memory;
@@ -45,26 +53,31 @@ export class WasmAllocator {
 
   #bumpAlloc(size: number): number {
     const ptr = this.#headPtr;
-    size = (size + 63) & -64; // Align to 64 bytes, like Arrow.
-    this.#headPtr += size;
-    if (ptr + size > this.#memory.buffer.byteLength) {
-      // Note: 4 GiB = max memory32 size
-      // https://spidermonkey.dev/blog/2025/01/15/is-memory64-actually-worth-using.html
-      this.#memory.grow(
-        ((ptr + size + 65535) >> 16) - (this.#memory.buffer.byteLength >> 16),
-      );
+    const endPtr = ptr + alignTo(size, ALLOCATION_ALIGNMENT);
+    if (endPtr > MAX_MEMORY32_BYTES) {
+      throw new RangeError("Allocation exceeds the 4 GiB memory32 limit");
     }
+
+    const currentBytes = this.#memory.buffer.byteLength;
+    if (endPtr > currentBytes) {
+      const requiredPages = Math.ceil(endPtr / WASM_PAGE_SIZE);
+      const currentPages = currentBytes / WASM_PAGE_SIZE;
+      this.#memory.grow(requiredPages - currentPages);
+    }
+
+    // Only advance the allocator after memory growth succeeds.
+    this.#headPtr = endPtr;
     return ptr;
   }
 
   #findSizeClass(size: number): number {
     // Small sizes: 64-byte increments from 64 to 512.
     if (size <= 512) {
-      return (size + 63) & -64;
+      return alignTo(size, 64);
     }
     // Medium sizes: 768 (512+256), then 256-byte increments from 1024 to 2048.
     if (size <= 2048) {
-      return (size + 511) & -512;
+      return alignTo(size, 512);
     }
     // Large sizes: powers of 2 from 4 KiB to 64 KiB.
     if (size <= 65536) {
@@ -73,7 +86,7 @@ export class WasmAllocator {
       return sizeClass;
     }
     // Very large sizes: 64 KiB increments starting from 128 KiB.
-    return (size + 65535) & -65536;
+    return alignTo(size, WASM_PAGE_SIZE);
   }
 
   // Debug methods


### PR DESCRIPTION
Now it can use all 4 GiB of addressable memory32 that are available, without browser-specific extensions.

Right now, Safari does not support Memory64:

<img width="1317" height="837" alt="image" src="https://github.com/user-attachments/assets/223b1696-af8f-4430-8552-216aa43d379a" />
