### PR TITLE
Performance improvements for Wasm TTS

### DIFF
--- a/src/backend/wasm.ts
+++ b/src/backend/wasm.ts
@@ -23,10 +23,11 @@ interface WasmExecutableData {
 }
 
 interface WasmProgram {
+  kernelHash: string;
   module: WebAssembly.Module;
   workSize: number;
   chunkAlignment: number;
-  minWorkPerWorker: number;
+  minWorkPerWorker?: number;
 }
 
 const compiledProgramCache = new Map<string, WasmProgram>();
@@ -122,27 +123,25 @@ export class WasmBackend implements Backend {
   }
 
   async prepareKernel(kernel: Kernel): Promise<Executable<WasmExecutableData>> {
-    const kernelHash = FpHash.hash(kernel);
-    const hashKey = kernelHash.toString();
+    const kernelHash = FpHash.hash(kernel).toString();
     const program = await runWithCacheAsync(
       compiledProgramCache,
-      hashKey,
+      kernelHash,
       async () => {
         const { bytes, ...metadata } = codegenWasm(kernel);
         const module = await WebAssembly.compile(bytes);
-        return { module, ...metadata };
+        return { kernelHash, module, ...metadata };
       },
     );
     return new Executable(kernel, { program, sync: false });
   }
 
   prepareKernelSync(kernel: Kernel): Executable<WasmExecutableData> {
-    const kernelHash = FpHash.hash(kernel);
-    const hashKey = kernelHash.toString();
-    const compiled = runWithCache(compiledProgramCache, hashKey, () => {
+    const kernelHash = FpHash.hash(kernel).toString();
+    const compiled = runWithCache(compiledProgramCache, kernelHash, () => {
       const { bytes, ...metadata } = codegenWasm(kernel);
       const module = new WebAssembly.Module(bytes);
-      return { module, ...metadata };
+      return { kernelHash, module, ...metadata };
     });
     return new Executable(kernel, { program: compiled, sync: true });
   }
@@ -229,6 +228,7 @@ export class WasmBackend implements Backend {
         const retainedSlots = [...inputs, ...outputs];
         for (const slot of retainedSlots) this.incRef(slot);
         const epoch = this.#workerPool.dispatch(
+          program.kernelHash,
           program.module,
           ptrs,
           program.workSize,

--- a/src/backend/wasm/codegen.ts
+++ b/src/backend/wasm/codegen.ts
@@ -48,7 +48,7 @@ interface WasmCodegenResult {
   bytes: Uint8Array<ArrayBuffer>;
   workSize: number;
   chunkAlignment: number;
-  minWorkPerWorker: number;
+  minWorkPerWorker?: number;
 }
 
 type ReductionPointerPlan = ReductionPointerCandidate & SimdPointerPlan;
@@ -1035,6 +1035,6 @@ export function codegenWasm(kernel: Kernel): WasmCodegenResult {
     minWorkPerWorker:
       tiledPlan && kernel.size / tiledPlan.tileSize >= 1024
         ? tiledPlan.tileSize * 32
-        : 256,
+        : undefined,
   };
 }

--- a/src/backend/wasm/parallel.ts
+++ b/src/backend/wasm/parallel.ts
@@ -18,14 +18,32 @@ export function hasSharedArrayBuffer(): boolean {
   );
 }
 
-const MIN_ELEMS_PER_THREAD = 256;
+// A worker message has meaningful fixed overhead. Spreading smaller kernels
+// across more workers costs more than the extra parallelism saves.
+const MIN_ELEMS_PER_THREAD = 512;
+const MAX_CACHED_KERNELS_PER_WORKER = 256;
 
 const WORKER_SOURCE = `
 ${cpuRoutineJSForWorkers()}
 
 let memory = null;
-let cachedModule = null;
-let cachedFunc = null;
+
+const kernelLru = new Map();
+function kernelFunc(kernelHash, module) {
+  let func = kernelLru.get(kernelHash);
+  if (func !== undefined) {
+    kernelLru.delete(kernelHash);
+    kernelLru.set(kernelHash, func);
+    return func;
+  }
+  const instance = new WebAssembly.Instance(module, { env: { memory } });
+  func = instance.exports.kernel;
+  kernelLru.set(kernelHash, func);
+  if (kernelLru.size > ${MAX_CACHED_KERNELS_PER_WORKER}) {
+    kernelLru.delete(kernelLru.keys().next().value);
+  }
+  return func;
+}
 
 self.onmessage = (e) => {
   const msg = e.data;
@@ -36,13 +54,8 @@ self.onmessage = (e) => {
   }
   try {
     if (msg.type === "kernel") {
-      const { module, ptrs, begin, end } = msg;
-      if (module !== cachedModule) {
-        cachedModule = module;
-        const instance = new WebAssembly.Instance(module, { env: { memory } });
-        cachedFunc = instance.exports.kernel;
-      }
-      cachedFunc(...ptrs, begin, end);
+      const { kernelHash, module, ptrs, begin, end } = msg;
+      kernelFunc(kernelHash, module)(...ptrs, begin, end);
     } else if (msg.type === "routine") {
       const inputs = msg.inputs.map(({ ptr, size }) =>
         new Uint8Array(memory.buffer, ptr, size)
@@ -134,6 +147,7 @@ export class WasmWorkerPool {
    * which is guaranteed to be monotonically increasing.
    */
   dispatch(
+    kernelHash: string,
     module: WebAssembly.Module,
     ptrs: number[],
     size: number,
@@ -141,7 +155,14 @@ export class WasmWorkerPool {
     minWorkPerWorker: number = MIN_ELEMS_PER_THREAD,
   ): bigint {
     return this.#enqueue(() =>
-      this.#dispatchNow(module, ptrs, size, chunkAlignment, minWorkPerWorker),
+      this.#dispatchNow(
+        kernelHash,
+        module,
+        ptrs,
+        size,
+        chunkAlignment,
+        minWorkPerWorker,
+      ),
     );
   }
 
@@ -182,6 +203,7 @@ export class WasmWorkerPool {
   }
 
   async #dispatchNow(
+    kernelHash: string,
     module: WebAssembly.Module,
     ptrs: number[],
     size: number,
@@ -206,7 +228,14 @@ export class WasmWorkerPool {
             if (e.data.ok) resolve();
             else reject(new Error(`Worker error: ${e.data.error}`));
           };
-          worker.postMessage({ type: "kernel", module, ptrs, begin, end });
+          worker.postMessage({
+            type: "kernel",
+            kernelHash,
+            module,
+            ptrs,
+            begin,
+            end,
+          });
         }),
       );
     }

--- a/src/frontend/jit.ts
+++ b/src/frontend/jit.ts
@@ -900,7 +900,7 @@ function splitGraphDataflow(backend: Backend, jaxpr: Jaxpr): Set<Var> {
     Primitive.Shrink,
     Primitive.Pad,
   ];
-  const materializeForReusedReduction = new Set<Var>();
+  const materializedProducers = new Set<Var>();
   const reductionInputHasReuse = (
     shape: number[],
     promoted: number[],
@@ -923,7 +923,7 @@ function splitGraphDataflow(backend: Backend, jaxpr: Jaxpr): Set<Var> {
       if (!input) return;
       current = input;
     }
-    materializeForReusedReduction.add(current);
+    materializedProducers.add(current);
   };
   for (const eqn of jaxpr.eqns) {
     let inputShapes: [number[], number[]] | null = null;
@@ -987,13 +987,23 @@ function splitGraphDataflow(backend: Backend, jaxpr: Jaxpr): Set<Var> {
     // effect is to pad the intermediate with 1s instead of 0s!
     Primitive.Pad,
   ];
+  for (const eqn of jaxpr.eqns) {
+    if (
+      needsCleanShapePrimitives.includes(eqn.primitive) ||
+      routinePrimitives.has(eqn.primitive)
+    ) {
+      for (const input of eqn.inputs) {
+        if (input instanceof Var) markNonViewProducer(input);
+      }
+    }
+  }
   for (let i = jaxpr.eqns.length - 1; i >= 0; i--) {
     const eqn = jaxpr.eqns[i];
     if (
       reductionEndpointEqns.has(i) ||
       heterogeneousViewPrimitives.includes(eqn.primitive) ||
       routinePrimitives.has(eqn.primitive) ||
-      eqn.outBinders.some((v) => materializeForReusedReduction.has(v)) ||
+      eqn.outBinders.some((v) => materializedProducers.has(v)) ||
       eqn.outBinders.some((v) => blackNodes.has(v))
     ) {
       for (const v of eqn.outBinders) {
@@ -1003,23 +1013,15 @@ function splitGraphDataflow(backend: Backend, jaxpr: Jaxpr): Set<Var> {
       continue;
     }
     const reach = new Set<Var>();
-    let needsCleanOutput = false;
-    outer: for (const v of eqn.outBinders) {
+    for (const v of eqn.outBinders) {
       for (const j of varToUsages.get(v) ?? []) {
-        if (
-          needsCleanShapePrimitives.includes(jaxpr.eqns[j].primitive) ||
-          routinePrimitives.has(jaxpr.eqns[j].primitive)
-        ) {
-          needsCleanOutput = true;
-          break outer;
-        }
         for (const o of jaxpr.eqns[j].outBinders) {
           const u = p1NextBlack.get(o);
           if (u) reach.add(u);
         }
       }
     }
-    if (reach.size > 1 || needsCleanOutput) {
+    if (reach.size > 1) {
       for (const v of eqn.outBinders) {
         blackNodes.add(v);
         p1NextBlack.set(v, v);

--- a/src/library/lax.ts
+++ b/src/library/lax.ts
@@ -7,6 +7,7 @@ const JsArray = globalThis.Array;
 
 import { DType } from "../alu";
 import { Array, ArrayLike, fudgeArray, zerosLike } from "../frontend/array";
+import { checkConvShape } from "../frontend/convolution";
 import * as core from "../frontend/core";
 import { bind1, Primitive } from "../frontend/core";
 import { moveaxis, vmap } from "../frontend/vmap";
@@ -164,6 +165,103 @@ function padtypeToPads(
 }
 
 /**
+ * Lower a supported 1D ConvTranspose into a dense channel contraction and
+ * stride-phase overlap-add. Returns null to use the generic Conv otherwise.
+ *
+ * This is a specialized fast path for transposed convolutions.
+ */
+function lowerConvTranspose1d(
+  lhs: Array,
+  rhs: Array,
+  windowStrides: number[],
+  padding: Pair[],
+  lhsDilation: number[],
+  rhsDilation: number[],
+): Array | null {
+  if (
+    lhs.ndim !== 3 ||
+    rhs.ndim !== 3 ||
+    windowStrides.length !== 1 ||
+    windowStrides[0] !== 1 ||
+    lhsDilation.length !== 1 ||
+    lhsDilation[0] <= 1 ||
+    rhsDilation.length !== 1 ||
+    rhsDilation[0] !== 1 ||
+    padding.length !== 1 ||
+    padding[0][0] < 0 ||
+    padding[0][1] < 0 ||
+    lhs.shape.some((size) => size <= 0) ||
+    rhs.shape.some((size) => size <= 0)
+  ) {
+    return null;
+  }
+
+  const outputShape = checkConvShape(lhs.shape, rhs.shape, {
+    vmapDims: 0,
+    strides: windowStrides,
+    padding,
+    lhsDilation,
+    rhsDilation,
+  });
+  if (outputShape.some((size) => size <= 0)) return null;
+
+  const [batchSize, inputChannels, inputLength] = lhs.shape;
+  const [outputChannels, , kernelSize] = rhs.shape;
+  const stride = lhsDilation[0];
+  const contributionCount = Math.ceil(kernelSize / stride);
+  if (contributionCount > 8) return null;
+
+  // Produce [N, C_out, kernel, input] without materializing input dilation.
+  lhs = lhs
+    .transpose([0, 2, 1])
+    .reshape([batchSize, 1, 1, inputLength, inputChannels]);
+  rhs = rhs
+    .transpose([0, 2, 1])
+    .reshape([1, outputChannels, kernelSize, 1, inputChannels]);
+  let columns = core.dot(lhs, rhs) as Array;
+
+  // Split the reversed kernel into [contribution, stride phase].
+  columns = core.flip(columns.transpose([0, 1, 3, 2]), [3]) as Array;
+  columns = core.pad(columns, {
+    3: [0, contributionCount * stride - kernelSize],
+  }) as Array;
+  columns = columns.reshape([
+    batchSize,
+    outputChannels,
+    inputLength,
+    contributionCount,
+    stride,
+  ]);
+
+  // Shift each contribution by one input block and sum the overlaps.
+  const terms = core
+    .split(columns, 3, rep(contributionCount, 1))
+    .map((term, index) => {
+      term = term.reshape([batchSize, outputChannels, inputLength, stride]);
+      return core.pad(term, {
+        2: [index, contributionCount - 1 - index],
+      }) as Array;
+    });
+  let output = terms
+    .reduce((lhs, rhs) => lhs.add(rhs))
+    .reshape([batchSize, outputChannels, -1]);
+
+  // Remove phase padding, then select the convolution's requested range.
+  const fullLength = (inputLength - 1) * stride + kernelSize;
+  output = output.slice([], [], [0, fullLength]);
+  const outputLength = outputShape[2];
+  const offset = kernelSize - 1 - padding[0][0];
+  const padLeft = Math.max(0, -offset);
+  const padRight = Math.max(0, offset + outputLength - fullLength);
+  output = core.pad(output, { 2: [padLeft, padRight] }) as Array;
+  return output.slice(
+    [],
+    [],
+    [offset + padLeft, offset + padLeft + outputLength],
+  );
+}
+
+/**
  * General n-dimensional convolution operator, with optional dilation.
  *
  * The semantics of this operation mimic the `jax.lax.conv_general_dilated`
@@ -205,6 +303,19 @@ export function convGeneralDilated(
       rhsDilation ?? rep(rhs.ndim - 2, 1),
       padding,
     );
+  }
+  if (featureGroupCount === 1) {
+    // Fast path for handling common transposed convolutions.
+    const spatialDims = lhs.ndim - 2;
+    const lowered = lowerConvTranspose1d(
+      lhs,
+      rhs,
+      windowStrides,
+      padding,
+      lhsDilation ?? rep(spatialDims, 1),
+      rhsDilation ?? rep(spatialDims, 1),
+    );
+    if (lowered !== null) return lowered;
   }
   if (featureGroupCount !== 1) {
     // We implement grouped convolutions by using leading vmapDims in the

--- a/test/conv.test.ts
+++ b/test/conv.test.ts
@@ -7,6 +7,7 @@ import {
   init,
   jit,
   lax,
+  makeJaxpr,
   numpy as np,
   vmap,
 } from "@jax-js/jax";
@@ -66,6 +67,188 @@ suite.each(devices)("device:%s", (device) => {
     const result = convFn(x, y);
     expect(result.js()).toEqual([[[-1.5, 0, 1.5, 3, 10.5]]]);
   });
+
+  test("lax ConvTranspose lowers to ordinary primitives", () => {
+    const fn = (x: np.Array, kernel: np.Array) =>
+      lax.convGeneralDilated(x, kernel, [1], [[2, 2]], {
+        lhsDilation: [2],
+      });
+    const x = np.array([[[1, 2, 3]]]);
+    const kernel = np.array([[[1, 10, 100]]]);
+
+    const eager = fn(x.ref, kernel.ref);
+    expect(eager.js()).toEqual([[[100, 10, 201, 20, 302, 30, 3]]]);
+
+    const { jaxpr } = makeJaxpr(fn)(x.ref, kernel.ref);
+    const loweredPrimitives = jaxpr.jaxpr.eqns.map((eqn) => eqn.primitive);
+    expect(loweredPrimitives).not.toContain("conv");
+    expect(loweredPrimitives).toContain("dot");
+    expect(loweredPrimitives).toContain("shrink");
+    expect(loweredPrimitives).toContain("add");
+    jaxpr.dispose();
+
+    const compiled = jit(fn);
+    const actual = compiled(x, kernel);
+    expect(actual.js()).toEqual([[[100, 10, 201, 20, 302, 30, 3]]]);
+    compiled.dispose();
+  });
+
+  test.each([
+    { dilation: 2, padding: [[2, 1]] },
+    { dilation: 3, padding: [[0, 2]] },
+    { dilation: 2, padding: [[-1, 2]] },
+  ])(
+    "jit ConvTranspose lowering: dilation=$dilation padding=$padding",
+    ({ dilation, padding }) => {
+      const convTransposeFn = jit((a: np.Array, b: np.Array) =>
+        lax.convGeneralDilated(a, b, [1], padding as [[number, number]], {
+          lhsDilation: [dilation],
+        }),
+      );
+      const x = np
+        .array([
+          [
+            [1, 2, 3, 4],
+            [5, 6, 7, 8],
+          ],
+          [
+            [2, 4, 6, 8],
+            [1, 3, 5, 7],
+          ],
+        ])
+        .reshape([2, 2, 4]);
+      const kernel = np
+        .array([
+          [
+            [1, 0, -1],
+            [2, 1, 0],
+          ],
+          [
+            [0, 1, 2],
+            [-1, 0, 1],
+          ],
+          [
+            [2, -1, 1],
+            [1, 1, -2],
+          ],
+        ])
+        .reshape([3, 2, 3]);
+
+      const expected = lax.convGeneralDilated(
+        x.ref,
+        kernel.ref,
+        [1],
+        padding as [[number, number]],
+        { lhsDilation: [dilation] },
+      );
+      const actual = convTransposeFn(x, kernel);
+      expect(actual).toBeAllclose(expected);
+    },
+  );
+
+  test("jit ConvTranspose result supports downstream operations", () => {
+    const postprocess = (x: np.Array, kernel: np.Array) => {
+      const y = lax
+        .convGeneralDilated(x, kernel, [1], [[2, 1]], {
+          lhsDilation: [2],
+        })
+        .add(1);
+      return np.split(y, [3], 2);
+    };
+    const compiled = jit(postprocess);
+    const x = np.array([
+      [
+        [1, 2, 3],
+        [4, 5, 6],
+      ],
+    ]);
+    const kernel = np.array([
+      [
+        [1, 0, -1],
+        [2, 1, 0],
+      ],
+      [
+        [0, 1, 2],
+        [-1, 0, 1],
+      ],
+    ]);
+
+    const expected = postprocess(x.ref, kernel.ref);
+    const actual = compiled(x, kernel);
+    expect(actual[0]).toBeAllclose(expected[0]);
+    expect(actual[1]).toBeAllclose(expected[1]);
+  });
+
+  test("jit ConvTranspose lowering preserves integer dtype", () => {
+    const convTransposeFn = jit((a: np.Array, b: np.Array) =>
+      lax.convGeneralDilated(a, b, [1], [[2, 1]], {
+        lhsDilation: [2],
+      }),
+    );
+    const x = np.array(
+      [
+        [
+          [1, 2, 3],
+          [4, 5, 6],
+        ],
+      ],
+      { dtype: np.int32 },
+    );
+    const kernel = np.array(
+      [
+        [
+          [1, 0, -1],
+          [2, 1, 0],
+        ],
+        [
+          [0, 1, 2],
+          [-1, 0, 1],
+        ],
+      ],
+      { dtype: np.int32 },
+    );
+
+    const expected = lax.convGeneralDilated(x.ref, kernel.ref, [1], [[2, 1]], {
+      lhsDilation: [2],
+    });
+    const actual = convTransposeFn(x, kernel);
+    expect(actual.dtype).toBe(np.int32);
+    expect(actual.js()).toEqual(expected.js());
+  });
+
+  test.each([
+    {
+      name: "kernel larger than twice the stride",
+      dilation: 2,
+      padding: [[4, 3]] as [[number, number]],
+      kernel: [[[1, -1, 2, 0, 3]]],
+    },
+    {
+      name: "kernel smaller than the stride",
+      dilation: 4,
+      padding: [[1, 2]] as [[number, number]],
+      kernel: [[[2, -1]]],
+    },
+  ])(
+    "jit ConvTranspose lowering supports $name",
+    ({ dilation, padding, kernel: kernelValues }) => {
+      const convTransposeFn = jit((a: np.Array, b: np.Array) =>
+        lax.convGeneralDilated(a, b, [1], padding, {
+          lhsDilation: [dilation],
+        }),
+      );
+      const x = np.array([[[1, 2, 3, 4]]]);
+      const kernel = np
+        .array(kernelValues)
+        .reshape([1, 1, kernelValues[0][0].length]);
+
+      const expected = lax.convGeneralDilated(x.ref, kernel.ref, [1], padding, {
+        lhsDilation: [dilation],
+      });
+      const actual = convTransposeFn(x, kernel);
+      expect(actual).toBeAllclose(expected);
+    },
+  );
 
   test("0d convolution", () => {
     const x = np.array([

--- a/test/dtype-f16.test.ts
+++ b/test/dtype-f16.test.ts
@@ -6,6 +6,7 @@ import {
   init,
   jit,
   jvp,
+  lax,
   nn,
   numpy as np,
 } from "@jax-js/jax";
@@ -80,5 +81,42 @@ suite.each(devices)("device:%s", (device) => {
     y = np.sum(x);
     expect(y.dtype).toBe(np.float16);
     expect(y.dataSync()).toEqual(new Float16Array([16008]));
+  });
+
+  test("jit ConvTranspose lowering supports f16", () => {
+    const convTransposeFn = jit((x: np.Array, kernel: np.Array) =>
+      lax.convGeneralDilated(x, kernel, [1], [[2, 1]], {
+        lhsDilation: [2],
+      }),
+    );
+    const x = np.array(
+      [
+        [
+          [1, 2, 3],
+          [4, 5, 6],
+        ],
+      ],
+      { dtype: np.float16 },
+    );
+    const kernel = np.array(
+      [
+        [
+          [1, 0, -1],
+          [2, 1, 0],
+        ],
+        [
+          [0, 1, 2],
+          [-1, 0, 1],
+        ],
+      ],
+      { dtype: np.float16 },
+    );
+
+    const expected = lax.convGeneralDilated(x.ref, kernel.ref, [1], [[2, 1]], {
+      lhsDilation: [2],
+    });
+    const actual = convTransposeFn(x, kernel);
+    expect(actual.dtype).toBe(np.float16);
+    expect(actual).toBeAllclose(expected, { rtol: 1e-3, atol: 1e-3 });
   });
 });

--- a/website/src/routes/tts/+page.svelte
+++ b/website/src/routes/tts/+page.svelte
@@ -2,15 +2,25 @@
   import { defaultDevice, init, numpy as np, tree } from "@jax-js/jax";
   import { cachedFetch, safetensors, tokenizers } from "@jax-js/loaders";
   import { AudioLinesIcon, DownloadIcon, GithubIcon } from "@lucide/svelte";
+  import { onMount } from "svelte";
 
   import DownloadManager from "$lib/common/DownloadManager.svelte";
   import { createStreamingPlayer } from "./audio";
-  import { playTTS } from "./inference";
+  import { playTTS, type TTSSamplingProgress } from "./inference";
   import { fromSafetensors, type PocketTTS } from "./pocket-tts";
+
+  type TTSBackend = "webgpu" | "wasm";
+
+  const BACKEND_LABEL: Record<TTSBackend, string> = {
+    webgpu: "WebGPU",
+    wasm: "Wasm",
+  };
+  const TTS_BACKENDS: TTSBackend[] = ["webgpu", "wasm"];
 
   // Cached large objects to download.
   let _weights: safetensors.File | null = null;
-  let _model: any | null = null;
+  let _model: PocketTTS | null = null;
+  let _modelBackend: TTSBackend | null = null;
   let _tokenizer: any | null = null;
 
   let downloadManager: DownloadManager;
@@ -24,13 +34,69 @@
   let selectedVoice = $state("azelma");
   let playing = $state(false);
   let audioBlob = $state<Blob | null>(null);
+  let backend = $state<TTSBackend>("webgpu");
+  let availableBackends = $state<TTSBackend[]>([]);
+  let checkedBackends = $state(false);
+  let samplingProgress = $state<TTSSamplingProgress | null>(null);
 
   // Advanced options
   let seed = $state<number | null>(null);
   let temperature = $state(0.7);
   let lsdDecodeSteps = $state(1);
 
-  async function downloadClipWeights(): Promise<safetensors.File> {
+  onMount(() => {
+    void initializeBackendOptions().catch((error) => {
+      console.warn("Failed to initialize Pocket TTS backends", error);
+    });
+  });
+
+  async function initializeBackendOptions() {
+    const devices = await init(...TTS_BACKENDS);
+    availableBackends = TTS_BACKENDS.filter((device) =>
+      devices.includes(device),
+    );
+    checkedBackends = true;
+    if (availableBackends.length > 0 && !availableBackends.includes(backend)) {
+      backend = availableBackends.includes("webgpu") ? "webgpu" : "wasm";
+    }
+  }
+
+  function disposeModel() {
+    if (_model) tree.dispose(_model);
+    _model = null;
+    _modelBackend = null;
+    hasModel = false;
+  }
+
+  function handleBackendChange(event: Event) {
+    const nextBackend = (event.currentTarget as HTMLSelectElement)
+      .value as TTSBackend;
+    if (nextBackend === backend) return;
+    backend = nextBackend;
+    samplingProgress = null;
+    audioBlob = null;
+    disposeModel();
+  }
+
+  async function setupDevice() {
+    if (!checkedBackends) await initializeBackendOptions();
+
+    let selectedBackend = backend;
+    if (!availableBackends.includes(selectedBackend)) {
+      if (selectedBackend === "webgpu" && availableBackends.includes("wasm")) {
+        selectedBackend = "wasm";
+      } else {
+        throw new Error(
+          `${BACKEND_LABEL[selectedBackend]} is not available in this browser.`,
+        );
+      }
+    }
+
+    backend = selectedBackend;
+    defaultDevice(selectedBackend);
+  }
+
+  async function downloadModelWeights(): Promise<safetensors.File> {
     if (_weights) return _weights;
     isDownloadingWeights = true;
     try {
@@ -50,9 +116,12 @@
   }
 
   async function getModel(): Promise<PocketTTS> {
-    if (_model) return _model;
-    const weights = await downloadClipWeights();
-    _model = fromSafetensors(weights);
+    if (_model && _modelBackend === backend) return _model;
+    if (_model) disposeModel();
+    const weights = await downloadModelWeights();
+    const weightDtype = backend === "wasm" ? np.float32 : np.float16;
+    _model = fromSafetensors(weights, weightDtype);
+    _modelBackend = backend;
     hasModel = true;
     return _model;
   }
@@ -109,14 +178,7 @@
   }
 
   async function run() {
-    const devices = await init();
-    if (devices.includes("webgpu")) {
-      defaultDevice("webgpu");
-    } else {
-      alert("WebGPU not supported on this device, required for inference");
-      return;
-    }
-
+    await setupDevice();
     const model = await getModel();
     const tokenizer = await getTokenizer();
     console.log("Model:", model);
@@ -128,13 +190,14 @@
     const audioPrompt = safetensors.parse(
       await cachedFetch(predefinedVoices[selectedVoice]),
     ).tensors.audio_prompt;
+    const weightDtype = backend === "wasm" ? np.float32 : np.float16;
     const voiceEmbed = np
       .array(audioPrompt.data as Float32Array<ArrayBuffer>, {
         shape: audioPrompt.shape,
         dtype: np.float32,
       })
       .slice(0)
-      .astype(np.float16);
+      .astype(weightDtype);
 
     const tokensAr = np.array(tokens, { dtype: np.uint32 });
     let embeds = model.flowLM.conditionerEmbed.ref.slice(tokensAr); // [seq_len, 1024]
@@ -147,6 +210,9 @@
         seed,
         temperature,
         lsdDecodeSteps,
+        onProgress: (progress) => {
+          samplingProgress = progress;
+        },
       });
       audioBlob = player.toWav();
     } finally {
@@ -181,6 +247,7 @@
     onsubmit={async (event) => {
       event.preventDefault();
       audioBlob = null;
+      samplingProgress = null;
       playing = true;
       try {
         await run();
@@ -195,18 +262,51 @@
       placeholder="Enter your prompt here…"
       bind:value={prompt}></textarea>
 
-    <div class="flex gap-3 mt-1 h-9">
-      <select class="border-2 rounded p-1" bind:value={selectedVoice}>
-        {#each Object.keys(predefinedVoices) as voice}
-          <option value={voice}
-            >{voice.charAt(0).toLocaleUpperCase() + voice.slice(1)}</option
-          >
-        {/each}
-      </select>
+    <div class="flex flex-wrap items-end gap-3 mt-2">
+      <label class="text-xs text-gray-600">
+        Voice
+        <select
+          class="block mt-1 h-9 border-2 rounded px-2 text-base text-black"
+          bind:value={selectedVoice}
+          disabled={playing}
+        >
+          {#each Object.keys(predefinedVoices) as voice}
+            <option value={voice}
+              >{voice.charAt(0).toLocaleUpperCase() + voice.slice(1)}</option
+            >
+          {/each}
+        </select>
+      </label>
+
+      <label class="text-xs text-gray-600">
+        Backend
+        <select
+          class="block mt-1 h-9 border-2 rounded px-2 text-base text-black"
+          value={backend}
+          onchange={handleBackendChange}
+          disabled={playing ||
+            !checkedBackends ||
+            availableBackends.length === 0}
+        >
+          {#if checkedBackends && availableBackends.length > 0}
+            {#each availableBackends as device}
+              <option value={device}>{BACKEND_LABEL[device]}</option>
+            {/each}
+          {:else if checkedBackends}
+            <option>No supported backend</option>
+          {:else}
+            <option value={backend}>Initializing…</option>
+          {/if}
+        </select>
+      </label>
+
       <button
-        class="btn"
+        class="btn h-9"
         type="submit"
-        disabled={playing || prompt.trim() === ""}
+        disabled={playing ||
+          prompt.trim() === "" ||
+          !checkedBackends ||
+          availableBackends.length === 0}
       >
         {#if playing}
           <AudioLinesIcon size={20} class="animate-pulse" />
@@ -217,7 +317,7 @@
 
       {#if audioBlob}
         <a
-          class="btn"
+          class="btn h-9"
           href={URL.createObjectURL(audioBlob)}
           download="tts_output.wav"
         >
@@ -226,11 +326,30 @@
       {/if}
     </div>
 
+    <div
+      class="mt-3 min-h-6 text-sm text-gray-600 tabular-nums"
+      aria-live="polite"
+    >
+      {#if playing && !samplingProgress}
+        Warming up {BACKEND_LABEL[backend]}…
+      {:else if samplingProgress}
+        {playing ? "Sampling" : "Completed"} · RTF {samplingProgress.realTimeFactor.toFixed(
+          2,
+        )}× · {samplingProgress.framesPerSecond.toFixed(1)} frame/s ·
+        {samplingProgress.framesGenerated} frames
+      {/if}
+    </div>
+
     <details class="mt-8 max-w-md">
       <summary class="cursor-pointer text-gray-600 hover:text-gray-800"
         >Advanced options</summary
       >
       <div class="mt-3 space-y-4 pl-2">
+        <p class="text-xs text-gray-500">
+          WebGPU runs on fp16 activations; Wasm uses fp32. Performance metrics
+          average the latest 10 frames. RTF is real-time factor: 12.5 FPS.
+        </p>
+
         <div>
           <label class="block text-sm text-gray-700">
             Seed

--- a/website/src/routes/tts/inference.ts
+++ b/website/src/routes/tts/inference.ts
@@ -9,12 +9,20 @@ import {
   runMimiDecode,
 } from "./pocket-tts";
 
+export interface TTSSamplingProgress {
+  framesGenerated: number;
+  elapsedMs: number;
+  framesPerSecond: number;
+  realTimeFactor: number;
+}
+
 export interface PlayTTSOptions {
   framesAfterEos: number;
   seed: number | null;
   lsdDecodeSteps: number;
   temperature: number;
   noiseClamp: number | null;
+  onProgress: (progress: TTSSamplingProgress) => void;
 }
 
 export async function playTTS(
@@ -27,6 +35,7 @@ export async function playTTS(
     lsdDecodeSteps = 1,
     temperature = 0.7,
     noiseClamp = null,
+    onProgress,
   }: Partial<PlayTTSOptions> = {},
 ): Promise<void> {
   let lastLatent = model.flowLM.bosEmb.ref.reshape([1, -1]); // [1, 32]
@@ -42,6 +51,10 @@ export async function playTTS(
 
     console.log("Starting TTS generation...");
     let lastTimestamp = performance.now();
+    const samplingStart = lastTimestamp;
+    let lastFrameTimestamp = samplingStart;
+    const recentFrameDurationsMs: number[] = [];
+    let framesGenerated = 0;
 
     for (let step = 0; step < 1000; step++) {
       let stepKey: np.Array;
@@ -108,6 +121,25 @@ export async function playTTS(
             `expected 1920 audio samples, got ${audioPcm.length}`,
           );
         }
+
+        // Update progress metrics for audio playback.
+        framesGenerated++;
+        const frameTimestamp = performance.now();
+        recentFrameDurationsMs.push(frameTimestamp - lastFrameTimestamp);
+        lastFrameTimestamp = frameTimestamp;
+        if (recentFrameDurationsMs.length > 10) recentFrameDurationsMs.shift();
+        const windowElapsedSeconds =
+          recentFrameDurationsMs.reduce((sum, duration) => sum + duration, 0) /
+          1000;
+        const framesPerSecond =
+          recentFrameDurationsMs.length / windowElapsedSeconds;
+        onProgress?.({
+          framesGenerated,
+          elapsedMs: frameTimestamp - samplingStart,
+          framesPerSecond,
+          realTimeFactor: framesPerSecond / 12.5,
+        });
+
         await lastAudioPromise;
         await player.playChunk(audioPcm);
       })();

--- a/website/src/routes/tts/pocket-tts.ts
+++ b/website/src/routes/tts/pocket-tts.ts
@@ -8,10 +8,10 @@ export type KVCache = {
   value: np.Array; // [T_cache, H, D]
 };
 
-export function emptyKVCache(): KVCache {
+export function emptyKVCache(dtype: np.DType = np.float32): KVCache {
   return {
-    key: np.zeros([0], { dtype: np.float16 }),
-    value: np.zeros([0], { dtype: np.float16 }),
+    key: np.zeros([0], { dtype }),
+    value: np.zeros([0], { dtype }),
   };
 }
 
@@ -40,7 +40,7 @@ export type FlowLMState = {
 
 export function createFlowLMState(model: FlowLMModel): FlowLMState {
   return {
-    kvCaches: model.transformer.map(() => emptyKVCache()),
+    kvCaches: model.transformer.map(() => emptyKVCache(model.bosEmb.dtype)),
     kvCacheLen: 0,
   };
 }
@@ -117,7 +117,7 @@ export function runFlowLMStep(
 
   const noiseShape = [1, ldim]; // [T, ldim] with T=1
   const std = Math.sqrt(temperature);
-  let noise = random.normal(key, noiseShape).mul(std);
+  let noise = random.normal(key, noiseShape).astype(sequence.dtype).mul(std);
   if (noiseClamp !== null) {
     // Truncated normal - clamp to [-noiseClamp, noiseClamp]
     noise = np.clip(noise, -noiseClamp, noiseClamp);
@@ -579,7 +579,7 @@ export function runMimiEncode(
   x = x.transpose([1, 0]); // [C, T] -> [T, C]
   const offset = np.array(0, { dtype: np.int32, device: x.device });
   for (const layer of encoderTransformer) {
-    let kvCache = emptyKVCache();
+    let kvCache = emptyKVCache(x.dtype);
     [x, kvCache] = runStreamingTransformerLayer(
       layer,
       kvCache,
@@ -617,7 +617,9 @@ export type SEANetDecoderState = {
 
 export function createMimiDecodeState(mimi: MimiModel): MimiDecodeState {
   return {
-    kvCaches: mimi.decoderTransformer.map(() => emptyKVCache()),
+    kvCaches: mimi.decoderTransformer.map((block) =>
+      emptyKVCache(block.selfAttn.inProj.weight.dtype),
+    ),
     kvCacheLen: 0,
     offset: 0,
     initialConvState: createConvTranspose1dState(mimi.upsample.convtr, 16, 512),
@@ -722,8 +724,12 @@ export function lsdDecode(
   for (let i = 0; i < numSteps; i++) {
     const s = i / numSteps;
     const t = (i + 1) / numSteps;
-    const sArr = np.full(x0.shape.slice(0, -1).concat([1]), s);
-    const tArr = np.full(x0.shape.slice(0, -1).concat([1]), t);
+    const sArr = np.full(x0.shape.slice(0, -1).concat([1]), s, {
+      dtype: x0.dtype,
+    });
+    const tArr = np.full(x0.shape.slice(0, -1).concat([1]), t, {
+      dtype: x0.dtype,
+    });
     const flowDir = flowNet(sArr, tArr, current.ref);
     current = current.add(flowDir.div(numSteps));
   }
@@ -860,7 +866,7 @@ export function createConv1dState(
       weight.shape[1], // in channels
       weight.shape[2] - stride, // kernel size - stride
     ],
-    { dtype: np.float16 },
+    { dtype: weight.dtype },
   );
 }
 
@@ -895,7 +901,7 @@ export function createConvTranspose1dState(
       weight.shape[1] * groups, // out channels
       weight.shape[2] - stride, // kernel size - stride
     ],
-    { dtype: np.float16 },
+    { dtype: weight.dtype },
   );
 }
 
@@ -965,15 +971,27 @@ const weightMapper = new WeightMapper({
   autoCamelCase: true,
 });
 
-export function fromSafetensors(file: safetensors.File): PocketTTS {
+export function fromSafetensors(
+  file: safetensors.File,
+  dtype: np.DType = np.float32,
+): PocketTTS {
   const mappedWeights = weightMapper.mapObject(file.tensors);
   const hydrated: Record<string, np.Array> = {};
   for (const [key, value] of Object.entries(mappedWeights)) {
     if (value.dtype === "F16") {
-      hydrated[key] = np.array(value.data as Float16Array<ArrayBuffer>, {
-        dtype: np.float16,
-        shape: value.shape,
-      });
+      if (dtype === np.float16) {
+        hydrated[key] = np.array(value.data as Float16Array<ArrayBuffer>, {
+          dtype,
+          shape: value.shape,
+        });
+      } else if (dtype === np.float32) {
+        hydrated[key] = np.array(
+          new Float32Array(value.data as Float16Array<ArrayBuffer>),
+          { dtype, shape: value.shape },
+        );
+      } else {
+        throw new Error(`Unsupported Pocket TTS dtype ${dtype}`);
+      }
     } else {
       throw new Error(`Unexpected dtype ${value.dtype} for weight ${key}`);
     }


### PR DESCRIPTION
- Improved Wasm backend performance by caching previously-sent modules on multithreaded web workers with LRU cache (10-30% faster, less gc jitter)
- Simplified the JIT compiler lowering logic for materialized input producers
- Added a new algorithm for the common case of transposed 1d convolutions, which was a bottleneck for the TTS demo and is now 30x faster on Wasm (also, 2x faster on WebGPU)

Finally, I added a backend picker to https://jax-js.com/tts - the kyutai pocket TTS demo. It runs in real-time on WebAssembly now, as well!