### PR TITLE
Add upload button to mobileclip example

### DIFF
--- a/website/src/routes/mobileclip/+page.svelte
+++ b/website/src/routes/mobileclip/+page.svelte
@@ -11,7 +11,7 @@
   import { BookMarkedIcon, FileTextIcon } from "@lucide/svelte";
 
   import DownloadManager from "$lib/common/DownloadManager.svelte";
-  import { type Book, downloadBook } from "./books";
+  import { type Book, bookFromText, downloadBook } from "./books";
   import {
     fromSafetensors,
     type MobileCLIP,
@@ -30,6 +30,7 @@
   const D_EMBED = 512;
 
   let downloadManager: DownloadManager;
+  let fileInput: HTMLInputElement | undefined = $state();
 
   async function downloadClipWeights(): Promise<safetensors.File> {
     if (_weights) return _weights;
@@ -96,6 +97,33 @@
   const runEncoder = jit(vmap(runMobileCLIPTextEncoder, [null, 0]));
 
   async function setupBook(bookId: string) {
+    await runSetup(() => downloadBook(bookId));
+  }
+
+  async function setupBookFromFile(file: File) {
+    await runSetup(async () => {
+      const text = await file.text();
+      const title = file.name.replace(/\.[^./]+$/, "");
+      const uploaded = bookFromText(title, text);
+      if (uploaded.chapters[0].excerpts.length === 0) {
+        throw new Error("No usable text found in file");
+      }
+      return uploaded;
+    });
+  }
+
+  async function handleFileChange(event: Event) {
+    const input = event.currentTarget as HTMLInputElement;
+    const file = input.files?.[0];
+    input.value = "";
+    if (file) await setupBookFromFile(file);
+  }
+
+  function triggerFileUpload() {
+    fileInput?.click();
+  }
+
+  async function runSetup(loadBook: () => Promise<Book>) {
     const devices = await init("webgpu");
     if (!devices.includes("webgpu")) {
       alert(
@@ -110,9 +138,9 @@
 
     isDownloadingData = true;
     try {
-      book = await downloadBook(bookId);
+      book = await loadBook();
     } catch (error: any) {
-      alert("Error downloading book: " + error.message);
+      alert("Error loading book: " + error.message);
       return;
     } finally {
       isDownloadingData = false;
@@ -345,10 +373,34 @@
           <div class="w-full max-w-md">
             <h3 class="font-medium mb-4">Upload your own data</h3>
             <div class="flex flex-col gap-3">
-              <button class="btn" disabled>
+              <input
+                type="file"
+                accept=".txt,text/plain"
+                bind:this={fileInput}
+                onchange={handleFileChange}
+                class="hidden"
+              />
+              <button
+                class="btn"
+                onclick={triggerFileUpload}
+                disabled={isDownloadingWeights || isDownloadingData}
+              >
                 <FileTextIcon size={20} />
-                Coming soon!
+                Upload a text file (.txt)
               </button>
+              <p class="text-xs text-gray-400">
+                The parser works best with plain-prose books like the ones
+                above. Try a
+                <a
+                  href="https://www.gutenberg.org/ebooks/search/?sort_order=downloads"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="text-gray-600 hover:text-primary underline"
+                >
+                  Project Gutenberg
+                </a>
+                plain text download.
+              </p>
             </div>
           </div>
         </div>

--- a/website/src/routes/mobileclip/books.ts
+++ b/website/src/routes/mobileclip/books.ts
@@ -33,6 +33,15 @@ export async function downloadBook(id: string): Promise<Book> {
   }
 }
 
+/** Build a single-chapter book from raw uploaded text. */
+export function bookFromText(title: string, text: string): Book {
+  return {
+    title,
+    author: "",
+    chapters: [{ title: "Full text", excerpts: splitExcerpts(text) }],
+  };
+}
+
 /** Split text into excerpts by paragraphs, with size constraints. */
 function splitExcerpts(text: string): string[] {
   const MIN_LENGTH = 40;


### PR DESCRIPTION

<img width="1040" height="422" alt="image" src="https://github.com/user-attachments/assets/a6722fe2-de87-416f-9ea1-7d9c0380d859" />

I ran into some weird splits with a one-sentence-per-line book I had (KJV.txt). I floated the idea of a more robust parser (e.g., falling back to single-newline splitting when no blank lines are present) but I don't think its worth the time.

Instead, just added a small hint under the "Upload your own data" button that notes the parser works best with plain-prose books like the ones above and links to Project Gutenberg.