### PR TITLE
[loaders] Fix parse of special tokens

### DIFF
--- a/packages/loaders/src/tokenizers.test.ts
+++ b/packages/loaders/src/tokenizers.test.ts
@@ -97,6 +97,9 @@ suite("tiktoken encodings", () => {
     const enc = await getBpe("r50k_base");
     expect(enc.encode("hello world")).toEqual([31373, 995]);
     expect(enc.encode("")).toEqual([]);
+    expect(enc.encodeWithSpecialTokens("a<|endoftext|>b")).toEqual([
+      64, 50256, 65,
+    ]);
   });
 
   test("p50k_base", async () => {

--- a/packages/loaders/src/tokenizers.ts
+++ b/packages/loaders/src/tokenizers.ts
@@ -295,7 +295,7 @@ export class BpeEncoding {
         const piece = nextSpecial[0];
         const token = this.specialTokensEncoder.get(piece)!;
         ret.push(token);
-        start = nextSpecial.index + nextSpecial.length;
+        start = nextSpecial.index + nextSpecial[0].length;
       } else {
         break;
       }


### PR DESCRIPTION
`nextSpecial` was a regexp match, so its length was not relevant - we wanted to match on the length of the match itself, or capture group 0.