### PR TITLE
Fix mean() truncating integer and boolean inputs

### DIFF
--- a/src/frontend/core.ts
+++ b/src/frontend/core.ts
@@ -884,7 +884,12 @@ export abstract class Tracer {
     const originalDtype = this.dtype;
     const castDtype = promoteTypes(originalDtype, DType.Float32);
     const result = reduce(this.astype(castDtype), AluOp.Add, axis, opts);
-    return result.mul(1 / n).astype(originalDtype) as this;
+    const out = result.mul(1 / n);
+    // JAX promotes integer and boolean inputs to float; only cast back to the
+    // original dtype when it is already floating-point (e.g. float16).
+    return (
+      isFloatDtype(originalDtype) ? out.astype(originalDtype) : out
+    ) as this;
   }
 
   /** Minimum of the elements of the array along a given axis. */

--- a/test/numpy.test.ts
+++ b/test/numpy.test.ts
@@ -218,6 +218,44 @@ suite.each(devices)("device:%s", (device) => {
     });
   });
 
+  suite("jax.numpy.mean()", () => {
+    test("promotes integer input to float", () => {
+      // Regression test: mean() used to cast the result back to the input
+      // dtype, truncating the fractional part (e.g. mean([1,2,3,4]) -> 2).
+      const x = np.array([1, 2, 3, 4], { dtype: np.int32 });
+      const y = np.mean(x);
+      expect(y.dtype).toBe(np.float32);
+      expect(y.js()).toBeCloseTo(2.5);
+    });
+
+    test("promotes boolean input to float", () => {
+      const x = np.array([true, false, true], { dtype: np.bool });
+      const y = np.mean(x);
+      expect(y.dtype).toBe(np.float32);
+      expect(y.js()).toBeCloseTo(2 / 3);
+    });
+
+    test("keeps float32 dtype", () => {
+      const x = np.array([1, 2, 3, 4], { dtype: np.float32 });
+      const y = np.mean(x);
+      expect(y.dtype).toBe(np.float32);
+      expect(y.js()).toBeCloseTo(2.5);
+    });
+
+    test("works along an axis", () => {
+      const x = np.array(
+        [
+          [1, 2, 3],
+          [4, 5, 6],
+        ],
+        { dtype: np.int32 },
+      );
+      const y = np.mean(x, 1);
+      expect(y.dtype).toBe(np.float32);
+      expect(y.js()).toEqual([2, 5]);
+    });
+  });
+
   suite("jax.numpy.cumsum()", () => {
     test("computes cumsum along axis", () => {
       const x = np.array([


### PR DESCRIPTION
## Summary 

`np.mean()` on integer or boolean arrays returned the wrong dtype and value. It computed the mean in float32 but then cast the result back to the input dtype, truncating the fractional part.

```js
np.mean(np.array([1, 2, 3, 4], { dtype: np.int32 }))
// before: int32, 2
// after:  float32, 2.5
```

JAX promotes integer and boolean inputs to float for mean(), and only keeps the original dtype when it is already floating-point (e.g. float16). This change matches that behavior.

## Changes
- src/frontend/core.ts: only cast the mean result back to the original dtype when it is floating-point; leave integer/boolean results as float.
- test/numpy.test.ts: add a jax.numpy.mean() regression suite covering int32  -> float32, bool  -> float32, float32 preserved, and along-axis reduction.


## Verification
- pnpm test test/numpy.test.ts -t "mean" -> 15 passed.
- pnpm test test/numpy.test.ts -> 1159 passed, no new failures.
- pnpm test test/random.test.ts (uses mean) -> 112 passed.
- Verified on both the wasm (default) and cpu backends.
- pnpm lint src/frontend/core.ts test/numpy.test.ts ->  clean.