### PR TITLE
Fix GQA semantics for attention heads

### DIFF
--- a/src/library/nn.ts
+++ b/src/library/nn.ts
@@ -19,11 +19,11 @@ import {
   negative,
   onesLike,
   reciprocal,
+  repeat,
   sqrt,
   square,
   squeeze,
   tanh,
-  tile,
   where,
   zerosLike,
 } from "./numpy";
@@ -512,8 +512,8 @@ export function dotProductAttention(
         `divisible by number of key/value heads K=${K} for GQA`,
     );
   const G = N / K; // number of query groups
-  key = tile(key, [1, 1, G, 1]);
-  value = tile(value, [1, 1, G, 1]);
+  key = repeat(key, G, 2);
+  value = repeat(value, G, 2);
 
   const scale = opts.scale ?? 1 / Math.sqrt(H);
   let scores = einsum("BLNH,BSNH->BNLS", query, key).mul(scale);

--- a/test/nn.test.ts
+++ b/test/nn.test.ts
@@ -409,6 +409,15 @@ suite.each(devices)("device:%s", (device) => {
       expect(out.shape).toEqual([1, 2, 4, 2]);
     });
 
+    test("grouped-query attention repeats adjacent key/value heads", () => {
+      const query = np.zeros([1, 1, 4, 1]);
+      const key = np.zeros([1, 1, 2, 1]);
+      const value = np.array([[[[10], [20]]]]);
+
+      const out = nn.dotProductAttention(query, key, value);
+      expect(out).toBeAllclose([[[[10], [10], [20], [20]]]]);
+    });
+
     test("multi-query attention (MQA)", () => {
       // Q: B=1, L=2, N=4 (query heads), H=2
       // K/V: B=1, S=2, K=1 (single key/value head), H=2


### PR DESCRIPTION
GQA was not tested well enough, and there was a bug in which KV heads were applied to each Q head (should be repeat instead of tile). Fixing this here.