### PR TITLE
Add jax.numpy.signbit

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -412,7 +412,7 @@ Most operations behave the same way as they do in JAX.
 | `setxor1d`            | ⚪️      | Python-specific                         |
 | `shape`               | 🟢      |                                         |
 | `sign`                | 🟢      |                                         |
-| `signbit`             | 🔴      |                                         |
+| `signbit`             | 🟢      |                                         |
 | `sin`                 | 🟢      |                                         |
 | `sinc`                | 🟡      | JVP not supported at x=0                |
 | `sinh`                | 🟢      |                                         |

--- a/src/alu.test.ts
+++ b/src/alu.test.ts
@@ -200,12 +200,18 @@ test("AluOp.Bitcast", () => {
 });
 
 test("AluOp.Signbit can inspect raw global values", () => {
-  const input = AluExp.globalIndex(DType.Float32, 0, 1, AluExp.i32(0));
-  const globals = Object.assign(() => NaN, {
-    signbit: () => 1,
-  });
+  const bits = new Uint32Array([0xffc00000, 0x7fc00000]);
+  const globals = [
+    {
+      values: new Float32Array(bits.buffer),
+      bytes: new Uint8Array(bits.buffer),
+    },
+  ];
+  const input = (index: number) =>
+    AluExp.globalIndex(DType.Float32, 0, 2, AluExp.i32(index));
 
-  expect(AluExp.signbit(input).evaluate({}, globals)).toBe(1);
+  expect(AluExp.signbit(input(0)).evaluate({}, globals)).toBe(1);
+  expect(AluExp.signbit(input(1)).evaluate({}, globals)).toBe(0);
 });
 
 test("AluOp.Threefry2x32", () => {

--- a/src/alu.test.ts
+++ b/src/alu.test.ts
@@ -199,13 +199,16 @@ test("AluOp.Bitcast", () => {
   expect(() => AluExp.bitcast(DType.Bool, AluExp.f32(1.0))).toThrow(TypeError);
 });
 
-test("AluOp.Signbit can inspect raw global values", () => {
-  const input = AluExp.globalIndex(DType.Float32, 0, 1, AluExp.i32(0));
-  const globals = Object.assign(() => NaN, {
-    signbit: () => 1,
-  });
+test("AluOp.Signbit", () => {
+  const e = AluExp.signbit(AluExp.f32(-2.5));
+  expect(e.evaluate({})).toBe(1);
+  expect(e.dtype).toBe(DType.Bool);
 
-  expect(AluExp.signbit(input).evaluate({}, globals)).toBe(1);
+  // Signed zero, and non-float dtypes.
+  expect(AluExp.signbit(AluExp.f32(-0)).evaluate({})).toBe(1);
+  expect(AluExp.signbit(AluExp.f32(0)).evaluate({})).toBe(0);
+  expect(AluExp.signbit(AluExp.i32(-3)).evaluate({})).toBe(1);
+  expect(AluExp.signbit(AluExp.u32(0xffffffff)).evaluate({})).toBe(0);
 });
 
 test("AluOp.Threefry2x32", () => {

--- a/src/alu.test.ts
+++ b/src/alu.test.ts
@@ -199,6 +199,15 @@ test("AluOp.Bitcast", () => {
   expect(() => AluExp.bitcast(DType.Bool, AluExp.f32(1.0))).toThrow(TypeError);
 });
 
+test("AluOp.Signbit can inspect raw global values", () => {
+  const input = AluExp.globalIndex(DType.Float32, 0, 1, AluExp.i32(0));
+  const globals = Object.assign(() => NaN, {
+    signbit: () => 1,
+  });
+
+  expect(AluExp.signbit(input).evaluate({}, globals)).toBe(1);
+});
+
 test("AluOp.Threefry2x32", () => {
   const k0 = AluExp.u32(0);
   const k1 = AluExp.u32(0);

--- a/src/alu.test.ts
+++ b/src/alu.test.ts
@@ -200,18 +200,12 @@ test("AluOp.Bitcast", () => {
 });
 
 test("AluOp.Signbit can inspect raw global values", () => {
-  const bits = new Uint32Array([0xffc00000, 0x7fc00000]);
-  const globals = [
-    {
-      values: new Float32Array(bits.buffer),
-      bytes: new Uint8Array(bits.buffer),
-    },
-  ];
-  const input = (index: number) =>
-    AluExp.globalIndex(DType.Float32, 0, 2, AluExp.i32(index));
+  const input = AluExp.globalIndex(DType.Float32, 0, 1, AluExp.i32(0));
+  const globals = Object.assign(() => NaN, {
+    signbit: () => 1,
+  });
 
-  expect(AluExp.signbit(input(0)).evaluate({}, globals)).toBe(1);
-  expect(AluExp.signbit(input(1)).evaluate({}, globals)).toBe(0);
+  expect(AluExp.signbit(input).evaluate({}, globals)).toBe(1);
 });
 
 test("AluOp.Threefry2x32", () => {

--- a/src/alu.ts
+++ b/src/alu.ts
@@ -20,9 +20,22 @@ export type DataArray =
   | Float16Array<ArrayBuffer>
   | Float64Array<ArrayBuffer>;
 
-export interface GlobalLoader {
-  (gid: number, bufidx: number): any;
-  signbit?: (gid: number, bufidx: number) => number;
+export interface GlobalData {
+  readonly values: DataArray;
+  readonly bytes: Uint8Array<ArrayBuffer>;
+}
+
+function getGlobalData(
+  globals: readonly GlobalData[] | undefined,
+  gid: number,
+  bufidx: number,
+): GlobalData {
+  if (!globals) throw new Error("Missing globals");
+  const global = globals[gid];
+  if (!global) throw new Error("gid out of bounds: " + gid);
+  if (bufidx < 0 || bufidx >= global.values.length)
+    throw new Error("bufidx out of bounds: " + bufidx);
+  return global;
 }
 
 export const byteWidth = (dtype: DType): number => {
@@ -1068,7 +1081,10 @@ export class AluExp implements FpHashable {
    *
    * Note that the representation of Bool is as a number (0 or 1) here.
    */
-  evaluate(context: Record<string, any>, globals?: GlobalLoader): number {
+  evaluate(
+    context: Record<string, any>,
+    globals?: readonly GlobalData[],
+  ): number {
     if (AluGroup.Binary.has(this.op) || AluGroup.Compare.has(this.op)) {
       const x = this.src[0].evaluate(context, globals);
       const y = this.src[1].evaluate(context, globals);
@@ -1111,13 +1127,14 @@ export class AluExp implements FpHashable {
       if (
         this.op === AluOp.Signbit &&
         this.src[0].op === AluOp.GlobalIndex &&
-        isFloatDtype(this.src[0].dtype) &&
-        globals?.signbit
+        isFloatDtype(this.src[0].dtype)
       ) {
         const input = this.src[0];
         const gid: number = input.arg[0];
         const bufidx = input.src[0].evaluate(context, globals);
-        return globals.signbit(gid, bufidx);
+        const global = getGlobalData(globals, gid, bufidx);
+        const width = global.values.BYTES_PER_ELEMENT;
+        return global.bytes[(bufidx + 1) * width - 1] >>> 7;
       }
 
       const x = this.src[0].evaluate(context, globals);
@@ -1219,20 +1236,18 @@ export class AluExp implements FpHashable {
         return x;
       }
       case AluOp.GlobalIndex: {
-        if (!globals) throw new Error("Missing globals function");
         const gid: number = this.arg[0];
         const bufidx = this.src[0].evaluate(context, globals);
-        return globals(gid, bufidx);
+        return getGlobalData(globals, gid, bufidx).values[bufidx];
       }
       case AluOp.GlobalView: {
         // Note: This branch is very slow. It should be lowered before evaluation.
-        if (!globals) throw new Error("Missing globals function");
         const gid: number = this.arg[0];
         const st: ShapeTracker = this.arg[1];
         const [iexpr, vexpr] = st.toAluExp(this.src);
         if (vexpr.evaluate(context, globals)) {
           const bufidx = iexpr.evaluate(context, globals);
-          return globals(gid, bufidx);
+          return getGlobalData(globals, gid, bufidx).values[bufidx];
         } else {
           return 0;
         }

--- a/src/alu.ts
+++ b/src/alu.ts
@@ -155,6 +155,11 @@ export class AluExp implements FpHashable {
           throw new TypeError(`Bitcast from ${src[0].dtype} -> ${dtype}`);
         break;
 
+      case AluOp.Signbit:
+        if (dtype !== DType.Bool || src.length !== 1)
+          throw new TypeError("Signbit requires one numeric input");
+        break;
+
       case AluOp.Threefry2x32:
         if (dtype !== DType.Uint32 || src.some((x) => x.dtype !== DType.Uint32))
           throw new TypeError("Threefry2x32 requires uint32 types");
@@ -252,6 +257,9 @@ export class AluExp implements FpHashable {
   static bitcast(dtype: DType, a: AluExp): AluExp {
     if (a.dtype === dtype) return a;
     return new AluExp(AluOp.Bitcast, dtype, [a]);
+  }
+  static signbit(a: AluExp): AluExp {
+    return new AluExp(AluOp.Signbit, DType.Bool, [a]);
   }
   static threefry2x32(
     k0: AluExp,
@@ -541,6 +549,9 @@ export class AluExp implements FpHashable {
         ret = [0, 1];
         break;
       case AluOp.Cmpne:
+        ret = [0, 1];
+        break;
+      case AluOp.Signbit:
         ret = [0, 1];
         break;
       case AluOp.Where:
@@ -1125,6 +1136,20 @@ export class AluExp implements FpHashable {
           return Math.ceil(x);
         case AluOp.Reciprocal:
           return 1 / x;
+        case AluOp.Signbit: {
+          const inputDtype = this.src[0].dtype;
+          if (inputDtype === DType.Int32) return Number(x < 0);
+          if (inputDtype === DType.Uint32 || inputDtype === DType.Bool)
+            return 0;
+
+          const buf = new ArrayBuffer(byteWidth(inputDtype));
+          const view = new DataView(buf);
+          if (inputDtype === DType.Float16) view.setFloat16(0, x, true);
+          else if (inputDtype === DType.Float32) view.setFloat32(0, x, true);
+          else if (inputDtype === DType.Float64) view.setFloat64(0, x, true);
+          else throw new Error(`Unsupported signbit input ${inputDtype}`);
+          return Number((view.getUint8(buf.byteLength - 1) & 0x80) !== 0);
+        }
         case AluOp.Cast: {
           const wasFloat = isFloatDtype(this.src[0].dtype);
           if (this.dtype === DType.Int32)
@@ -1385,6 +1410,7 @@ export enum AluOp {
   Reciprocal = "Reciprocal",
   Cast = "Cast",
   Bitcast = "Bitcast",
+  Signbit = "Signbit",
 
   BitCombine = "BitCombine", // arg = 'or' | 'and' | 'xor'
   BitInvert = "BitInvert",
@@ -1433,6 +1459,7 @@ export const AluGroup = {
     AluOp.Reciprocal,
     AluOp.Cast,
     AluOp.Bitcast,
+    AluOp.Signbit,
   ]),
   Compare: new Set([AluOp.Cmplt, AluOp.Cmpne]),
   Variable: new Set([

--- a/src/alu.ts
+++ b/src/alu.ts
@@ -20,11 +20,6 @@ export type DataArray =
   | Float16Array<ArrayBuffer>
   | Float64Array<ArrayBuffer>;
 
-export interface GlobalLoader {
-  (gid: number, bufidx: number): any;
-  signbit?: (gid: number, bufidx: number) => number;
-}
-
 export const byteWidth = (dtype: DType): number => {
   switch (dtype) {
     case DType.Float32:
@@ -1068,7 +1063,10 @@ export class AluExp implements FpHashable {
    *
    * Note that the representation of Bool is as a number (0 or 1) here.
    */
-  evaluate(context: Record<string, any>, globals?: GlobalLoader): number {
+  evaluate(
+    context: Record<string, any>,
+    globals?: (gid: number, bufidx: number) => any,
+  ): number {
     if (AluGroup.Binary.has(this.op) || AluGroup.Compare.has(this.op)) {
       const x = this.src[0].evaluate(context, globals);
       const y = this.src[1].evaluate(context, globals);
@@ -1108,18 +1106,6 @@ export class AluExp implements FpHashable {
     }
 
     if (AluGroup.Unary.has(this.op)) {
-      if (
-        this.op === AluOp.Signbit &&
-        this.src[0].op === AluOp.GlobalIndex &&
-        isFloatDtype(this.src[0].dtype) &&
-        globals?.signbit
-      ) {
-        const input = this.src[0];
-        const gid: number = input.arg[0];
-        const bufidx = input.src[0].evaluate(context, globals);
-        return globals.signbit(gid, bufidx);
-      }
-
       const x = this.src[0].evaluate(context, globals);
       switch (this.op) {
         case AluOp.Sin:

--- a/src/alu.ts
+++ b/src/alu.ts
@@ -1137,18 +1137,15 @@ export class AluExp implements FpHashable {
         case AluOp.Reciprocal:
           return 1 / x;
         case AluOp.Signbit: {
-          const inputDtype = this.src[0].dtype;
-          if (inputDtype === DType.Int32) return Number(x < 0);
-          if (inputDtype === DType.Uint32 || inputDtype === DType.Bool)
-            return 0;
+          const dtype = this.src[0].dtype;
+          if (!isFloatDtype(dtype))
+            return Number(dtype === DType.Int32 && x < 0);
 
-          const buf = new ArrayBuffer(byteWidth(inputDtype));
-          const view = new DataView(buf);
-          if (inputDtype === DType.Float16) view.setFloat16(0, x, true);
-          else if (inputDtype === DType.Float32) view.setFloat32(0, x, true);
-          else if (inputDtype === DType.Float64) view.setFloat64(0, x, true);
-          else throw new Error(`Unsupported signbit input ${inputDtype}`);
-          return Number((view.getUint8(buf.byteLength - 1) & 0x80) !== 0);
+          const view = new DataView(new ArrayBuffer(byteWidth(dtype)));
+          if (dtype === DType.Float16) view.setFloat16(0, x);
+          else if (dtype === DType.Float32) view.setFloat32(0, x);
+          else view.setFloat64(0, x);
+          return view.getUint8(0) >>> 7;
         }
         case AluOp.Cast: {
           const wasFloat = isFloatDtype(this.src[0].dtype);

--- a/src/alu.ts
+++ b/src/alu.ts
@@ -155,11 +155,6 @@ export class AluExp implements FpHashable {
           throw new TypeError(`Bitcast from ${src[0].dtype} -> ${dtype}`);
         break;
 
-      case AluOp.Signbit:
-        if (dtype !== DType.Bool || src.length !== 1)
-          throw new TypeError("Signbit requires one numeric input");
-        break;
-
       case AluOp.Threefry2x32:
         if (dtype !== DType.Uint32 || src.some((x) => x.dtype !== DType.Uint32))
           throw new TypeError("Threefry2x32 requires uint32 types");

--- a/src/alu.ts
+++ b/src/alu.ts
@@ -20,6 +20,11 @@ export type DataArray =
   | Float16Array<ArrayBuffer>
   | Float64Array<ArrayBuffer>;
 
+export interface GlobalLoader {
+  (gid: number, bufidx: number): any;
+  signbit?: (gid: number, bufidx: number, dtype: DType) => number;
+}
+
 export const byteWidth = (dtype: DType): number => {
   switch (dtype) {
     case DType.Float32:
@@ -1067,10 +1072,7 @@ export class AluExp implements FpHashable {
    *
    * Note that the representation of Bool is as a number (0 or 1) here.
    */
-  evaluate(
-    context: Record<string, any>,
-    globals?: (gid: number, bufidx: number) => any,
-  ): number {
+  evaluate(context: Record<string, any>, globals?: GlobalLoader): number {
     if (AluGroup.Binary.has(this.op) || AluGroup.Compare.has(this.op)) {
       const x = this.src[0].evaluate(context, globals);
       const y = this.src[1].evaluate(context, globals);
@@ -1110,6 +1112,18 @@ export class AluExp implements FpHashable {
     }
 
     if (AluGroup.Unary.has(this.op)) {
+      if (
+        this.op === AluOp.Signbit &&
+        this.src[0].op === AluOp.GlobalIndex &&
+        isFloatDtype(this.src[0].dtype) &&
+        globals?.signbit
+      ) {
+        const input = this.src[0];
+        const gid: number = input.arg[0];
+        const bufidx = input.src[0].evaluate(context, globals);
+        return globals.signbit(gid, bufidx, input.dtype);
+      }
+
       const x = this.src[0].evaluate(context, globals);
       switch (this.op) {
         case AluOp.Sin:

--- a/src/alu.ts
+++ b/src/alu.ts
@@ -22,7 +22,7 @@ export type DataArray =
 
 export interface GlobalLoader {
   (gid: number, bufidx: number): any;
-  signbit?: (gid: number, bufidx: number, dtype: DType) => number;
+  signbit?: (gid: number, bufidx: number) => number;
 }
 
 export const byteWidth = (dtype: DType): number => {
@@ -551,11 +551,7 @@ export class AluExp implements FpHashable {
       }
 
       case AluOp.Cmplt:
-        ret = [0, 1];
-        break;
       case AluOp.Cmpne:
-        ret = [0, 1];
-        break;
       case AluOp.Signbit:
         ret = [0, 1];
         break;
@@ -1121,7 +1117,7 @@ export class AluExp implements FpHashable {
         const input = this.src[0];
         const gid: number = input.arg[0];
         const bufidx = input.src[0].evaluate(context, globals);
-        return globals.signbit(gid, bufidx, input.dtype);
+        return globals.signbit(gid, bufidx);
       }
 
       const x = this.src[0].evaluate(context, globals);
@@ -1155,10 +1151,8 @@ export class AluExp implements FpHashable {
           if (!isFloatDtype(dtype))
             return Number(dtype === DType.Int32 && x < 0);
 
-          const view = new DataView(new ArrayBuffer(byteWidth(dtype)));
-          if (dtype === DType.Float16) view.setFloat16(0, x);
-          else if (dtype === DType.Float32) view.setFloat32(0, x);
-          else view.setFloat64(0, x);
+          const view = new DataView(new ArrayBuffer(8));
+          view.setFloat64(0, x);
           return view.getUint8(0) >>> 7;
         }
         case AluOp.Cast: {

--- a/src/alu.ts
+++ b/src/alu.ts
@@ -20,22 +20,9 @@ export type DataArray =
   | Float16Array<ArrayBuffer>
   | Float64Array<ArrayBuffer>;
 
-export interface GlobalData {
-  readonly values: DataArray;
-  readonly bytes: Uint8Array<ArrayBuffer>;
-}
-
-function getGlobalData(
-  globals: readonly GlobalData[] | undefined,
-  gid: number,
-  bufidx: number,
-): GlobalData {
-  if (!globals) throw new Error("Missing globals");
-  const global = globals[gid];
-  if (!global) throw new Error("gid out of bounds: " + gid);
-  if (bufidx < 0 || bufidx >= global.values.length)
-    throw new Error("bufidx out of bounds: " + bufidx);
-  return global;
+export interface GlobalLoader {
+  (gid: number, bufidx: number): any;
+  signbit?: (gid: number, bufidx: number) => number;
 }
 
 export const byteWidth = (dtype: DType): number => {
@@ -1081,10 +1068,7 @@ export class AluExp implements FpHashable {
    *
    * Note that the representation of Bool is as a number (0 or 1) here.
    */
-  evaluate(
-    context: Record<string, any>,
-    globals?: readonly GlobalData[],
-  ): number {
+  evaluate(context: Record<string, any>, globals?: GlobalLoader): number {
     if (AluGroup.Binary.has(this.op) || AluGroup.Compare.has(this.op)) {
       const x = this.src[0].evaluate(context, globals);
       const y = this.src[1].evaluate(context, globals);
@@ -1127,14 +1111,13 @@ export class AluExp implements FpHashable {
       if (
         this.op === AluOp.Signbit &&
         this.src[0].op === AluOp.GlobalIndex &&
-        isFloatDtype(this.src[0].dtype)
+        isFloatDtype(this.src[0].dtype) &&
+        globals?.signbit
       ) {
         const input = this.src[0];
         const gid: number = input.arg[0];
         const bufidx = input.src[0].evaluate(context, globals);
-        const global = getGlobalData(globals, gid, bufidx);
-        const width = global.values.BYTES_PER_ELEMENT;
-        return global.bytes[(bufidx + 1) * width - 1] >>> 7;
+        return globals.signbit(gid, bufidx);
       }
 
       const x = this.src[0].evaluate(context, globals);
@@ -1236,18 +1219,20 @@ export class AluExp implements FpHashable {
         return x;
       }
       case AluOp.GlobalIndex: {
+        if (!globals) throw new Error("Missing globals function");
         const gid: number = this.arg[0];
         const bufidx = this.src[0].evaluate(context, globals);
-        return getGlobalData(globals, gid, bufidx).values[bufidx];
+        return globals(gid, bufidx);
       }
       case AluOp.GlobalView: {
         // Note: This branch is very slow. It should be lowered before evaluation.
+        if (!globals) throw new Error("Missing globals function");
         const gid: number = this.arg[0];
         const st: ShapeTracker = this.arg[1];
         const [iexpr, vexpr] = st.toAluExp(this.src);
         if (vexpr.evaluate(context, globals)) {
           const bufidx = iexpr.evaluate(context, globals);
-          return getGlobalData(globals, gid, bufidx).values[bufidx];
+          return globals(gid, bufidx);
         } else {
           return 0;
         }

--- a/src/backend/cpu.ts
+++ b/src/backend/cpu.ts
@@ -1,7 +1,46 @@
-import { AluOp, dtypedArray, type GlobalLoader, Kernel } from "../alu";
+import {
+  AluExp,
+  AluOp,
+  byteWidth,
+  type DataArray,
+  DType,
+  dtypedArray,
+  isFloatDtype,
+  Kernel,
+} from "../alu";
 import { Backend, Device, Executable, Slot, SlotError } from "../backend";
 import { Routine, runCpuRoutine } from "../routine";
 import { tuneNullopt } from "../tuner";
+
+/**
+ * Rewrite `Signbit` of a float global load into an integer load of the
+ * element's sign byte, via a raw byte view of the same buffer exposed as
+ * global `numInputs + gid`.
+ *
+ * JS engines may canonicalize NaN when reading a float out of a typed array,
+ * losing its sign, so the sign bit must be read as an integer instead.
+ */
+function rewriteSignbitLoads(exp: AluExp, numInputs: number): AluExp {
+  return exp.rewrite((e) => {
+    if (e.op !== AluOp.Signbit) return;
+    const input = e.src[0];
+    if (input.op !== AluOp.GlobalIndex || !isFloatDtype(input.dtype)) return;
+    const [gid, len] = input.arg as [number, number];
+    const width = byteWidth(input.dtype);
+    // Little-endian: the sign bit is in the last byte of the element.
+    const byteIdx = AluExp.add(
+      AluExp.mul(input.src[0], AluExp.i32(width)),
+      AluExp.i32(width - 1),
+    );
+    const signByte = AluExp.globalIndex(
+      DType.Int32,
+      numInputs + gid,
+      len * width,
+      byteIdx,
+    );
+    return AluExp.cmplt(AluExp.i32(127), signByte);
+  });
+}
 
 /** Most basic implementation of `Backend` for testing. */
 export class CpuBackend implements Backend {
@@ -90,9 +129,12 @@ export class CpuBackend implements Backend {
     }
 
     const kernel = exe.source as Kernel;
-    const { exp, epilogue } = tuneNullopt(kernel);
+    let { exp, epilogue } = tuneNullopt(kernel);
     const inputBuffers = inputs.map((slot) => this.#getBuffer(slot));
     const outputBuffers = outputs.map((slot) => this.#getBuffer(slot));
+
+    exp = rewriteSignbitLoads(exp, inputBuffers.length);
+    epilogue = epilogue && rewriteSignbitLoads(epilogue, inputBuffers.length);
 
     const usedArgs = new Map(
       [
@@ -103,27 +145,25 @@ export class CpuBackend implements Backend {
       ].map((exp) => [exp.arg[0] as number, exp.dtype]),
     );
 
-    const inputArrays = inputBuffers.map((buf, i) => {
-      const dtype = usedArgs.get(i);
-      if (!dtype) return null!; // This arg is unused, so we just blank it out.
-      return dtypedArray(dtype, buf);
-    });
+    const inputArrays: (DataArray | Uint8Array<ArrayBuffer>)[] =
+      inputBuffers.map((buf, i) => {
+        const dtype = usedArgs.get(i);
+        if (!dtype) return null!; // This arg is unused, so we just blank it out.
+        return dtypedArray(dtype, buf);
+      });
+    for (const gid of usedArgs.keys()) {
+      // Byte views of the inputs, from rewritten signbit loads.
+      if (gid >= inputBuffers.length)
+        inputArrays[gid] = inputBuffers[gid - inputBuffers.length];
+    }
     const outputArray = dtypedArray(kernel.dtype, outputBuffers[0]);
 
-    const checkBounds = (gid: number, bufidx: number) => {
+    const globals = (gid: number, bufidx: number) => {
       if (gid < 0 || gid >= inputArrays.length)
         throw new Error("gid out of bounds: " + gid);
       if (bufidx < 0 || bufidx >= inputArrays[gid].length)
         throw new Error("bufidx out of bounds: " + bufidx);
-    };
-    const globals: GlobalLoader = (gid: number, bufidx: number) => {
-      checkBounds(gid, bufidx);
       return inputArrays[gid][bufidx];
-    };
-    globals.signbit = (gid: number, bufidx: number) => {
-      checkBounds(gid, bufidx);
-      const width = inputArrays[gid].BYTES_PER_ELEMENT;
-      return inputBuffers[gid][(bufidx + 1) * width - 1] >>> 7;
     };
     if (!kernel.reduction) {
       for (let i = 0; i < kernel.size; i++) {

--- a/src/backend/cpu.ts
+++ b/src/backend/cpu.ts
@@ -2,7 +2,6 @@ import {
   AluExp,
   AluOp,
   byteWidth,
-  type DataArray,
   DType,
   dtypedArray,
   isFloatDtype,
@@ -145,17 +144,15 @@ export class CpuBackend implements Backend {
       ].map((exp) => [exp.arg[0] as number, exp.dtype]),
     );
 
-    const inputArrays: (DataArray | Uint8Array<ArrayBuffer>)[] =
-      inputBuffers.map((buf, i) => {
+    const inputArrays: ArrayLike<number>[] = [
+      ...inputBuffers.map((buf, i) => {
         const dtype = usedArgs.get(i);
         if (!dtype) return null!; // This arg is unused, so we just blank it out.
         return dtypedArray(dtype, buf);
-      });
-    for (const gid of usedArgs.keys()) {
+      }),
       // Byte views of the inputs, from rewritten signbit loads.
-      if (gid >= inputBuffers.length)
-        inputArrays[gid] = inputBuffers[gid - inputBuffers.length];
-    }
+      ...inputBuffers,
+    ];
     const outputArray = dtypedArray(kernel.dtype, outputBuffers[0]);
 
     const globals = (gid: number, bufidx: number) => {

--- a/src/backend/cpu.ts
+++ b/src/backend/cpu.ts
@@ -1,4 +1,4 @@
-import { AluOp, dtypedArray, type GlobalLoader, Kernel } from "../alu";
+import { AluOp, dtypedArray, type GlobalData, Kernel } from "../alu";
 import { Backend, Device, Executable, Slot, SlotError } from "../backend";
 import { Routine, runCpuRoutine } from "../routine";
 import { tuneNullopt } from "../tuner";
@@ -103,28 +103,12 @@ export class CpuBackend implements Backend {
       ].map((exp) => [exp.arg[0] as number, exp.dtype]),
     );
 
-    const inputArrays = inputBuffers.map((buf, i) => {
+    const globals: GlobalData[] = inputBuffers.map((bytes, i) => {
       const dtype = usedArgs.get(i);
       if (!dtype) return null!; // This arg is unused, so we just blank it out.
-      return dtypedArray(dtype, buf);
+      return { bytes, values: dtypedArray(dtype, bytes) };
     });
     const outputArray = dtypedArray(kernel.dtype, outputBuffers[0]);
-
-    const checkBounds = (gid: number, bufidx: number) => {
-      if (gid < 0 || gid >= inputArrays.length)
-        throw new Error("gid out of bounds: " + gid);
-      if (bufidx < 0 || bufidx >= inputArrays[gid].length)
-        throw new Error("bufidx out of bounds: " + bufidx);
-    };
-    const globals: GlobalLoader = (gid: number, bufidx: number) => {
-      checkBounds(gid, bufidx);
-      return inputArrays[gid][bufidx];
-    };
-    globals.signbit = (gid: number, bufidx: number) => {
-      checkBounds(gid, bufidx);
-      const width = inputArrays[gid].BYTES_PER_ELEMENT;
-      return inputBuffers[gid][(bufidx + 1) * width - 1] >>> 7;
-    };
     if (!kernel.reduction) {
       for (let i = 0; i < kernel.size; i++) {
         outputArray[i] = exp.evaluate({ gidx: i }, globals);

--- a/src/backend/cpu.ts
+++ b/src/backend/cpu.ts
@@ -1,10 +1,4 @@
-import {
-  AluOp,
-  byteWidth,
-  dtypedArray,
-  type GlobalLoader,
-  Kernel,
-} from "../alu";
+import { AluOp, dtypedArray, type GlobalLoader, Kernel } from "../alu";
 import { Backend, Device, Executable, Slot, SlotError } from "../backend";
 import { Routine, runCpuRoutine } from "../routine";
 import { tuneNullopt } from "../tuner";
@@ -126,9 +120,9 @@ export class CpuBackend implements Backend {
       checkBounds(gid, bufidx);
       return inputArrays[gid][bufidx];
     };
-    globals.signbit = (gid: number, bufidx: number, dtype) => {
+    globals.signbit = (gid: number, bufidx: number) => {
       checkBounds(gid, bufidx);
-      const width = byteWidth(dtype);
+      const width = inputArrays[gid].BYTES_PER_ELEMENT;
       return inputBuffers[gid][(bufidx + 1) * width - 1] >>> 7;
     };
     if (!kernel.reduction) {

--- a/src/backend/cpu.ts
+++ b/src/backend/cpu.ts
@@ -1,4 +1,4 @@
-import { AluOp, dtypedArray, type GlobalData, Kernel } from "../alu";
+import { AluOp, dtypedArray, type GlobalLoader, Kernel } from "../alu";
 import { Backend, Device, Executable, Slot, SlotError } from "../backend";
 import { Routine, runCpuRoutine } from "../routine";
 import { tuneNullopt } from "../tuner";
@@ -103,12 +103,28 @@ export class CpuBackend implements Backend {
       ].map((exp) => [exp.arg[0] as number, exp.dtype]),
     );
 
-    const globals: GlobalData[] = inputBuffers.map((bytes, i) => {
+    const inputArrays = inputBuffers.map((buf, i) => {
       const dtype = usedArgs.get(i);
       if (!dtype) return null!; // This arg is unused, so we just blank it out.
-      return { bytes, values: dtypedArray(dtype, bytes) };
+      return dtypedArray(dtype, buf);
     });
     const outputArray = dtypedArray(kernel.dtype, outputBuffers[0]);
+
+    const checkBounds = (gid: number, bufidx: number) => {
+      if (gid < 0 || gid >= inputArrays.length)
+        throw new Error("gid out of bounds: " + gid);
+      if (bufidx < 0 || bufidx >= inputArrays[gid].length)
+        throw new Error("bufidx out of bounds: " + bufidx);
+    };
+    const globals: GlobalLoader = (gid: number, bufidx: number) => {
+      checkBounds(gid, bufidx);
+      return inputArrays[gid][bufidx];
+    };
+    globals.signbit = (gid: number, bufidx: number) => {
+      checkBounds(gid, bufidx);
+      const width = inputArrays[gid].BYTES_PER_ELEMENT;
+      return inputBuffers[gid][(bufidx + 1) * width - 1] >>> 7;
+    };
     if (!kernel.reduction) {
       for (let i = 0; i < kernel.size; i++) {
         outputArray[i] = exp.evaluate({ gidx: i }, globals);

--- a/src/backend/cpu.ts
+++ b/src/backend/cpu.ts
@@ -1,4 +1,10 @@
-import { AluOp, dtypedArray, Kernel } from "../alu";
+import {
+  AluOp,
+  byteWidth,
+  dtypedArray,
+  type GlobalLoader,
+  Kernel,
+} from "../alu";
 import { Backend, Device, Executable, Slot, SlotError } from "../backend";
 import { Routine, runCpuRoutine } from "../routine";
 import { tuneNullopt } from "../tuner";
@@ -110,12 +116,20 @@ export class CpuBackend implements Backend {
     });
     const outputArray = dtypedArray(kernel.dtype, outputBuffers[0]);
 
-    const globals = (gid: number, bufidx: number) => {
+    const checkBounds = (gid: number, bufidx: number) => {
       if (gid < 0 || gid >= inputArrays.length)
         throw new Error("gid out of bounds: " + gid);
       if (bufidx < 0 || bufidx >= inputArrays[gid].length)
         throw new Error("bufidx out of bounds: " + bufidx);
+    };
+    const globals: GlobalLoader = (gid: number, bufidx: number) => {
+      checkBounds(gid, bufidx);
       return inputArrays[gid][bufidx];
+    };
+    globals.signbit = (gid: number, bufidx: number, dtype) => {
+      checkBounds(gid, bufidx);
+      const width = byteWidth(dtype);
+      return inputBuffers[gid][(bufidx + 1) * width - 1] >>> 7;
     };
     if (!kernel.reduction) {
       for (let i = 0; i < kernel.size; i++) {

--- a/src/backend/wasm/translation.ts
+++ b/src/backend/wasm/translation.ts
@@ -136,18 +136,13 @@ export function translateExp(
       else if (op === AluOp.Ceil) (gen(src[0]), dtyF(cg, op, dtype).ceil());
       else if (op === AluOp.Signbit) {
         const inputDtype = src[0].dtype;
-        if (inputDtype === DType.Float32) {
-          cg.f32.const(1);
+        if (inputDtype === DType.Float32 || inputDtype === DType.Float64) {
+          const dt = dtyF(cg, op, inputDtype);
+          dt.const(1);
           gen(src[0]);
-          cg.f32.copysign();
-          cg.f32.const(0);
-          cg.f32.lt();
-        } else if (inputDtype === DType.Float64) {
-          cg.f64.const(1);
-          gen(src[0]);
-          cg.f64.copysign();
-          cg.f64.const(0);
-          cg.f64.lt();
+          dt.copysign();
+          dt.const(0);
+          dt.lt();
         } else if (inputDtype === DType.Int32) {
           gen(src[0]);
           cg.i32.const(0);

--- a/src/backend/wasm/translation.ts
+++ b/src/backend/wasm/translation.ts
@@ -134,7 +134,28 @@ export function translateExp(
         (dt.const(1), gen(src[0]), dt.div());
       } else if (op === AluOp.Floor) (gen(src[0]), dtyF(cg, op, dtype).floor());
       else if (op === AluOp.Ceil) (gen(src[0]), dtyF(cg, op, dtype).ceil());
-      else if (op === AluOp.Cast) {
+      else if (op === AluOp.Signbit) {
+        const inputDtype = src[0].dtype;
+        if (inputDtype === DType.Float32) {
+          cg.f32.const(1);
+          gen(src[0]);
+          cg.f32.copysign();
+          cg.f32.const(0);
+          cg.f32.lt();
+        } else if (inputDtype === DType.Float64) {
+          cg.f64.const(1);
+          gen(src[0]);
+          cg.f64.copysign();
+          cg.f64.const(0);
+          cg.f64.lt();
+        } else if (inputDtype === DType.Int32) {
+          gen(src[0]);
+          cg.i32.const(0);
+          cg.i32.lt_s();
+        } else if (inputDtype === DType.Uint32 || inputDtype === DType.Bool) {
+          cg.i32.const(0);
+        } else throw new UnsupportedOpError(op, dtype, "wasm", inputDtype);
+      } else if (op === AluOp.Cast) {
         gen(src[0]);
         const dtype0 = src[0].dtype;
         const i32repr =

--- a/src/backend/webgl.ts
+++ b/src/backend/webgl.ts
@@ -695,7 +695,14 @@ function generateExpression(
       else if (op === AluOp.Floor) source = `floor(${strip1(a)})`;
       else if (op === AluOp.Ceil) source = `ceil(${strip1(a)})`;
       else if (op === AluOp.Reciprocal) source = `(1.0 / ${a})`;
-      else if (op === AluOp.Cast) source = `${glslType(dtype)}(${strip1(a)})`;
+      else if (op === AluOp.Signbit) {
+        const inputDtype = src[0].dtype;
+        if (inputDtype === DType.Int32) source = `(${strip1(a)} < 0)`;
+        else if (inputDtype === DType.Uint32 || inputDtype === DType.Bool)
+          source = "false";
+        else if (isFloatDtype(inputDtype))
+          source = `(floatBitsToInt(float(${strip1(a)})) < 0)`;
+      } else if (op === AluOp.Cast) source = `${glslType(dtype)}(${strip1(a)})`;
       else if (op === AluOp.Bitcast) {
         const dtype0 = src[0].dtype;
         if (dtype === dtype0) source = a;

--- a/src/backend/webgl.ts
+++ b/src/backend/webgl.ts
@@ -695,14 +695,9 @@ function generateExpression(
       else if (op === AluOp.Floor) source = `floor(${strip1(a)})`;
       else if (op === AluOp.Ceil) source = `ceil(${strip1(a)})`;
       else if (op === AluOp.Reciprocal) source = `(1.0 / ${a})`;
-      else if (op === AluOp.Signbit) {
-        const inputDtype = src[0].dtype;
-        if (inputDtype === DType.Int32) source = `(${strip1(a)} < 0)`;
-        else if (inputDtype === DType.Uint32 || inputDtype === DType.Bool)
-          source = "false";
-        else if (isFloatDtype(inputDtype))
-          source = `(floatBitsToInt(float(${strip1(a)})) < 0)`;
-      } else if (op === AluOp.Cast) source = `${glslType(dtype)}(${strip1(a)})`;
+      else if (op === AluOp.Signbit)
+        source = `(floatBitsToInt(float(${strip1(a)})) < 0)`;
+      else if (op === AluOp.Cast) source = `${glslType(dtype)}(${strip1(a)})`;
       else if (op === AluOp.Bitcast) {
         const dtype0 = src[0].dtype;
         if (dtype === dtype0) source = a;

--- a/src/backend/webgpu/codegen.ts
+++ b/src/backend/webgpu/codegen.ts
@@ -262,7 +262,14 @@ export class WgslExpCodegen {
         else if (op === AluOp.Reciprocal) source = `(1.0 / ${a})`;
         else if (op === AluOp.Floor) source = `floor(${strip1(a)})`;
         else if (op === AluOp.Ceil) source = `ceil(${strip1(a)})`;
-        else if (op === AluOp.Cast) {
+        else if (op === AluOp.Signbit) {
+          const inputDtype = src[0].dtype;
+          if (inputDtype === DType.Int32) source = `(${strip1(a)} < 0)`;
+          else if (inputDtype === DType.Uint32 || inputDtype === DType.Bool)
+            source = "false";
+          else if (inputDtype === DType.Float16 || inputDtype === DType.Float32)
+            source = `((bitcast<u32>(f32(${strip1(a)})) & 0x80000000u) != 0u)`;
+        } else if (op === AluOp.Cast) {
           const srcTy = dtypeToWgsl(src[0].dtype);
           const dstTy = dtypeToWgsl(dtype);
           if (

--- a/src/backend/webgpu/codegen.ts
+++ b/src/backend/webgpu/codegen.ts
@@ -268,7 +268,7 @@ export class WgslExpCodegen {
           else if (inputDtype === DType.Uint32 || inputDtype === DType.Bool)
             source = "false";
           else if (inputDtype === DType.Float16 || inputDtype === DType.Float32)
-            source = `((bitcast<u32>(f32(${strip1(a)})) & 0x80000000u) != 0u)`;
+            source = `(bitcast<i32>(f32(${strip1(a)})) < 0)`;
         } else if (op === AluOp.Cast) {
           const srcTy = dtypeToWgsl(src[0].dtype);
           const dstTy = dtypeToWgsl(dtype);

--- a/src/frontend/array.ts
+++ b/src/frontend/array.ts
@@ -1000,6 +1000,9 @@ export class Array extends Tracer {
           return [y];
         }
       },
+      [Primitive.Signbit]([x]) {
+        return [x.#unary(AluOp.Signbit, DType.Bool)];
+      },
       [Primitive.Sin]([x]) {
         return [x.#unary(AluOp.Sin)];
       },

--- a/src/frontend/core.ts
+++ b/src/frontend/core.ts
@@ -54,6 +54,7 @@ export enum Primitive {
   StopGradient = "stop_gradient",
   Cast = "cast",
   Bitcast = "bitcast",
+  Signbit = "signbit",
   Sin = "sin",
   Cos = "cos",
   Asin = "asin",
@@ -224,6 +225,10 @@ export function cast(x: TracerValue, dtype: DType) {
 
 export function bitcast(x: TracerValue, dtype: DType) {
   return bind1(Primitive.Bitcast, [x], { dtype });
+}
+
+export function signbit(x: TracerValue) {
+  return bind1(Primitive.Signbit, [x]);
 }
 
 export function sin(x: TracerValue) {

--- a/src/frontend/jaxpr.ts
+++ b/src/frontend/jaxpr.ts
@@ -846,6 +846,9 @@ export const abstractEvalRules: { [P in Primitive]: AbstractEvalRule<P> } = {
     }
     return [new ShapedArray(x.shape, dtype, false)];
   },
+  [Primitive.Signbit]([x]: ShapedArray[]) {
+    return [new ShapedArray(x.shape, DType.Bool, false)];
+  },
   [Primitive.Sin]: vectorizedUnopAbstractEval,
   [Primitive.Cos]: vectorizedUnopAbstractEval,
   [Primitive.Asin]: vectorizedUnopAbstractEval,

--- a/src/frontend/jit.ts
+++ b/src/frontend/jit.ts
@@ -589,6 +589,7 @@ const jitRules: { [P in Primitive]: JitRule<P> } = {
   [Primitive.StopGradient]: unopJit((a) => a), // No-op, just return the input.
   [Primitive.Cast]: unopJit((a, { dtype }) => AluExp.cast(dtype, a)),
   [Primitive.Bitcast]: unopJit((a, { dtype }) => AluExp.bitcast(dtype, a)),
+  [Primitive.Signbit]: unopJit(AluExp.signbit),
   [Primitive.Sin]: unopJit(AluExp.sin),
   [Primitive.Cos]: unopJit(AluExp.cos),
   [Primitive.Asin]: unopJit(AluExp.asin),
@@ -846,6 +847,7 @@ function splitGraphDataflow(backend: Backend, jaxpr: Jaxpr): Set<Var> {
           case Primitive.StopGradient:
           case Primitive.Cast:
           case Primitive.Bitcast:
+          case Primitive.Signbit:
           case Primitive.Sin:
           case Primitive.Cos:
           case Primitive.Asin:

--- a/src/frontend/jvp.ts
+++ b/src/frontend/jvp.ts
@@ -231,6 +231,7 @@ const jvpRules: { [P in Primitive]: JvpRule<P> } = {
     dx.dispose(); // Non-differentiable operation.
     return [[bitcast(x.ref, dtype)], [zerosLike(x)]];
   },
+  [Primitive.Signbit]: zeroTangentsJvp(Primitive.Signbit),
   [Primitive.Sin]([x], [dx]) {
     return [[sin(x.ref)], [cos(x).mul(dx)]];
   },

--- a/src/frontend/vmap.ts
+++ b/src/frontend/vmap.ts
@@ -279,6 +279,7 @@ const vmapRules: Partial<{ [P in Primitive]: VmapRule<P> }> = {
   [Primitive.StopGradient]: unopBatcher(Primitive.StopGradient),
   [Primitive.Cast]: unopBatcher(Primitive.Cast),
   [Primitive.Bitcast]: unopBatcher(Primitive.Bitcast),
+  [Primitive.Signbit]: unopBatcher(Primitive.Signbit),
   [Primitive.Sin]: unopBatcher(Primitive.Sin),
   [Primitive.Cos]: unopBatcher(Primitive.Cos),
   [Primitive.Asin]: unopBatcher(Primitive.Asin),

--- a/src/library/numpy.ts
+++ b/src/library/numpy.ts
@@ -1870,6 +1870,9 @@ export function sign(x: ArrayLike): Array {
   return where(notEqual(x.ref, 0), where(less(x, 0), -1, 1), 0);
 }
 
+/** Test element-wise whether the sign bit is set. */
+export const signbit = core.signbit as (x: ArrayLike) => Array;
+
 /**
  * @function
  * Return the value with the magnitude of x and the sign of y, element-wise.

--- a/test/dtype-f16.test.ts
+++ b/test/dtype-f16.test.ts
@@ -33,6 +33,19 @@ suite.each(devices)("device:%s", (device) => {
     expect(a.js()).toEqual([1.5, 2.5, 3.5]);
   });
 
+  test("signbit() preserves f16 sign bits", () => {
+    const bits = new Uint16Array([
+      0xbc00, // -1
+      0x8000, // -0
+      0x0000, // +0
+      0x3c00, // +1
+      0xfe00, // negative NaN
+      0x7e00, // positive NaN
+    ]);
+    const x = np.array(new Float16Array(bits.buffer));
+    expect(np.signbit(x).js()).toEqual([true, true, false, false, true, false]);
+  });
+
   test("jit of f16 calculation", () => {
     const f = jit((x: np.Array) => np.sum(x.ref.mul(x)));
     expect(f(np.arange(10).astype(np.float16))).toBeAllclose(285);

--- a/test/dtype-f16.test.ts
+++ b/test/dtype-f16.test.ts
@@ -34,14 +34,18 @@ suite.each(devices)("device:%s", (device) => {
   });
 
   test("signbit() preserves f16 sign bits", () => {
-    const values = new Float16Array([-1, -0, 0, 1, NaN, NaN]);
-    // JavaScript cannot observe a NaN's sign, so set only those bits explicitly.
-    const bits = new Uint16Array(values.buffer);
+    const positiveNaN = new Float16Array([NaN]);
+    const negativeNaN = new Float16Array([NaN]);
     const signMask = 1 << 15;
-    bits[4] |= signMask;
-    bits[5] &= ~signMask;
+    new Uint16Array(positiveNaN.buffer)[0] &= ~signMask;
+    new Uint16Array(negativeNaN.buffer)[0] |= signMask;
+
+    const values = new Float16Array([-1, -0, 0, 1, NaN, NaN]);
+    // Same-type set() copies the NaNs without normalizing their raw bits.
+    values.set(positiveNaN, 4);
+    values.set(negativeNaN, 5);
     const x = np.array(values);
-    expect(np.signbit(x).js()).toEqual([true, true, false, false, true, false]);
+    expect(np.signbit(x).js()).toEqual([true, true, false, false, false, true]);
   });
 
   test("jit of f16 calculation", () => {

--- a/test/dtype-f16.test.ts
+++ b/test/dtype-f16.test.ts
@@ -34,15 +34,13 @@ suite.each(devices)("device:%s", (device) => {
   });
 
   test("signbit() preserves f16 sign bits", () => {
-    const bits = new Uint16Array([
-      0xbc00, // -1
-      0x8000, // -0
-      0x0000, // +0
-      0x3c00, // +1
-      0xfe00, // negative NaN
-      0x7e00, // positive NaN
-    ]);
-    const x = np.array(new Float16Array(bits.buffer));
+    const values = new Float16Array([-1, -0, 0, 1, NaN, NaN]);
+    // JavaScript cannot observe a NaN's sign, so set only those bits explicitly.
+    const bits = new Uint16Array(values.buffer);
+    const signMask = 1 << 15;
+    bits[4] |= signMask;
+    bits[5] &= ~signMask;
+    const x = np.array(values);
     expect(np.signbit(x).js()).toEqual([true, true, false, false, true, false]);
   });
 

--- a/test/dtype-f16.test.ts
+++ b/test/dtype-f16.test.ts
@@ -34,16 +34,11 @@ suite.each(devices)("device:%s", (device) => {
   });
 
   test("signbit() preserves f16 sign bits", () => {
-    const positiveNaN = new Float16Array([NaN]);
-    const negativeNaN = new Float16Array([NaN]);
-    const signMask = 1 << 15;
-    new Uint16Array(positiveNaN.buffer)[0] &= ~signMask;
-    new Uint16Array(negativeNaN.buffer)[0] |= signMask;
-
     const values = new Float16Array([-1, -0, 0, 1, NaN, NaN]);
-    // Same-type set() copies the NaNs without normalizing their raw bits.
-    values.set(positiveNaN, 4);
-    values.set(negativeNaN, 5);
+    // Write the NaNs as raw bits, since float writes may canonicalize NaN.
+    const bits = new Uint16Array(values.buffer);
+    bits[4] = 0x7e00; // NaN
+    bits[5] = 0xfe00; // -NaN
     const x = np.array(values);
     expect(np.signbit(x).js()).toEqual([true, true, false, false, false, true]);
   });

--- a/test/dtype-f64.test.ts
+++ b/test/dtype-f64.test.ts
@@ -33,16 +33,11 @@ suite.each(devices)("device:%s", (device) => {
   });
 
   test("signbit() preserves f64 sign bits", () => {
-    const positiveNaN = new Float64Array([NaN]);
-    const negativeNaN = new Float64Array([NaN]);
-    const signMask = 1n << 63n;
-    new BigUint64Array(positiveNaN.buffer)[0] &= ~signMask;
-    new BigUint64Array(negativeNaN.buffer)[0] |= signMask;
-
     const values = new Float64Array([-1, -0, 0, 1, NaN, NaN]);
-    // Same-type set() copies the NaNs without normalizing their raw bits.
-    values.set(positiveNaN, 4);
-    values.set(negativeNaN, 5);
+    // Write the NaNs as raw bits, since float writes may canonicalize NaN.
+    const bits = new BigUint64Array(values.buffer);
+    bits[4] = 0x7ff8000000000000n; // NaN
+    bits[5] = 0xfff8000000000000n; // -NaN
     const x = np.array(values);
     expect(np.signbit(x).js()).toEqual([true, true, false, false, false, true]);
   });

--- a/test/dtype-f64.test.ts
+++ b/test/dtype-f64.test.ts
@@ -33,14 +33,18 @@ suite.each(devices)("device:%s", (device) => {
   });
 
   test("signbit() preserves f64 sign bits", () => {
-    const values = new Float64Array([-1, -0, 0, 1, NaN, NaN]);
-    // JavaScript cannot observe a NaN's sign, so set only those bits explicitly.
-    const bits = new BigUint64Array(values.buffer);
+    const positiveNaN = new Float64Array([NaN]);
+    const negativeNaN = new Float64Array([NaN]);
     const signMask = 1n << 63n;
-    bits[4] |= signMask;
-    bits[5] &= ~signMask;
+    new BigUint64Array(positiveNaN.buffer)[0] &= ~signMask;
+    new BigUint64Array(negativeNaN.buffer)[0] |= signMask;
+
+    const values = new Float64Array([-1, -0, 0, 1, NaN, NaN]);
+    // Same-type set() copies the NaNs without normalizing their raw bits.
+    values.set(positiveNaN, 4);
+    values.set(negativeNaN, 5);
     const x = np.array(values);
-    expect(np.signbit(x).js()).toEqual([true, true, false, false, true, false]);
+    expect(np.signbit(x).js()).toEqual([true, true, false, false, false, true]);
   });
 
   test("jit of f64 calculation", () => {

--- a/test/dtype-f64.test.ts
+++ b/test/dtype-f64.test.ts
@@ -33,15 +33,13 @@ suite.each(devices)("device:%s", (device) => {
   });
 
   test("signbit() preserves f64 sign bits", () => {
-    const bits = new BigUint64Array([
-      0xbff0000000000000n, // -1
-      0x8000000000000000n, // -0
-      0x0000000000000000n, // +0
-      0x3ff0000000000000n, // +1
-      0xfff8000000000000n, // negative NaN
-      0x7ff8000000000000n, // positive NaN
-    ]);
-    const x = np.array(new Float64Array(bits.buffer));
+    const values = new Float64Array([-1, -0, 0, 1, NaN, NaN]);
+    // JavaScript cannot observe a NaN's sign, so set only those bits explicitly.
+    const bits = new BigUint64Array(values.buffer);
+    const signMask = 1n << 63n;
+    bits[4] |= signMask;
+    bits[5] &= ~signMask;
+    const x = np.array(values);
     expect(np.signbit(x).js()).toEqual([true, true, false, false, true, false]);
   });
 

--- a/test/dtype-f64.test.ts
+++ b/test/dtype-f64.test.ts
@@ -32,6 +32,19 @@ suite.each(devices)("device:%s", (device) => {
     expect(a.js()).toEqual([1.5, 2.5, 3.5]);
   });
 
+  test("signbit() preserves f64 sign bits", () => {
+    const bits = new BigUint64Array([
+      0xbff0000000000000n, // -1
+      0x8000000000000000n, // -0
+      0x0000000000000000n, // +0
+      0x3ff0000000000000n, // +1
+      0xfff8000000000000n, // negative NaN
+      0x7ff8000000000000n, // positive NaN
+    ]);
+    const x = np.array(new Float64Array(bits.buffer));
+    expect(np.signbit(x).js()).toEqual([true, true, false, false, true, false]);
+  });
+
   test("jit of f64 calculation", () => {
     const f = jit((x: np.Array) => np.sum(x.ref.mul(x)));
     expect(f(np.arange(10).astype(np.float64))).toBeAllclose(285);

--- a/test/numpy.test.ts
+++ b/test/numpy.test.ts
@@ -1461,7 +1461,7 @@ suite.each(devices)("device:%s", (device) => {
 
     test("preserves the sign of NaN", () => {
       if (!hasStrictNumerics(device)) return;
-      const bits = new Uint32Array([0xffc00000, 0x7fc00000]);
+      const bits = new Uint32Array([0xffc00000, 0x7fc00000]); // [-NaN, NaN]
       const x = np.array(new Float32Array(bits.buffer));
       expect(np.signbit(x).js()).toEqual([true, false]);
     });

--- a/test/numpy.test.ts
+++ b/test/numpy.test.ts
@@ -1444,6 +1444,46 @@ suite.each(devices)("device:%s", (device) => {
     });
   });
 
+  suite("jax.numpy.signbit()", () => {
+    test("identifies negative values and signed zero", () => {
+      const x = np.array([-Infinity, -3, -0, 0, 2, Infinity]);
+      const result = np.signbit(x);
+      expect(result.dtype).toBe(np.bool);
+      expect(result.js()).toEqual([true, true, true, false, false, false]);
+    });
+
+    test("supports integer and boolean inputs", () => {
+      expect(
+        np.signbit(np.array([-2, 0, 3], { dtype: np.int32 })).js(),
+      ).toEqual([true, false, false]);
+      expect(np.signbit(np.array([false, true])).js()).toEqual([false, false]);
+    });
+
+    test("preserves the sign of NaN", () => {
+      if (!hasStrictNumerics(device)) return;
+      const bits = new Uint32Array([0xffc00000, 0x7fc00000]);
+      const x = np.array(new Float32Array(bits.buffer));
+      expect(np.signbit(x).js()).toEqual([true, false]);
+    });
+
+    test("works with jit and vmap", () => {
+      const signbitJit = jit((x: np.Array) => np.signbit(x));
+      expect(signbitJit(np.array([-0, 0, -4, 4])).js()).toEqual([
+        true,
+        false,
+        true,
+        false,
+      ]);
+
+      const signbitVmap = vmap((x: np.Array) => np.signbit(x));
+      expect(signbitVmap(np.array([-2, 0, 3])).js()).toEqual([
+        true,
+        false,
+        false,
+      ]);
+    });
+  });
+
   suite("jax.numpy.reciprocal()", () => {
     test("computes element-wise reciprocal", () => {
       const x = np.array([1, 2, 3]);


### PR DESCRIPTION
## Summary
Add `jax.numpy.signbit`. This includes
- updates to frontend, tracing, JIT, JVP, and vmap paths
- lower sign-bit checks across CPU evaluation and the Wasm, WebGL, and WebGPU backends
- preserving signed zero and signed NaN behavior, with coverage for float16, float32, float64, integer, and boolean inputs

## Why

`jax.numpy.signbit` was not previously implemented, so callers could not inspect the actual sign bit of floating-point values. In particular, comparison-based workarounds cannot distinguish `-0` from `0` or preserve the sign of NaN.

## Impact

Users can now call `np.signbit` consistently in eager execution, `jit`, and `vmap`, with backend-specific lowering that retains IEEE sign-bit semantics.

## Validation

- `pnpm build`
- `pnpm check`
- `pnpm lint --max-warnings 0`
- `pnpm format:check`
- `BROWSER=firefox pnpm test --run` — 39 files passed; 1,877 tests passed and 3 expected failures
- targeted WebKit coverage — 4 files passed; 924 tests passed and 3 expected failures
- GitHub Actions — build/lint/test, formatting, Ubuntu platform, and macOS platform jobs all pass
