### PR TITLE
Fix stale API documentation links

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -109,7 +109,7 @@ mostly meant for compatibility in browsers that don't support WebGPU, but you sh
 possible._
 
 Most operations behave the same way as they do in JAX.
-[API docs](https://jax-js.com/docs/modules/_jax-js_jax.numpy.html).
+[API docs](https://jax-js.com/docs/_jax-js/jax/numpy.html).
 
 | API                   | Support | Notes                                   |
 | --------------------- | ------- | --------------------------------------- |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -24,7 +24,7 @@ In the tables below, we use a color legend to refer to functions in JAX:
 
 ## [`jax`](https://docs.jax.dev/en/latest/jax.html)
 
-[API docs](https://jax-js.com/docs/modules/_jax-js_jax.html) for these functions.
+[API docs](https://jax-js.com/docs/_jax-js/jax.html) for these functions.
 
 | API                  | Support | Notes                                           |
 | -------------------- | ------- | ----------------------------------------------- |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -694,7 +694,7 @@ These modules are unimplemented:
 - `jax.example_libraries`
 - `jax.experimental`
 
-## [`optax`](https://jax-js.com/docs/_jax-js/onnx)
+## [`optax`](https://jax-js.com/docs/_jax-js/optax)
 
 We have ported a subset of the [Optax](https://github.com/google-deepmind/optax) gradient processing
 and optimization library at `@jax-js/optax`. You can install this alongside `@jax-js/jax`.


### PR DESCRIPTION
## Summary
1. Some links point towards https://jax-js.com/docs/modules/_jax-js_jax.html, which gives a 404 now
<img width="486" height="157" alt="Screenshot 2026-08-03 at 4 45 43 PM" src="https://github.com/user-attachments/assets/e78ba702-dd5f-4c05-b027-ea9c962b4701" />

Updated to new live link at https://jax-js.com/docs/_jax-js/jax.html

2. Updated the optax header to point towards correct link of https://jax-js.com/docs/_jax-js/optax. It was previously pointing at https://jax-js.com/docs/_jax-js/onnx

## Why

1. The JAX and NumPy links used paths from an older TypeDoc layout, so they no longer opened the intended documentation
2. Point to correct link