### PR TITLE
Add jax.numpy.arraySplit

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -146,7 +146,7 @@ Most operations behave the same way as they do in JAX.
 | `array_equal`         | 🟢      |                                         |
 | `array_equiv`         | 🟢      |                                         |
 | `array_repr`          | ⚪️      | string formatting                       |
-| `array_split`         | 🟠      | `split` is supported                    |
+| `array_split`         | 🟢      |                                         |
 | `array_str`           | ⚪️      | string formatting                       |
 | `asarray`             | ⚪️      | alias of `array`                        |
 | `asin`                | 🟢      |                                         |

--- a/src/library/numpy.ts
+++ b/src/library/numpy.ts
@@ -614,6 +614,11 @@ export function split(
   const size = a.shape[axis];
   let sizes: number[];
   if (typeof indicesOrSections === "number") {
+    if (!Number.isInteger(indicesOrSections) || indicesOrSections <= 0) {
+      throw new Error(
+        `split: sections must be a positive integer, got ${indicesOrSections}`,
+      );
+    }
     if (size % indicesOrSections !== 0) {
       throw new Error(
         `Array of size ${size} cannot be split into ${indicesOrSections} equal parts`,
@@ -623,11 +628,45 @@ export function split(
     sizes = rep(indicesOrSections, partSize);
   } else {
     const indices = indicesOrSections.map((i) => (i < 0 ? i + size : i));
-    sizes = [indices[0]];
-    for (let i = 1; i < indices.length; i++)
-      sizes.push(indices[i] - indices[i - 1]);
-    sizes.push(size - indices[indices.length - 1]);
+    const bounds = [0, ...indices, size];
+    sizes = range(bounds.length - 1).map((i) => bounds[i + 1] - bounds[i]);
   }
+  return splitBySizes(a, sizes, axis);
+}
+
+/**
+ * Split an array into multiple sub-arrays, allowing unevenly sized sections.
+ *
+ * If the axis does not divide evenly, the first sections are one element
+ * larger than the remaining sections.
+ */
+export function arraySplit(
+  a: ArrayLike,
+  indicesOrSections: number | number[],
+  axis: number = 0,
+): Array[] {
+  a = fudgeArray(a);
+  axis = checkAxis(axis, a.ndim);
+  if (typeof indicesOrSections !== "number") {
+    return split(a, indicesOrSections, axis);
+  }
+  if (!Number.isInteger(indicesOrSections) || indicesOrSections <= 0) {
+    throw new Error(
+      `arraySplit: sections must be a positive integer, got ${indicesOrSections}`,
+    );
+  }
+
+  const size = a.shape[axis];
+  const partSize = Math.floor(size / indicesOrSections);
+  const remainder = size % indicesOrSections;
+  const sizes = [
+    ...rep(remainder, partSize + 1),
+    ...rep(indicesOrSections - remainder, partSize),
+  ];
+  return splitBySizes(a, sizes, axis);
+}
+
+function splitBySizes(a: Array, sizes: number[], axis: number): Array[] {
   // Split in groups of up to 8 outputs, as the transpose rule turns into a
   // Concatenate primitive that has limited input arguments.
   const results: Array[] = [];

--- a/src/library/numpy.ts
+++ b/src/library/numpy.ts
@@ -614,11 +614,6 @@ export function split(
   const size = a.shape[axis];
   let sizes: number[];
   if (typeof indicesOrSections === "number") {
-    if (!Number.isInteger(indicesOrSections) || indicesOrSections <= 0) {
-      throw new Error(
-        `split: sections must be a positive integer, got ${indicesOrSections}`,
-      );
-    }
     if (size % indicesOrSections !== 0) {
       throw new Error(
         `Array of size ${size} cannot be split into ${indicesOrSections} equal parts`,
@@ -649,11 +644,6 @@ export function arraySplit(
   axis = checkAxis(axis, a.ndim);
   if (typeof indicesOrSections !== "number") {
     return split(a, indicesOrSections, axis);
-  }
-  if (!Number.isInteger(indicesOrSections) || indicesOrSections <= 0) {
-    throw new Error(
-      `arraySplit: sections must be a positive integer, got ${indicesOrSections}`,
-    );
   }
 
   const size = a.shape[axis];

--- a/test/numpy.test.ts
+++ b/test/numpy.test.ts
@@ -2022,6 +2022,65 @@ suite.each(devices)("device:%s", (device) => {
         expect(a.js()).toEqual([i]);
       }
     });
+
+    test("supports an empty list of split indices", () => {
+      const x = np.arange(5);
+      const [a] = np.split(x, []);
+      expect(a.js()).toEqual([0, 1, 2, 3, 4]);
+    });
+  });
+
+  suite("jax.numpy.arraySplit()", () => {
+    test("splits an array into uneven parts", () => {
+      const x = np.arange(8);
+      const [a, b, c] = np.arraySplit(x, 3);
+      expect(a.js()).toEqual([0, 1, 2]);
+      expect(b.js()).toEqual([3, 4, 5]);
+      expect(c.js()).toEqual([6, 7]);
+    });
+
+    test("returns empty trailing parts when sections exceed axis size", () => {
+      const x = np.arange(3);
+      const parts = np.arraySplit(x, 5);
+      expect(parts.map((part) => part.js())).toEqual([[0], [1], [2], [], []]);
+    });
+
+    test("splits along a negative axis", () => {
+      const x = np.arange(10).reshape([2, 5]);
+      const [a, b, c] = np.arraySplit(x, 3, -1);
+      expect(a.js()).toEqual([
+        [0, 1],
+        [5, 6],
+      ]);
+      expect(b.js()).toEqual([
+        [2, 3],
+        [7, 8],
+      ]);
+      expect(c.js()).toEqual([[4], [9]]);
+    });
+
+    test("supports explicit split indices", () => {
+      const x = np.arange(7);
+      const [a, b, c] = np.arraySplit(x, [2, 5]);
+      expect(a.js()).toEqual([0, 1]);
+      expect(b.js()).toEqual([2, 3, 4]);
+      expect(c.js()).toEqual([5, 6]);
+    });
+
+    test("rejects invalid section counts", () => {
+      const x = np.arange(5);
+      expect(() => np.arraySplit(x, 0)).toThrow(Error);
+      expect(() => np.arraySplit(x, -2)).toThrow(Error);
+      expect(() => np.arraySplit(x, 2.5)).toThrow(Error);
+    });
+
+    test("works inside jit", () => {
+      const f = jit((x: np.Array) => {
+        const [a, b, c] = np.arraySplit(x, 3);
+        return np.concatenate([c, b, a]);
+      });
+      expect(f(np.arange(8)).js()).toEqual([6, 7, 3, 4, 5, 0, 1, 2]);
+    });
   });
 
   suite("jax.numpy.concatenate()", () => {

--- a/test/numpy.test.ts
+++ b/test/numpy.test.ts
@@ -2022,12 +2022,6 @@ suite.each(devices)("device:%s", (device) => {
         expect(a.js()).toEqual([i]);
       }
     });
-
-    test("supports an empty list of split indices", () => {
-      const x = np.arange(5);
-      const [a] = np.split(x, []);
-      expect(a.js()).toEqual([0, 1, 2, 3, 4]);
-    });
   });
 
   suite("jax.numpy.arraySplit()", () => {
@@ -2065,6 +2059,12 @@ suite.each(devices)("device:%s", (device) => {
       expect(a.js()).toEqual([0, 1]);
       expect(b.js()).toEqual([2, 3, 4]);
       expect(c.js()).toEqual([5, 6]);
+    });
+
+    test("supports an empty list of split indices", () => {
+      const x = np.arange(5);
+      const [a] = np.arraySplit(x, []);
+      expect(a.js()).toEqual([0, 1, 2, 3, 4]);
     });
 
     test("works inside jit", () => {

--- a/test/numpy.test.ts
+++ b/test/numpy.test.ts
@@ -2067,13 +2067,6 @@ suite.each(devices)("device:%s", (device) => {
       expect(c.js()).toEqual([5, 6]);
     });
 
-    test("rejects invalid section counts", () => {
-      const x = np.arange(5);
-      expect(() => np.arraySplit(x, 0)).toThrow(Error);
-      expect(() => np.arraySplit(x, -2)).toThrow(Error);
-      expect(() => np.arraySplit(x, 2.5)).toThrow(Error);
-    });
-
     test("works inside jit", () => {
       const f = jit((x: np.Array) => {
         const [a, b, c] = np.arraySplit(x, 3);


### PR DESCRIPTION
## Summary
Add `jax.numpy.arraySplit()` with JAX-compatible uneven section sizing

## Why

`split()` requires equal-sized sections, so callers currently have no NumPy-compatible way to divide an axis unevenly

## Validation

- `pnpm check`
- `pnpm lint --max-warnings 0`
- `pnpm format:check`
- `pnpm test run test/numpy.test.ts --no-browser` (606 passed, 2 expected failures)
