### PR TITLE
Add jax.numpy.signbit

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -412,7 +412,7 @@ Most operations behave the same way as they do in JAX.
 | `setxor1d`            | ⚪️      | Python-specific                         |
 | `shape`               | 🟢      |                                         |
 | `sign`                | 🟢      |                                         |
-| `signbit`             | 🔴      |                                         |
+| `signbit`             | 🟢      |                                         |
 | `sin`                 | 🟢      |                                         |
 | `sinc`                | 🟡      | JVP not supported at x=0                |
 | `sinh`                | 🟢      |                                         |

--- a/src/frontend/array.ts
+++ b/src/frontend/array.ts
@@ -1349,7 +1349,9 @@ function arrayFromData(
     // Check if all elements are of the same value and short-circuit.
     let allEqual = true;
     for (let i = 1; i < data.length; i++) {
-      if (data[i] !== data[0]) {
+      // `!==` checks ordinary inequality and keeps NaN off the constant path
+      // (NaN !== NaN); `Object.is` additionally distinguishes -0 from 0.
+      if (data[i] !== data[0] || !Object.is(data[i], data[0])) {
         allEqual = false;
         break;
       }

--- a/src/library/numpy.ts
+++ b/src/library/numpy.ts
@@ -1900,6 +1900,30 @@ export function sign(x: ArrayLike): Array {
 }
 
 /**
+ * Test element-wise whether the sign bit is set.
+ *
+ * Unlike comparisons with zero, this distinguishes `-0` from `0`. The sign of
+ * NaN is also preserved, except where the platform canonicalizes NaN: JS
+ * engines may do so when the cpu backend reads floats out of typed arrays, and
+ * conversions of f16 NaN on GPU backends may lose the sign as well.
+ */
+export function signbit(x: ArrayLike): Array {
+  const arr = fudgeArray(x);
+  switch (arr.dtype) {
+    case DType.Bool:
+    case DType.Uint32:
+      return zerosLike(arr, { dtype: DType.Bool });
+    case DType.Int32:
+      return less(arr, 0);
+    default:
+      // Read the sign bit of floats through a bitcast. There is no 16- or
+      // 64-bit integer dtype, so f16 and f64 go through f32 first; the cast
+      // keeps the sign bit for every value class.
+      return less(arr.astype(DType.Float32).view(DType.Int32), 0);
+  }
+}
+
+/**
  * @function
  * Return the value with the magnitude of x and the sign of y, element-wise.
  */

--- a/test/dtype-f16.test.ts
+++ b/test/dtype-f16.test.ts
@@ -33,6 +33,11 @@ suite.each(devices)("device:%s", (device) => {
     expect(a.js()).toEqual([1.5, 2.5, 3.5]);
   });
 
+  test("signbit() distinguishes f16 signed zero", () => {
+    const x = np.array([-1.5, -0, 0, 1.5], { dtype: np.float16 });
+    expect(np.signbit(x).js()).toEqual([true, true, false, false]);
+  });
+
   test("jit of f16 calculation", () => {
     const f = jit((x: np.Array) => np.sum(x.ref.mul(x)));
     expect(f(np.arange(10).astype(np.float16))).toBeAllclose(285);

--- a/test/dtype-f64.test.ts
+++ b/test/dtype-f64.test.ts
@@ -11,6 +11,8 @@ import {
 } from "@jax-js/jax";
 import { beforeEach, expect, suite, test } from "vitest";
 
+import { preservesNanSign } from "./setup";
+
 // f64 is currently only supported on WebAssembly.
 const devices = ["cpu", "wasm"] as const;
 
@@ -30,6 +32,24 @@ suite.each(devices)("device:%s", (device) => {
     expect(await a.ref.data()).toEqual(new Float64Array([1.5, 2.5, 3.5]));
     expect(a.ref.dataSync()).toEqual(new Float64Array([1.5, 2.5, 3.5]));
     expect(a.js()).toEqual([1.5, 2.5, 3.5]);
+  });
+
+  test("signbit() distinguishes f64 signed zero", () => {
+    const x = np.array([-1.5, -0, 0, 1.5], { dtype: np.float64 });
+    expect(np.signbit(x).js()).toEqual([true, true, false, false]);
+  });
+
+  test("signbit() preserves the sign of f64 NaN", () => {
+    // On wasm, all current engines preserve the NaN sign through the
+    // f64 -> f32 demote, though the Wasm spec leaves it nondeterministic.
+    if (!preservesNanSign(device)) return;
+    const values = new Float64Array(2);
+    // Write the NaNs as raw bits, since float writes may canonicalize NaN.
+    const bits = new BigUint64Array(values.buffer);
+    bits[0] = 0xfff8000000000000n; // -NaN
+    bits[1] = 0x7ff8000000000000n; // NaN
+    const x = np.array(values);
+    expect(np.signbit(x).js()).toEqual([true, false]);
   });
 
   test("jit of f64 calculation", () => {

--- a/test/dtype-f64.test.ts
+++ b/test/dtype-f64.test.ts
@@ -11,8 +11,6 @@ import {
 } from "@jax-js/jax";
 import { beforeEach, expect, suite, test } from "vitest";
 
-import { preservesNanSign } from "./setup";
-
 // f64 is currently only supported on WebAssembly.
 const devices = ["cpu", "wasm"] as const;
 
@@ -40,9 +38,8 @@ suite.each(devices)("device:%s", (device) => {
   });
 
   test("signbit() preserves the sign of f64 NaN", () => {
-    // On wasm, all current engines preserve the NaN sign through the
-    // f64 -> f32 demote, though the Wasm spec leaves it nondeterministic.
-    if (!preservesNanSign(device)) return;
+    // JS may canonicalize f64 NaNs on the CPU backend.
+    if (device === "cpu") return;
     const values = new Float64Array(2);
     // Write the NaNs as raw bits, since float writes may canonicalize NaN.
     const bits = new BigUint64Array(values.buffer);

--- a/test/numpy.test.ts
+++ b/test/numpy.test.ts
@@ -10,7 +10,7 @@ import {
 } from "@jax-js/jax";
 import { beforeEach, expect, onTestFinished, suite, test } from "vitest";
 
-import { hasStrictNumerics } from "./setup";
+import { hasStrictNumerics, preservesNanSign } from "./setup";
 
 const devicesAvailable = await init();
 
@@ -1441,6 +1441,54 @@ suite.each(devices)("device:%s", (device) => {
     // TODO: Fix sign(NaN) returning 1 instead of NaN
     test.fails("works with NaN", () => {
       expect(np.sign(NaN).js()).toBeNaN();
+    });
+  });
+
+  suite("jax.numpy.signbit()", () => {
+    test("identifies negative values and signed zero", () => {
+      const x = np.array([-Infinity, -3, -0, 0, 2, Infinity]);
+      const result = np.signbit(x);
+      expect(result.dtype).toBe(np.bool);
+      expect(result.js()).toEqual([true, true, true, false, false, false]);
+    });
+
+    test("distinguishes signed zero for scalar and constant inputs", () => {
+      expect(np.signbit(np.array(-0)).js()).toBe(true);
+      expect(np.signbit(np.array([0, -0])).js()).toEqual([false, true]);
+    });
+
+    test("supports integer and boolean inputs", () => {
+      expect(
+        np.signbit(np.array([-2, 0, 3], { dtype: np.int32 })).js(),
+      ).toEqual([true, false, false]);
+      expect(
+        np.signbit(np.array([0, 1, 0xffffffff], { dtype: np.uint32 })).js(),
+      ).toEqual([false, false, false]);
+      expect(np.signbit(np.array([false, true])).js()).toEqual([false, false]);
+    });
+
+    test("preserves the sign of NaN", () => {
+      if (!preservesNanSign(device)) return;
+      const bits = new Uint32Array([0xffc00000, 0x7fc00000]); // [-NaN, NaN]
+      const x = np.array(new Float32Array(bits.buffer));
+      expect(np.signbit(x).js()).toEqual([true, false]);
+    });
+
+    test("works with jit and vmap", () => {
+      const signbitJit = jit((x: np.Array) => np.signbit(x));
+      expect(signbitJit(np.array([-0, 0, -4, 4])).js()).toEqual([
+        true,
+        false,
+        true,
+        false,
+      ]);
+
+      const signbitVmap = vmap((x: np.Array) => np.signbit(x));
+      expect(signbitVmap(np.array([-2, 0, 3])).js()).toEqual([
+        true,
+        false,
+        false,
+      ]);
     });
   });
 

--- a/test/numpy.test.ts
+++ b/test/numpy.test.ts
@@ -10,7 +10,7 @@ import {
 } from "@jax-js/jax";
 import { beforeEach, expect, onTestFinished, suite, test } from "vitest";
 
-import { hasStrictNumerics, preservesNanSign } from "./setup";
+import { hasStrictNumerics } from "./setup";
 
 const devicesAvailable = await init();
 
@@ -1468,7 +1468,7 @@ suite.each(devices)("device:%s", (device) => {
     });
 
     test("preserves the sign of NaN", () => {
-      if (!preservesNanSign(device)) return;
+      if (!hasStrictNumerics(device)) return;
       const bits = new Uint32Array([0xffc00000, 0x7fc00000]); // [-NaN, NaN]
       const x = np.array(new Float32Array(bits.buffer));
       expect(np.signbit(x).js()).toEqual([true, false]);

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -37,12 +37,3 @@ expect.extend({
 export function hasStrictNumerics(device: Device): boolean {
   return device !== "webgl";
 }
-
-/**
- * The cpu backend reads floats out of typed arrays as JS numbers, and some JS
- * engines canonicalize NaN in the process, losing its sign. We skip tests that
- * depend on the sign of NaN for these devices.
- */
-export function preservesNanSign(device: Device): boolean {
-  return device !== "cpu" && hasStrictNumerics(device);
-}

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -37,3 +37,12 @@ expect.extend({
 export function hasStrictNumerics(device: Device): boolean {
   return device !== "webgl";
 }
+
+/**
+ * The cpu backend reads floats out of typed arrays as JS numbers, and some JS
+ * engines canonicalize NaN in the process, losing its sign. We skip tests that
+ * depend on the sign of NaN for these devices.
+ */
+export function preservesNanSign(device: Device): boolean {
+  return device !== "cpu" && hasStrictNumerics(device);
+}


### PR DESCRIPTION
Opened this as per the reviewer's [suggestion](https://github.com/ekzhang/jax-js/pull/160#pullrequestreview-4840340123). Can close https://github.com/ekzhang/jax-js/pull/160 if this PR gets merged

## Impact

Users can detect negative values, negative zero, and signed NaNs where the backend preserves the NaN sign. Integer and boolean inputs follow NumPy/JAX semantics and return boolean arrays.

## Validation

- `pnpm build`
- `pnpm check`
- `pnpm lint --max-warnings 0`
- `pnpm format:check`
- targeted signbit and dtype suites on Chromium, Firefox, and WebKit
- full Chromium suite: 2,487 passed; two existing WebGPU FFT tolerance failures reproduced on upstream `main`
